### PR TITLE
Fix clang 8 build

### DIFF
--- a/geometry/Building.cpp
+++ b/geometry/Building.cpp
@@ -1275,13 +1275,10 @@ bool Building::AddGoal(Goal* goal)
       return true;
 }
 
-bool Building::
-
-
-AddTrainType(std::shared_ptr<TrainType> TT)
+bool Building::AddTrainType(std::shared_ptr<TrainType> TT)
 {
       if (_trainTypes.count(TT->type)!=0) {
-            Log->Write("WARNING: Duplicate type for train found [%s]",TT->type);
+            Log->Write("WARNING: Duplicate type for train found [%s]",TT->type.c_str());
       }
       _trainTypes[TT->type] = TT;
       return true;


### PR DESCRIPTION
I was having a go at compiling this project and noticed a build failure on clang-8 on Linux:

Building::AddTrainType was calling
`void OutputHandler::Write(const char* message,...)` 
with a non-trivial type std::string. 

See clang doc for this diagnstic:
https://releases.llvm.org/8.0.0/tools/clang/docs/DiagnosticsReference.html#wnon-pod-varargs