### PR TITLE
Fix trivially fixable warnings

### DIFF
--- a/IO/IODispatcher.cpp
+++ b/IO/IODispatcher.cpp
@@ -118,7 +118,7 @@ string TrajectoriesJPSV04::WritePed(Pedestrian* ped)
      return string(tmp);
 }
 
-void TrajectoriesJPSV04::WriteHeader(long nPeds, double fps, Building* building, int seed, int count)
+void TrajectoriesJPSV04::WriteHeader(long nPeds, double fps, Building* building, int seed, int /*count*/)
 {
      building->GetCaption();
      string tmp;
@@ -355,6 +355,7 @@ std::string getSourceFileName(const std::string & GetProjectFile)
         }
         return ret;
     }
+    return ret;
 }
 
 std::string getEventFileName(const std::string & GetProjectFile)
@@ -543,19 +544,19 @@ void TrajectoriesFLAT::WriteFooter()
 {
 
 }
-void TrajectoriesFLAT::WriteSources(const std::vector<std::shared_ptr<AgentsSource> > sources)
+void TrajectoriesFLAT::WriteSources(const std::vector<std::shared_ptr<AgentsSource> > /*sources*/)
 {
 
 }
-void TrajectoriesVTK::WriteSources(const std::vector<std::shared_ptr<AgentsSource> > sources)
+void TrajectoriesVTK::WriteSources(const std::vector<std::shared_ptr<AgentsSource> > /*sources*/)
 {
 
 }
-void TrajectoriesJPSV06::WriteSources(const std::vector<std::shared_ptr<AgentsSource> > sources)
+void TrajectoriesJPSV06::WriteSources(const std::vector<std::shared_ptr<AgentsSource> > /*sources*/)
 {
 
 }
-void TrajectoriesXML_MESH::WriteSources(const std::vector<std::shared_ptr<AgentsSource> > sources)
+void TrajectoriesXML_MESH::WriteSources(const std::vector<std::shared_ptr<AgentsSource> > /*sources*/)
 {
 
 }
@@ -639,7 +640,7 @@ void TrajectoriesVTK::WriteFooter()
 }
 
 
-void TrajectoriesJPSV06::WriteHeader(long nPeds, double fps, Building* building, int seed, int count)
+void TrajectoriesJPSV06::WriteHeader(long nPeds, double fps, Building* building, int seed, int /*count*/)
 {
      building->GetCaption();
      string tmp;
@@ -795,7 +796,7 @@ void TrajectoriesXML_MESH::WriteGeometry(Building* building)
 }
 
 
-void TrajectoriesJPSV05::WriteHeader(long nPeds, double fps, Building* building, int seed, int count)
+void TrajectoriesJPSV05::WriteHeader(long nPeds, double fps, Building* building, int seed, int /*count*/)
 {
      building->GetCaption();
      string tmp;

--- a/Simulation.cpp
+++ b/Simulation.cpp
@@ -348,7 +348,7 @@ void Simulation::UpdateRoutesAndLocations()
 //    }
 
 #pragma omp parallel for shared(pedsToRemove, allRooms)
-     for (signed int p = 0; p < allPeds.size(); ++p) {
+     for (size_t p = 0; p < allPeds.size(); ++p) {
           auto ped = allPeds[p];
           Room* room = _building->GetRoom(ped->GetRoomID());
           SubRoom* sub0 = room->GetSubRoom(ped->GetSubRoomID());

--- a/events/Event.cpp
+++ b/events/Event.cpp
@@ -25,7 +25,7 @@ int Event::GetId() const
      return _id;
 }
 
-const DoorState Event::GetState() const
+const DoorState& Event::GetState() const
 {
      return _state;
 }

--- a/events/Event.h
+++ b/events/Event.h
@@ -38,7 +38,7 @@ public:
      /**
       * @return the state (open, close) of the event
       */
-     const DoorState GetState() const;
+     const DoorState& GetState() const;
 
      /**
       * @return the time at which the event was recorded

--- a/events/EventManager.cpp
+++ b/events/EventManager.cpp
@@ -726,6 +726,7 @@ Router * EventManager::CreateRouter(const RoutingStrategy& strategy)
 
           case ROUTING_FF_QUICKEST:
                rout = new FFRouter(ROUTING_FF_QUICKEST, ROUTING_FF_QUICKEST, _building->GetConfig()->get_has_specific_goals(), _building->GetConfig());
+               break;
 
           default:
                Log->Write("ERROR: \twrong value for routing strategy [%d]!!!\n", strategy );

--- a/geometry/Building.cpp
+++ b/geometry/Building.cpp
@@ -687,7 +687,7 @@ bool Building::resetGeometry(std::shared_ptr<TrainTimeTable> tab)
       // std::cout << "temp Added Doors: " <<TempAddedDoors[tab->id].size() <<  "\n";
       return true;
 }
-bool Building::InitPlatforms()
+void Building::InitPlatforms()
 {
       int num_platform = -1;
       for (auto& roomItr : _rooms)

--- a/geometry/Building.h
+++ b/geometry/Building.h
@@ -318,7 +318,7 @@ public:
 private:
 
      bool InitInsideGoals();
-     bool InitPlatforms();
+     void InitPlatforms();
      void StringExplode(std::string str, std::string separator, std::vector<std::string>* results);
      /** @defgroup auto-correct-geometry
       * functions used to auto-correct the geometry.

--- a/geometry/Goal.cpp
+++ b/geometry/Goal.cpp
@@ -242,8 +242,8 @@ bool Goal::ConvertLineToPoly()
           _crossing->SetPoint2(point2);
      }else{
           _crossing->SetPoint1(_poly[0]);
-          Line line(_poly[_poly.size()/2], _poly[(_poly.size()/2)+1], 0);
-          _crossing->SetPoint2(line.GetCentre());
+          Line tmp_line(_poly[_poly.size()/2], _poly[(_poly.size()/2)+1], 0);
+          _crossing->SetPoint2(tmp_line.GetCentre());
      }
 
 
@@ -352,9 +352,9 @@ int Goal::GetRoomID() const
      return _roomID;
 }
 
-void Goal::SetRoomID(int _roomID)
+void Goal::SetRoomID(int roomID)
 {
-     Goal::_roomID = _roomID;
+     _roomID = roomID;
 }
 
 int Goal::GetSubRoomID() const
@@ -362,7 +362,7 @@ int Goal::GetSubRoomID() const
      return _subRoomID;
 }
 
-void Goal::SetSubRoomID(int _subRoomID)
+void Goal::SetSubRoomID(int subRoomID)
 {
-     Goal::_subRoomID = _subRoomID;
+     _subRoomID = subRoomID;
 }

--- a/geometry/GoalManager.cpp
+++ b/geometry/GoalManager.cpp
@@ -86,7 +86,7 @@ bool GoalManager::CheckInsideWaitingArea(Pedestrian* ped, int goalID)
      Goal* goal = _allGoals[goalID];
 
      if (goal!=nullptr){
-          if (WaitingArea* wa = dynamic_cast<WaitingArea*>(goal)) {
+          if (dynamic_cast<WaitingArea*>(goal)) {
                return goal->IsInsideGoal(ped->GetPos());
           }
      }

--- a/geometry/Line.cpp
+++ b/geometry/Line.cpp
@@ -67,14 +67,6 @@ int Line::GetUniqueID() const
      return _uid;
 }
 
-Line::Line(const Line& orig):
-      _point1(orig.GetPoint1()), _point2(orig.GetPoint2()), _centre(orig.GetCentre()), _length(orig.GetLength()), _uid(orig.GetUniqueID())
-{
-}
-
-Line::~Line()
-{
-}
 
 /*************************************************************
  Setter-Funktionen

--- a/geometry/Line.h
+++ b/geometry/Line.h
@@ -60,9 +60,7 @@ public:
 
      Line(const Point& p1, const Point& p2);
 
-     Line(const Line& orig);
-
-     virtual ~Line();
+     virtual ~Line() = default;
 
      /**
       * All Line elements (also derived class) have a unique ID

--- a/geometry/Point.cpp
+++ b/geometry/Point.cpp
@@ -32,16 +32,6 @@
 /************************************************************
   Konstruktoren
  ************************************************************/
-
-Point::Point(const Point& orig) 
-{
-//     std::cout << "Point: " << toString() << std::endl;
-//     std::cout << "orig:  " << toString() << std::endl;
-
-     _x = orig._x;
-     _y = orig._y;
-}
-
 std::string Point::toString() const
 {
      std::stringstream tmp;

--- a/geometry/Point.h
+++ b/geometry/Point.h
@@ -27,7 +27,7 @@
  *
  *
  **/
- 
+
 
 #ifndef _POINT_H
 #define _POINT_H
@@ -52,13 +52,6 @@ public:
       * @param [in] y: y-coordinate as double
       */
      Point(double x = 0, double y = 0) : _x(x), _y(y) {};
-
-     /**
-      * **Copy-Ctor**
-      * Constructs a new point as copy of the original point.
-      * @param [in] orig: original point which shall be copied
-      */
-     Point(const Point& orig);
 
      /// Norm
      double Norm() const;

--- a/geometry/WaitingArea.cpp
+++ b/geometry/WaitingArea.cpp
@@ -10,9 +10,9 @@ int WaitingArea::getMaxNumPed() const
      return maxNumPed;
 }
 
-void WaitingArea::setMaxNumPed(int maxNumPed)
+void WaitingArea::setMaxNumPed(int newMaxNumPed)
 {
-     WaitingArea::maxNumPed = maxNumPed;
+     maxNumPed = newMaxNumPed;
 }
 
 int WaitingArea::getMinNumPed() const
@@ -20,9 +20,9 @@ int WaitingArea::getMinNumPed() const
      return minNumPed;
 }
 
-void WaitingArea::setMinNumPed(int minNumPed)
+void WaitingArea::setMinNumPed(int newMinNumPed)
 {
-     WaitingArea::minNumPed = minNumPed;
+     minNumPed = newMinNumPed;
 }
 
 bool WaitingArea::isOpen() const
@@ -30,9 +30,9 @@ bool WaitingArea::isOpen() const
      return open;
 }
 
-void WaitingArea::setOpen(bool open)
+void WaitingArea::setOpen(bool newOpenState)
 {
-     WaitingArea::open = open;
+     open = newOpenState;
 }
 
 bool WaitingArea::isGlobalTimer() const
@@ -51,9 +51,9 @@ const std::map<int, double>& WaitingArea::getNextGoals() const
      return nextGoals;
 }
 
-bool WaitingArea::setNextGoals(const std::map<int, double>& nextGoals)
+bool WaitingArea::setNextGoals(const std::map<int, double>& newNextGoals)
 {
-     WaitingArea::nextGoals = nextGoals;
+     nextGoals = newNextGoals;
 
      nextGoalsOpen.clear();
 
@@ -122,9 +122,9 @@ double WaitingArea::getWaitingTime() const
      return waitingTime;
 }
 
-void WaitingArea::setWaitingTime(double waitingTime)
+void WaitingArea::setWaitingTime(double newWaitingTime)
 {
-     WaitingArea::waitingTime = waitingTime;
+     waitingTime = newWaitingTime;
 }
 
 int WaitingArea::GetNextGoal()
@@ -158,9 +158,6 @@ void WaitingArea::removePed(int ped)
      if (pedInside.size() < minNumPed){
           startTime = -1.;
      }
-
-
-
 }
 
 void WaitingArea::startTimer(double time)
@@ -180,7 +177,7 @@ bool WaitingArea::isWaiting(double time, const Building* building)
           startTimer(time);
      }
 
-     if ((trans == nullptr) ){
+     if (trans == nullptr){
           if (globalTimer){
                if (time > waitingTime){
                     return false;
@@ -210,7 +207,7 @@ int WaitingArea::getTransitionID() const
      return transitionID;
 }
 
-void WaitingArea::setTransitionID(int transitionID)
+void WaitingArea::setTransitionID(int newTransitionID)
 {
-     WaitingArea::transitionID = transitionID;
+     transitionID = newTransitionID;
 }

--- a/geometry/Wall.cpp
+++ b/geometry/Wall.cpp
@@ -42,11 +42,6 @@ Wall::Wall(const Point& p1, const Point& p2, const std::string& type) : Line(p1,
 {
 }
 
-Wall::Wall(const Wall& orig) : Line(orig)
-{
-     _type=orig.GetType();
-}
-
 void Wall::WriteToErrorLog() const
 {
      char tmp[CLENGTH];

--- a/geometry/Wall.h
+++ b/geometry/Wall.h
@@ -24,7 +24,7 @@
  *
  *
  **/
- 
+
 
 #ifndef _WALL_H
 #define _WALL_H
@@ -45,9 +45,9 @@ public:
      Wall(const Point& p1, const Point& p2, const std::string& type="internal");
 
      /**
-      * Constructor
+      * Destructor
       */
-     Wall(const Wall& orig);
+     ~Wall() override = default;
 
      /**
       * set/get the wall type. Values are external and internal
@@ -67,7 +67,7 @@ public:
      /**
       * @return a nicely formated string of the object
       */
-     virtual std::string Write() const;
+     std::string Write() const override;
 
 private:
      std::string _type;

--- a/math/GradientModel.cpp
+++ b/math/GradientModel.cpp
@@ -120,9 +120,10 @@ bool GradientModel::Init (Building* building)
      pedsToRemove.clear();
      bool error_occurred = false;
 #pragma omp parallel for
-    for(signed int p=0;p<allPeds.size();p++) {
+    for(size_t p=0;p<allPeds.size();p++) {
          Pedestrian* ped = allPeds[p];
-         double cosPhi, sinPhi;
+         double cosPhi = 0;
+         double sinPhi = 0;
          //a destination could not be found for that pedestrian
          if (ped->FindRoute() == -1) {
               Log->Write(

--- a/math/VelocityModel.cpp
+++ b/math/VelocityModel.cpp
@@ -202,7 +202,6 @@ void VelocityModel::ComputeNextTimeStep(double current, double deltaT, Building*
                 vector<Pedestrian*> neighbours;
                 building->GetGrid()->GetNeighbourhood(ped,neighbours);
 
-                double time = Pedestrian::GetGlobalTime();
                 int size = (int) neighbours.size();
 ////                if (ped->GetID() == 71) {
 ////                     std::cout << "------------------------------------" << std::endl;

--- a/mpi/LCGrid.cpp
+++ b/mpi/LCGrid.cpp
@@ -252,8 +252,8 @@ void LCGrid::GetNeighbourhood(const Pedestrian* ped, vector<Pedestrian*>& neighb
      if ((myID == 70) && (fmod(Pedestrian::GetGlobalTime() , 45.) == 0) ){
           std::cout << Pedestrian::GetGlobalTime() << ":\t\tNeighborhood of 71 " << neighbourhood.size() << std::endl;
 
-          for (auto& ped : neighbourhood){
-               std::cout << "Neighbor added: " << ped->GetID() << " at " << ped->GetPos().toString() << std::endl;
+          for (auto& neighbour : neighbourhood){
+               std::cout << "Neighbor added: " << neighbour->GetID() << " at " << neighbour->GetPos().toString() << std::endl;
           }
           std::cout << "---------------------------" << std::endl;
 

--- a/pedestrian/AgentsSourcesManager.cpp
+++ b/pedestrian/AgentsSourcesManager.cpp
@@ -34,7 +34,6 @@
 #include "AgentsQueue.h"
 
 #include "../voronoi-boost/VoronoiPositionGenerator.h"
-#define UNUSED(x) [&x]{}()  // c++11 silence warnings
 
 using namespace std;
 

--- a/pedestrian/Ellipse.cpp
+++ b/pedestrian/Ellipse.cpp
@@ -55,21 +55,6 @@ JEllipse::JEllipse()
      _vel0 = 0; // desired speed
 }
 
-JEllipse::JEllipse(const JEllipse& orig)
-{
-     _vel = orig.GetV(); // velocity vector
-     _center = orig.GetCenter();
-     _cosPhi = orig.GetCosPhi();
-     _sinPhi = orig.GetSinPhi();
-     _Xp = orig.GetXp(); //x Ellipse-coord of the centre (Center in (xc,yc) )
-     _Amin = orig.GetAmin(); // Semi-axis in direction of motion:  pAmin + V * pAv
-     _Av = orig.GetAv();
-     _Bmin = orig.GetBmin(); // Semi-axis in direction of shoulders: pBmax - V *[(pBmax - pBmin) / V0]
-     _Bmax = orig.GetBmax();
-     _do_stretch = orig.DoesStretch();
-     _vel0 = orig.GetV0(); // desired speed
-}
-
 
 /*************************************************************
  Setter-Funktionen
@@ -239,9 +224,9 @@ double JEllipse::GetEB() const
      // return (v<v_min)? 0.5*b_shoulder: 0.5*(b_shoulder + a * exp(b*v));
       // todo: we dont  have the possiblity to choose between ellipses and circles.
       // for the moment we can control this only with the parameter values in the following formula
-      
+
       //double x;
-      //if(_vel0 > 0.001) 
+      //if(_vel0 > 0.001)
       //      x = (_Bmax - _Bmin) / _vel0;
       //else
       //      x = 0;

--- a/pedestrian/Ellipse.h
+++ b/pedestrian/Ellipse.h
@@ -50,9 +50,7 @@ private:
 
 
 public:
-
      JEllipse();
-     JEllipse(const JEllipse& orig);
 
 
      void SetV(const Point& v);

--- a/routing/DirectionStrategy.cpp
+++ b/routing/DirectionStrategy.cpp
@@ -40,8 +40,6 @@
 //#include <ctime>
 #include <chrono>
 
-#define UNUSED(x) [&x]{}()  // c++11 silence warnings
-
 DirectionStrategy::DirectionStrategy()
 {
 }
@@ -51,26 +49,23 @@ DirectionStrategy::~DirectionStrategy()
 {
 }
 
-double DirectionStrategy::GetDistance2Wall(Pedestrian* ped) const
+double DirectionStrategy::GetDistance2Wall(Pedestrian* /*ped*/) const
 {
      return -1.;
 }
-double DirectionStrategy::GetDistance2Target(Pedestrian* ped, int UID)
+double DirectionStrategy::GetDistance2Target(Pedestrian* /*ped*/, int /*UID*/)
 {
      return -1.;
 }
 
 /// 1
-Point DirectionMiddlePoint::GetTarget(Room* room, Pedestrian* ped) const
+Point DirectionMiddlePoint::GetTarget(Room* /*room*/, Pedestrian* ped) const
 {
-    UNUSED(room); // suppress the unused warning
     return (ped->GetExitLine()->GetPoint1() + ped->GetExitLine()->GetPoint2())*0.5;
 }
 /// 2
-Point DirectionMinSeperationShorterLine::GetTarget(Room* room, Pedestrian* ped) const
+Point DirectionMinSeperationShorterLine::GetTarget(Room* /*room*/, Pedestrian* ped) const
 {
-    UNUSED(room); // suppress the unused warning
-
      double d = ped->GetEllipse().GetBmin() + 0.1 ; // shoulder//0.5;
      const Point& p1 = ped->GetExitLine()->GetPoint1();
      const Point& p2 = ped->GetExitLine()->GetPoint2();
@@ -98,10 +93,8 @@ Point DirectionMinSeperationShorterLine::GetTarget(Room* room, Pedestrian* ped) 
 
 }
 /// 3
-Point DirectionInRangeBottleneck::GetTarget(Room* room, Pedestrian* ped) const
+Point DirectionInRangeBottleneck::GetTarget(Room* /*room*/, Pedestrian* ped) const
 {
-   UNUSED(room); // suppress the unused warning
-
     const Point& p1 = ped->GetExitLine()->GetPoint1();
     const Point& p2 = ped->GetExitLine()->GetPoint2();
     Line ExitLine = Line(p1, p2, 0);
@@ -288,9 +281,8 @@ Point DirectionGeneral::GetTarget(Room* room, Pedestrian* ped) const
 }
 
 /// 6
-Point DirectionFloorfield::GetTarget(Room* room, Pedestrian* ped) const
+Point DirectionFloorfield::GetTarget(Room* /*room*/, Pedestrian* ped) const
 {
-     UNUSED(room);
 #if DEBUG
 
     if (1) {
@@ -368,7 +360,6 @@ Point DirectionLocalFloorfield::GetTarget(Room* room, Pedestrian* ped) const
 //     if (floorfield->getCostToDestination(ped->GetExitIndex(), ped->GetPos()) < 1.0) {
 //          p = p * floorfield->getCostToDestination(ped->GetExitIndex(), ped->GetPos());
 //     }
-     Point P = p + ped->GetPos();
      return (p + ped->GetPos());
 
 #if DEBUG
@@ -574,7 +565,7 @@ DirectionSubLocalFloorfield::~DirectionSubLocalFloorfield() {
 }
 
 ///10
-Point DirectionSubLocalFloorfieldTrips::GetTarget(Room* room, Pedestrian* ped) const
+Point DirectionSubLocalFloorfieldTrips::GetTarget(Room* /*room*/, Pedestrian* ped) const
 {
      Goal* goal = ped->GetBuilding()->GetFinalGoal(ped->GetFinalDestination());
      // Pedestrian is inside a waiting area
@@ -708,7 +699,7 @@ DirectionSubLocalFloorfieldTrips::~DirectionSubLocalFloorfieldTrips() {
 }
 
 ///11
-Point DirectionSubLocalFloorfieldTripsVoronoi::GetTarget(Room* room, Pedestrian* ped) const
+Point DirectionSubLocalFloorfieldTripsVoronoi::GetTarget(Room* /*room*/, Pedestrian* ped) const
 {
      Goal* goal = ped->GetBuilding()->GetFinalGoal(ped->GetFinalDestination());
      // Pedestrian is inside a waiting area
@@ -840,7 +831,7 @@ DirectionSubLocalFloorfieldTripsVoronoi::~DirectionSubLocalFloorfieldTripsVorono
 }
 
 // 12
-Point DirectionTrain::GetTarget(Room* room, Pedestrian* ped) const
+Point DirectionTrain::GetTarget(Room* /*room*/, Pedestrian* ped) const
 {
 
      Point p1 = ped->GetExitLine()->GetPoint1();

--- a/routing/ai_router/cognitiveMap/internnavigationnetwork.cpp
+++ b/routing/ai_router/cognitiveMap/internnavigationnetwork.cpp
@@ -50,8 +50,8 @@ void InternNavigationNetwork::AddVertex(const NavLine *navLine)
 void InternNavigationNetwork::AddEdge(const NavLine *navLine1, const NavLine *navLine2)
 {
     //find indeces of vertices(landmarks) in graph
-    Vertex A;
-    Vertex B;
+    Vertex A{};
+    Vertex B{};
 
     for (auto it=_navLines.begin(); it!=_navLines.end(); ++it)
     {

--- a/routing/ai_router/cognitiveMap/landmarknetwork.cpp
+++ b/routing/ai_router/cognitiveMap/landmarknetwork.cpp
@@ -121,8 +121,8 @@ void AILandmarkNetwork::AddConnection(const AIConnection *connection)
     //find indeces of vertices(landmarks) in graph
     const AILandmark* landmarkA = _region->GetLandmarkByID(connection->GetLandmarkIds().first);
     const AILandmark* landmarkB = _region->GetLandmarkByID(connection->GetLandmarkIds().second);
-    Vertex A;
-    Vertex B;
+    Vertex A = _landmarks[landmarkA];
+    Vertex B = _landmarks[landmarkB];
 
 //    for (auto it=_landmarks.begin(); it!=_landmarks.end(); ++it)
 //    {
@@ -142,9 +142,6 @@ void AILandmarkNetwork::AddConnection(const AIConnection *connection)
 //                break;
 //        }
 //    }
-
-    A=_landmarks[landmarkA];
-    B=_landmarks[landmarkB];
 
     Point vector = landmarkA->GetRandomPoint()-landmarkB->GetRandomPoint();//->GetRandomPoint()-landmarkB->GetRandomPoint();
     double distance = vector.Norm();

--- a/routing/ff_router/FloorfieldViaFM.cpp
+++ b/routing/ff_router/FloorfieldViaFM.cpp
@@ -1659,7 +1659,7 @@ void FloorfieldViaFM::writeGoalFF(const std::string& filename, std::vector<int> 
     file.close();
 }
 
-SubRoom* FloorfieldViaFM::isInside(const long int key) {
+SubRoom* FloorfieldViaFM::isInside(const long int /*key*/) {
 //    Point probe = _grid->getPointFromKey(key);
 
 //    const std::map<int, std::shared_ptr<Room>>& roomMap = _building->GetAllRooms();

--- a/routing/ff_router/UnivFFviaFM.cpp
+++ b/routing/ff_router/UnivFFviaFM.cpp
@@ -109,7 +109,6 @@ UnivFFviaFM::UnivFFviaFM(Room* roomArg, Configuration* const confArg, double hx,
           }
           //find insidePoint and save it, together with UID
           Point normalVec = anyDoor.NormalVec();
-          double length = normalVec.Norm();
           Point midPoint = anyDoor.GetCentre();
           Point candidate01 = midPoint + (normalVec * 0.25);
           Point candidate02 = midPoint - (normalVec * 0.25);
@@ -191,7 +190,6 @@ UnivFFviaFM::UnivFFviaFM(SubRoom* subRoomArg, Configuration* const confArg, doub
      //find insidePoint and save it, together with UID
     Line anyDoor = Line{(--tmpDoors.end())->second};
     Point normalVec = anyDoor.NormalVec();
-    double length = normalVec.Norm();
     Point midPoint = anyDoor.GetCentre();
     Point candidate01 = midPoint + (normalVec * 0.25);
     Point candidate02 = midPoint - (normalVec * 0.25);
@@ -442,7 +440,7 @@ void UnivFFviaFM::recreateAllForQuickest() {
 #pragma omp parallel
      {
 #pragma omp for
-          for (signed int i = 0; i < _doors.size(); ++i) {
+          for (size_t i = 0; i < _doors.size(); ++i) {
                auto doorPair = _doors.begin();
                std::advance(doorPair, i);
                addTarget(doorPair->first, _costFieldWithKey[doorPair->first], _directionFieldWithKey[doorPair->first]);
@@ -533,8 +531,8 @@ void UnivFFviaFM::finalizeTargetLine(const int uid, const Line& line, Point* tar
     long int key;
     long int deltaX, deltaY, deltaX1, deltaY1, px, py, xe, ye, i; //Bresenham Algorithm
 
-    long int goodneighbor;
-    directNeighbor neigh;
+    //long int goodneighbor;
+    //directNeighbor neigh;
 
 
     key = _grid->getKeyAtPoint(line.GetPoint1());
@@ -1458,7 +1456,7 @@ void UnivFFviaFM::addAllTargetsParallel() {
 #pragma omp parallel
      {
 #pragma omp for
-          for (signed int i = 0; i < _doors.size(); ++i) {
+          for (size_t i = 0; i < _doors.size(); ++i) {
                auto doorPair = _doors.begin();
                std::advance(doorPair, i);
                addTarget(doorPair->first, _costFieldWithKey[doorPair->first], _directionFieldWithKey[doorPair->first]);
@@ -1491,7 +1489,7 @@ void UnivFFviaFM::addTargetsParallel(std::vector<int> wantedDoors) {
 #pragma omp parallel
      {
 #pragma omp for
-          for (signed int i = 0; i < wantedDoors.size(); ++i) {
+          for (size_t i = 0; i < wantedDoors.size(); ++i) {
                auto doorUID = wantedDoors.begin();
                std::advance(doorUID, i);
                addTarget(*doorUID, _costFieldWithKey[*doorUID], _directionFieldWithKey[*doorUID]);

--- a/routing/ff_router/ffRouter.cpp
+++ b/routing/ff_router/ffRouter.cpp
@@ -627,7 +627,6 @@ int FFRouter::FindExit(Pedestrian* p)
 void FFRouter::FloydWarshall()
 {
      bool change = false;
-     double savedDistance = 0.;
      int totalnum = _allDoorUIDs.size();
      for(int k = 0; k<totalnum; ++k) {
           for(int i = 0; i<totalnum; ++i) {
@@ -638,7 +637,6 @@ void FFRouter::FloydWarshall()
                     if ((_distMatrix[key_ik] < DBL_MAX) && (_distMatrix[key_kj] < DBL_MAX) &&
                        (_distMatrix[key_ik] + _distMatrix[key_kj] < _distMatrix[key_ij]))
                     {
-                         savedDistance = _distMatrix[key_ij] - _distMatrix[key_ik] - _distMatrix[key_kj];
                          _distMatrix.erase(key_ij);
                          _distMatrix.insert(std::make_pair(key_ij, _distMatrix[key_ik] + _distMatrix[key_kj]));
                          _pathsMatrix.erase(key_ij);
@@ -649,7 +647,6 @@ void FFRouter::FloydWarshall()
           }
      }
      if (change) {
-          //Log->Write("Floyd nochmal!!! %f", savedDistance);
           FloydWarshall();
      } else {
           Log->Write("INFO:\t FloydWarshall done!");

--- a/routing/ff_router_trips/FloorfieldViaFMTrips.cpp
+++ b/routing/ff_router_trips/FloorfieldViaFMTrips.cpp
@@ -357,7 +357,6 @@ void FloorfieldViaFMTrips::createMapEntryInLineToGoalID(const int goalID, bool i
             //find closest door and add to cheatmap "goalToLineUID" map
 
             const std::map<int, Transition*>& transitions = _building->GetAllTransitions();
-            const std::map<int, Crossing*>& crossings = _building->GetAllCrossings();
 
             int UID_of_MIN = -1;
             int UID_of_MIN2 = -1;
@@ -1664,7 +1663,7 @@ void FloorfieldViaFMTrips::writeGoalFF(const std::string& filename, std::vector<
     file.close();
 }
 
-SubRoom* FloorfieldViaFMTrips::isInside(const long int key) {
+SubRoom* FloorfieldViaFMTrips::isInside(const long int /*key*/) {
 //    Point probe = _grid->getPointFromKey(key);
 
 //    const std::map<int, std::shared_ptr<Room>>& roomMap = _building->GetAllRooms();

--- a/routing/ff_router_trips/UnivFFviaFMTrips.cpp
+++ b/routing/ff_router_trips/UnivFFviaFMTrips.cpp
@@ -50,7 +50,7 @@ UnivFFviaFMTrips::UnivFFviaFMTrips(Room* r, Configuration* const conf, double hx
           : UnivFFviaFMTrips(r, conf, hx, wallAvoid, useWallDistances, std::vector<int>(), goals){
 }
 
-UnivFFviaFMTrips::UnivFFviaFMTrips(Room* roomArg, Configuration* const confArg, double hx, double wallAvoid, bool useWallDistances, std::vector<int> wantedDoors, std::map<int, Goal*> goals) {
+UnivFFviaFMTrips::UnivFFviaFMTrips(Room* roomArg, Configuration* const confArg, double hx, double wallAvoid, bool useWallDistances, std::vector<int> wantedDoors, std::map<int, Goal*> /*goals*/) {
      //build the vector with walls(wall or obstacle), the map with <UID, Door(Cross or Trans)>, the vector with targets(UIDs)
      //then call other constructor including the mode
      _configuration = confArg;
@@ -116,7 +116,6 @@ UnivFFviaFMTrips::UnivFFviaFMTrips(Room* roomArg, Configuration* const confArg, 
 
           //find insidePoint and save it, together with UID
           Point normalVec = anyDoor.NormalVec();
-          double length = normalVec.Norm();
           Point midPoint = anyDoor.GetCentre();
           Point candidate01 = midPoint + (normalVec * 0.25);
           Point candidate02 = midPoint - (normalVec * 0.25);
@@ -147,7 +146,7 @@ UnivFFviaFMTrips::UnivFFviaFMTrips(SubRoom* sr, Configuration* const conf, doubl
           : UnivFFviaFMTrips(sr, conf, hx, wallAvoid, useWallDistances, std::vector<int>(), goals){
 }
 
-UnivFFviaFMTrips::UnivFFviaFMTrips(SubRoom* subRoomArg, Configuration* const confArg, double hx, double wallAvoid, bool useWallDistances, std::vector<int> wantedDoors, std::map<int, Goal*> goals) {
+UnivFFviaFMTrips::UnivFFviaFMTrips(SubRoom* subRoomArg, Configuration* const confArg, double hx, double wallAvoid, bool useWallDistances, std::vector<int> wantedDoors, std::map<int, Goal*> /*goals*/) {
      //build the vector with walls(wall or obstacle), the map with <UID, Door(Cross or Trans)>, the vector with targets(UIDs)
      //then call other constructor including the mode
 
@@ -200,7 +199,6 @@ UnivFFviaFMTrips::UnivFFviaFMTrips(SubRoom* subRoomArg, Configuration* const con
      //find insidePoint and save it, together with UID
     Line anyDoor = Line{(--tmpDoors.end())->second};
     Point normalVec = anyDoor.NormalVec();
-    double length = normalVec.Norm();
     Point midPoint = anyDoor.GetCentre();
     Point candidate01 = midPoint + (normalVec * 0.25);
     Point candidate02 = midPoint - (normalVec * 0.25);
@@ -452,7 +450,7 @@ void UnivFFviaFMTrips::recreateAllForQuickest() {
 #pragma omp parallel
      {
 #pragma omp for
-          for (signed int i = 0; i < _doors.size(); ++i) {
+          for (size_t i = 0; i < _doors.size(); ++i) {
                auto doorPair = _doors.begin();
                std::advance(doorPair, i);
                addTarget(doorPair->first, _costFieldWithKey[doorPair->first], _directionFieldWithKey[doorPair->first]);
@@ -543,8 +541,8 @@ void UnivFFviaFMTrips::finalizeTargetLine(const int uid, const Line& line, Point
     long int key;
     long int deltaX, deltaY, deltaX1, deltaY1, px, py, xe, ye, i; //Bresenham Algorithm
 
-    long int goodneighbor;
-    directNeighbor neigh;
+    //long int goodneighbor;
+    //directNeighbor neigh;
 
 
     key = _grid->getKeyAtPoint(line.GetPoint1());
@@ -1468,7 +1466,7 @@ void UnivFFviaFMTrips::addAllTargetsParallel() {
 #pragma omp parallel
      {
 #pragma omp for
-          for (signed int i = 0; i < _doors.size(); ++i) {
+          for (size_t i = 0; i < _doors.size(); ++i) {
                auto doorPair = _doors.begin();
                std::advance(doorPair, i);
                addTarget(doorPair->first, _costFieldWithKey[doorPair->first], _directionFieldWithKey[doorPair->first]);
@@ -1501,7 +1499,7 @@ void UnivFFviaFMTrips::addTargetsParallel(std::vector<int> wantedDoors) {
 #pragma omp parallel
      {
 #pragma omp for
-          for (signed int i = 0; i < wantedDoors.size(); ++i) {
+          for (size_t i = 0; i < wantedDoors.size(); ++i) {
                auto doorUID = wantedDoors.begin();
                std::advance(doorUID, i);
                addTarget(*doorUID, _costFieldWithKey[*doorUID], _directionFieldWithKey[*doorUID]);
@@ -1548,8 +1546,6 @@ void UnivFFviaFMTrips::writeFF(const std::string& filename, std::vector<int> tar
 
     Log->Write("FloorfieldViaFM::writeFF(): writing to file %s: There are %d targets.", filename.c_str(), targetID.size());
 
-    int numX = (int) ((_grid->GetxMax()-_grid->GetxMin())/_grid->Gethx());
-    int numY = (int) ((_grid->GetyMax()-_grid->GetyMin())/_grid->Gethy());
     //int numTotal = numX * numY;
     //std::cerr << numTotal << " numTotal" << std::endl;
     //std::cerr << grid->GetnPoints() << " grid" << std::endl;

--- a/routing/ff_router_trips/ffRouterTrips.cpp
+++ b/routing/ff_router_trips/ffRouterTrips.cpp
@@ -107,12 +107,10 @@ bool FFRouterTrips::Init(Building* building)
           //get global field to manage goals (which are not in a subroom)
           _globalFF = new FloorfieldViaFMTrips(building, 0.25, 0.25, 0.0, false, true);
           for (auto &itrGoal : building->GetAllGoals()) {
-               if(WaitingArea* wa = dynamic_cast<WaitingArea*>(itrGoal.second)) {
+               if(dynamic_cast<WaitingArea*>(itrGoal.second)) {
                     _globalFF->createMapEntryInLineToGoalID(itrGoal.first, true);
-//                    std::cout << "Added " << itrGoal.first << " to goalIDs " << wa->getTransitionID() << std::endl;
                }else{
                     _globalFF->createMapEntryInLineToGoalID(itrGoal.first, false);
-//                    std::cout << "Added " << itrGoal.first << " to goalIDs " << std::endl;
                }
                goalIDs.emplace_back(itrGoal.first);
           }
@@ -131,7 +129,6 @@ bool FFRouterTrips::Init(Building* building)
      _CroTrByUID.clear();
      auto& allTrans = building->GetAllTransitions();
      auto& allCross = building->GetAllCrossings();
-     auto& allGoals = building->GetAllGoals();
 
      std::vector<std::pair<int, int>> roomAndCroTrVector;
      roomAndCroTrVector.clear();
@@ -464,10 +461,7 @@ int FFRouterTrips::FindExit(Pedestrian* ped)
 //          std::cout << goal.first << " -> " << goal.second << std::endl;
 //     }
 
-     SubRoom* subroom = _building->GetSubRoomByUID(ped->GetSubRoomUID());
      Goal* goal = _building->GetFinalGoal(ped->GetFinalDestination());
-
-     int ret;
 
      // Check if current position is already waiting area
      // yes: set next goal and return findExit(p)
@@ -590,7 +584,7 @@ int FFRouterTrips::FindExit1(Pedestrian* p)
      }
 
 
-     int bestFinalDoor = -1; // to silence the compiler
+     //int bestFinalDoor = -1; // to silence the compiler
      for(int finalDoor : validFinalDoor) {
           //with UIDs, we can ask for shortest path
           for (int doorUID : DoorUIDsOfRoom) {
@@ -626,7 +620,7 @@ int FFRouterTrips::FindExit1(Pedestrian* p)
                                  bestDoor = _pathsMatrix[key]; //@todo: @ar.graf: check this hack
                              }
                          }
-                         bestFinalDoor = key.second;
+                         //bestFinalDoor = key.second;
                     }
                }
           }
@@ -655,7 +649,6 @@ int FFRouterTrips::FindExit1(Pedestrian* p)
 void FFRouterTrips::FloydWarshall()
 {
      bool change = false;
-     double savedDistance = 0.;
      int totalnum = _allDoorUIDs.size();
      for(int k = 0; k<totalnum; ++k) {
           for(int i = 0; i<totalnum; ++i) {
@@ -666,7 +659,6 @@ void FFRouterTrips::FloydWarshall()
                     if ((_distMatrix[key_ik] < DBL_MAX) && (_distMatrix[key_kj] < DBL_MAX) &&
                        (_distMatrix[key_ik] + _distMatrix[key_kj] < _distMatrix[key_ij]))
                     {
-                         savedDistance = _distMatrix[key_ij] - _distMatrix[key_ik] - _distMatrix[key_kj];
                          _distMatrix.erase(key_ij);
                          _distMatrix.insert(std::make_pair(key_ij, _distMatrix[key_ik] + _distMatrix[key_kj]));
                          _pathsMatrix.erase(key_ij);
@@ -677,7 +669,6 @@ void FFRouterTrips::FloydWarshall()
           }
      }
      if (change) {
-          //Log->Write("Floyd nochmal!!! %f", savedDistance);
           FloydWarshall();
      } else {
           Log->Write("INFO:\t FloydWarshall done!");

--- a/routing/global_shortest/GlobalRouter.cpp
+++ b/routing/global_shortest/GlobalRouter.cpp
@@ -81,7 +81,7 @@ GlobalRouter::GlobalRouter(int id, RoutingStrategy s) :  Router(id, s)
 GlobalRouter::~GlobalRouter()
 {
      if (_distMatrix && _pathsMatrix) {
-          const int exitsCnt = (const int) (_building->GetNumberOfGoals() + _building->GetAllGoals().size());
+          const int exitsCnt = _building->GetNumberOfGoals() + _building->GetAllGoals().size();
           for (int p = 0; p < exitsCnt; ++p) {
                delete[] _distMatrix[p];
                delete[] _pathsMatrix[p];
@@ -118,7 +118,7 @@ bool GlobalRouter::Init(Building* building)
      }
 
      // initialize the distances matrix for the floydwahrshall
-     const int exitsCnt = (const int) (_building->GetNumberOfGoals() + _building->GetAllGoals().size());
+     const int exitsCnt = _building->GetNumberOfGoals() + _building->GetAllGoals().size();
 
      _distMatrix = new double*[exitsCnt];
      _pathsMatrix = new int*[exitsCnt];
@@ -690,7 +690,7 @@ bool GlobalRouter::GetPath(Pedestrian*ped, int goalID, std::vector<SubRoom*>& pa
  */
 void GlobalRouter::FloydWarshall()
 {
-     const int n = (const int) (_building->GetNumberOfGoals() + _building->GetAllGoals().size());
+     const int n = _building->GetNumberOfGoals() + _building->GetAllGoals().size();
      std::cout << "FloydWarshall ------------------" << std::endl;
      for (int k = 0; k < n; k++) {
           for (int i = 0; i<n; i++) {

--- a/routing/smoke_router/cognitiveMap/associations.cpp
+++ b/routing/smoke_router/cognitiveMap/associations.cpp
@@ -1,8 +1,6 @@
 #include "associations.h"
 #include "connection.h"
 
-#define UNUSED(x) [&x]{}()  // c++11 silence warnings
-
 Association::Association()
 {
     _landmark=nullptr;
@@ -10,9 +8,8 @@ Association::Association()
 
 }
 
-Association::Association(ptrLandmark landmark, ptrLandmark associated_landmark, bool connected)
+Association::Association(ptrLandmark landmark, ptrLandmark associated_landmark, bool /*connected*/)
 {
-    UNUSED(connected);
     _landmark=landmark;
     _associatedLandmark=associated_landmark;
 

--- a/routing/smoke_router/cognitiveMap/internnavigationnetwork.cpp
+++ b/routing/smoke_router/cognitiveMap/internnavigationnetwork.cpp
@@ -46,8 +46,8 @@ void InternNavigationNetwork::AddVertex(const NavLine *navLine)
 void InternNavigationNetwork::AddEdge(const NavLine *navLine1, const NavLine *navLine2)
 {
     //find indeces of vertices(landmarks) in graph
-    Vertex A;
-    Vertex B;
+    Vertex A{};
+    Vertex B{};
 
     for (auto it=_navLines.begin(); it!=_navLines.end(); ++it)
     {

--- a/routing/smoke_router/cognitiveMap/landmarknetwork.cpp
+++ b/routing/smoke_router/cognitiveMap/landmarknetwork.cpp
@@ -118,8 +118,8 @@ void LandmarkNetwork::AddConnection(const ptrConnection &connection)
     //find indeces of vertices(landmarks) in graph
     ptrLandmark landmarkA = connection->GetLandmarks().first;
     ptrLandmark landmarkB = connection->GetLandmarks().second;
-    Vertex A;
-    Vertex B;
+    Vertex A{};
+    Vertex B{};
 
     for (auto it=_landmarks.begin(); it!=_landmarks.end(); ++it)
     {

--- a/routing/smoke_router/navigation_graph/GraphVertex.cpp
+++ b/routing/smoke_router/navigation_graph/GraphVertex.cpp
@@ -35,7 +35,6 @@
 #include <queue>
 
 using namespace std;
-#define UNUSED(x) [&x]{}()  // c++11 silence warnings
 
 /**
  * Constructors & Destructors
@@ -103,9 +102,8 @@ int GraphVertex::RemoveOutEdge(GraphEdge * edge)
 }
 
 
-int GraphVertex::RemoveOutEdge(const GraphVertex * dest)
+int GraphVertex::RemoveOutEdge(const GraphVertex * /*dest*/)
 {
-     UNUSED(dest);
      //return out_edges.erase(dest);
      return 1;
 

--- a/routing/smoke_router/sensor/LastDestinationsSensor.cpp
+++ b/routing/smoke_router/sensor/LastDestinationsSensor.cpp
@@ -35,7 +35,6 @@
 #include "../../../pedestrian/Pedestrian.h"
 //#include <vector>
 //#include <set>
-#define UNUSED(x) [&x]{}()  // c++11 silence warnings
 
 LastDestinationsSensor::~LastDestinationsSensor()
 {
@@ -46,9 +45,8 @@ std::string LastDestinationsSensor::GetName() const
     return "LastDestinationsSensor";
 }
 
-void LastDestinationsSensor::execute(const Pedestrian * pedestrian, CognitiveMap &cognitive_map) const
+void LastDestinationsSensor::execute(const Pedestrian * /*pedestrian*/, CognitiveMap &cognitive_map) const
 {
-    UNUSED(pedestrian);
     NavigationGraph * ng = cognitive_map.GetGraphNetwork()->GetNavigationGraph();
     std::vector<const GraphEdge *> & destinations = cognitive_map.GetGraphNetwork()->GetDestinations();
     int i = 1;

--- a/routing/smoke_router/sensor/SensorManager.cpp
+++ b/routing/smoke_router/sensor/SensorManager.cpp
@@ -39,12 +39,9 @@
 #include "../../../geometry/Building.h"
 #include "../BrainStorage.h"
 
-#define UNUSED(x) [&x]{}()  // c++11 silence warnings
-
-SensorManager::SensorManager(const Building * b, BrainStorage * cms)
+SensorManager::SensorManager(const Building * /*b*/, BrainStorage * cms)
      : /*building(b), */cm_storage(cms)
 {
-     UNUSED(b);
     _periodicUpdateInterval=1/UPDATE_RATE;
 }
 

--- a/routing/trips_router/TripsRouter.cpp
+++ b/routing/trips_router/TripsRouter.cpp
@@ -11,7 +11,7 @@ TripsRouter::TripsRouter()
      Log->Write("TripsRouter!");
 }
 
-TripsRouter::TripsRouter(int id, RoutingStrategy s, Configuration* config) : Router(id, s)
+TripsRouter::TripsRouter(int id, RoutingStrategy s, Configuration* /*config*/) : Router(id, s)
 {
 
 }
@@ -21,7 +21,7 @@ TripsRouter::~TripsRouter()
 
 }
 
-bool TripsRouter::Init(Building* building)
+bool TripsRouter::Init(Building* /*building*/)
 {
      Log->Write("TripsRouter::Init");
 
@@ -36,7 +36,7 @@ bool TripsRouter::ReInit()
      return true;
 }
 
-int TripsRouter::FindExit(Pedestrian* p)
+int TripsRouter::FindExit(Pedestrian* /*p*/)
 {
      // Check if current position is already waiting area
      // yes: set next goal and return findExit(p)

--- a/tinyxml/tinyxmlparser.cpp
+++ b/tinyxml/tinyxmlparser.cpp
@@ -2,23 +2,23 @@
 www.sourceforge.net/projects/tinyxml
 Original code by Lee Thomason (www.grinninglizard.com)
 
-This software is provided 'as-is', without any express or implied 
-warranty. In no event will the authors be held liable for any 
+This software is provided 'as-is', without any express or implied
+warranty. In no event will the authors be held liable for any
 damages arising from the use of this software.
 
-Permission is granted to anyone to use this software for any 
-purpose, including commercial applications, and to alter it and 
+Permission is granted to anyone to use this software for any
+purpose, including commercial applications, and to alter it and
 redistribute it freely, subject to the following restrictions:
 
-1. The origin of this software must not be misrepresented; you must 
+1. The origin of this software must not be misrepresented; you must
 not claim that you wrote the original software. If you use this
 software in a product, an acknowledgment in the product documentation
 would be appreciated but is not required.
 
-2. Altered source versions must be plainly marked as such, and 
+2. Altered source versions must be plainly marked as such, and
 must not be misrepresented as being the original software.
 
-3. This notice may not be removed or altered from any source 
+3. This notice may not be removed or altered from any source
 distribution.
 */
 
@@ -39,8 +39,8 @@ distribution.
 
 // Note tha "PutString" hardcodes the same list. This
 // is less flexible than it appears. Changing the entries
-// or order will break putstring.	
-TiXmlBase::Entity TiXmlBase::entity[ TiXmlBase::NUM_ENTITY ] = 
+// or order will break putstring.
+TiXmlBase::Entity TiXmlBase::entity[ TiXmlBase::NUM_ENTITY ] =
 {
 	{ "&amp;",  5, '&' },
 	{ "&lt;",   4, '<' },
@@ -54,16 +54,16 @@ TiXmlBase::Entity TiXmlBase::entity[ TiXmlBase::NUM_ENTITY ] =
 // Including the basic of this table, which determines the #bytes in the
 // sequence from the lead byte. 1 placed for invalid sequences --
 // although the result will be junk, pass it through as much as possible.
-// Beware of the non-characters in UTF-8:	
+// Beware of the non-characters in UTF-8:
 //				ef bb bf (Microsoft "lead bytes")
 //				ef bf be
-//				ef bf bf 
+//				ef bf bf
 
 const unsigned char TIXML_UTF_LEAD_0 = 0xefU;
 const unsigned char TIXML_UTF_LEAD_1 = 0xbbU;
 const unsigned char TIXML_UTF_LEAD_2 = 0xbfU;
 
-const int TiXmlBase::utf8ByteTable[256] = 
+const int TiXmlBase::utf8ByteTable[256] =
 {
 	//	0	1	2	3	4	5	6	7	8	9	a	b	c	d	e	f
 		1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	// 0x00
@@ -75,9 +75,9 @@ const int TiXmlBase::utf8ByteTable[256] =
 		1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	// 0x60
 		1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	// 0x70	End of ASCII range
 		1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	// 0x80 0x80 to 0xc1 invalid
-		1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	// 0x90 
-		1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	// 0xa0 
-		1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	// 0xb0 
+		1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	// 0x90
+		1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	// 0xa0
+		1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	1,	// 0xb0
 		1,	1,	2,	2,	2,	2,	2,	2,	2,	2,	2,	2,	2,	2,	2,	2,	// 0xc0 0xc2 to 0xdf 2 byte
 		2,	2,	2,	2,	2,	2,	2,	2,	2,	2,	2,	2,	2,	2,	2,	2,	// 0xd0
 		3,	3,	3,	3,	3,	3,	3,	3,	3,	3,	3,	3,	3,	3,	3,	3,	// 0xe0 0xe0 to 0xef 3 byte
@@ -91,7 +91,7 @@ void TiXmlBase::ConvertUTF32ToUTF8( unsigned long input, char* output, int* leng
 	const unsigned long BYTE_MARK = 0x80;
 	const unsigned long FIRST_BYTE_MARK[7] = { 0x00, 0x00, 0xC0, 0xE0, 0xF0, 0xF8, 0xFC };
 
-	if (input < 0x80) 
+	if (input < 0x80)
 		*length = 1;
 	else if ( input < 0x800 )
 		*length = 2;
@@ -105,22 +105,22 @@ void TiXmlBase::ConvertUTF32ToUTF8( unsigned long input, char* output, int* leng
 	output += *length;
 
 	// Scary scary fall throughs.
-	switch (*length) 
+	switch (*length)
 	{
 		case 4:
-			--output; 
-			*output = (char)((input | BYTE_MARK) & BYTE_MASK); 
+			--output;
+			*output = (char)((input | BYTE_MARK) & BYTE_MASK);
 			input >>= 6;
 		case 3:
-			--output; 
-			*output = (char)((input | BYTE_MARK) & BYTE_MASK); 
+			--output;
+			*output = (char)((input | BYTE_MARK) & BYTE_MASK);
 			input >>= 6;
 		case 2:
-			--output; 
-			*output = (char)((input | BYTE_MARK) & BYTE_MASK); 
+			--output;
+			*output = (char)((input | BYTE_MARK) & BYTE_MASK);
 			input >>= 6;
 		case 1:
-			--output; 
+			--output;
 			*output = (char)(input | FIRST_BYTE_MARK[*length]);
 	}
 }
@@ -130,7 +130,7 @@ void TiXmlBase::ConvertUTF32ToUTF8( unsigned long input, char* output, int* leng
 {
 	// This will only work for low-ascii, everything else is assumed to be a valid
 	// letter. I'm not sure this is the best approach, but it is quite tricky trying
-	// to figure out alhabetical vs. not across encoding. So take a very 
+	// to figure out alhabetical vs. not across encoding. So take a very
 	// conservative approach.
 
 //	if ( encoding == TIXML_ENCODING_UTF8 )
@@ -151,7 +151,7 @@ void TiXmlBase::ConvertUTF32ToUTF8( unsigned long input, char* output, int* leng
 {
 	// This will only work for low-ascii, everything else is assumed to be a valid
 	// letter. I'm not sure this is the best approach, but it is quite tricky trying
-	// to figure out alhabetical vs. not across encoding. So take a very 
+	// to figure out alhabetical vs. not across encoding. So take a very
 	// conservative approach.
 
 //	if ( encoding == TIXML_ENCODING_UTF8 )
@@ -224,7 +224,7 @@ void TiXmlParsingData::Stamp( const char* now, TiXmlEncoding encoding )
 			case '\r':
 				// bump down to the next line
 				++row;
-				col = 0;				
+				col = 0;
 				// Eat the character
 				++p;
 
@@ -266,11 +266,11 @@ void TiXmlParsingData::Stamp( const char* now, TiXmlEncoding encoding )
 						// In these cases, don't advance the column. These are
 						// 0-width spaces.
 						if ( *(pU+1)==TIXML_UTF_LEAD_1 && *(pU+2)==TIXML_UTF_LEAD_2 )
-							p += 3;	
+							p += 3;
 						else if ( *(pU+1)==0xbfU && *(pU+2)==0xbeU )
-							p += 3;	
+							p += 3;
 						else if ( *(pU+1)==0xbfU && *(pU+2)==0xbfU )
-							p += 3;	
+							p += 3;
 						else
 							{ p +=3; ++col; }	// A normal character.
 					}
@@ -322,10 +322,10 @@ const char* TiXmlBase::SkipWhiteSpace( const char* p, TiXmlEncoding encoding )
 		while ( *p )
 		{
 			const unsigned char* pU = (const unsigned char*)p;
-			
+
 			// Skip the stupid Microsoft UTF-8 Byte order marks
 			if (	*(pU+0)==TIXML_UTF_LEAD_0
-				 && *(pU+1)==TIXML_UTF_LEAD_1 
+				 && *(pU+1)==TIXML_UTF_LEAD_1
 				 && *(pU+2)==TIXML_UTF_LEAD_2 )
 			{
 				p += 3;
@@ -413,12 +413,12 @@ const char* TiXmlBase::ReadName( const char* p, TIXML_STRING * name, TiXmlEncodi
 	// After that, they can be letters, underscores, numbers,
 	// hyphens, or colons. (Colons are valid ony for namespaces,
 	// but tinyxml can't tell namespaces from names.)
-	if (    p && *p 
+	if (    p && *p
 		 && ( IsAlpha( (unsigned char) *p, encoding ) || *p == '_' ) )
 	{
 		const char* start = p;
 		while(		p && *p
-				&&	(		IsAlphaNum( (unsigned char ) *p, encoding ) 
+				&&	(		IsAlphaNum( (unsigned char ) *p, encoding )
 						 || *p == '_'
 						 || *p == '-'
 						 || *p == '.'
@@ -469,7 +469,7 @@ const char* TiXmlBase::GetEntity( const char* p, char* value, int* length, TiXml
 					ucs += mult * (*q - 'a' + 10);
 				else if ( *q >= 'A' && *q <= 'F' )
 					ucs += mult * (*q - 'A' + 10 );
-				else 
+				else
 					return 0;
 				mult *= 16;
 				--q;
@@ -492,7 +492,7 @@ const char* TiXmlBase::GetEntity( const char* p, char* value, int* length, TiXml
 			{
 				if ( *q >= '0' && *q <= '9' )
 					ucs += mult * (*q - '0');
-				else 
+				else
 					return 0;
 				mult *= 10;
 				--q;
@@ -571,10 +571,10 @@ bool TiXmlBase::StringEqual( const char* p,
 	return false;
 }
 
-const char* TiXmlBase::ReadText(	const char* p, 
-									TIXML_STRING * text, 
-									bool trimWhiteSpace, 
-									const char* endTag, 
+const char* TiXmlBase::ReadText(	const char* p,
+									TIXML_STRING * text,
+									bool trimWhiteSpace,
+									const char* endTag,
 									bool caseInsensitive,
 									TiXmlEncoding encoding )
 {
@@ -647,7 +647,7 @@ void TiXmlDocument::StreamIn( std::istream * in, TIXML_STRING * tag )
 	// This "pre-streaming" will never read the closing ">" so the
 	// sub-tag can orient itself.
 
-	if ( !StreamTo( in, '<', tag ) ) 
+	if ( !StreamTo( in, '<', tag ) )
 	{
 		SetError( TIXML_ERROR_PARSING_EMPTY, 0, 0, TIXML_ENCODING_UNKNOWN );
 		return;
@@ -669,7 +669,7 @@ void TiXmlDocument::StreamIn( std::istream * in, TIXML_STRING * tag )
 
 		if ( in->good() )
 		{
-			// We now have something we presume to be a node of 
+			// We now have something we presume to be a node of
 			// some sort. Identify it, and call the node to
 			// continue streaming.
 			TiXmlNode* node = Identify( tag->c_str() + tagIndex, TIXML_DEFAULT_ENCODING );
@@ -778,7 +778,7 @@ const char* TiXmlDocument::Parse( const char* p, TiXmlParsingData* prevData, TiX
 				encoding = TIXML_ENCODING_UTF8;
 			else if ( StringEqual( enc, "UTF8", true, TIXML_ENCODING_UNKNOWN ) )
 				encoding = TIXML_ENCODING_UTF8;	// incorrect, but be nice
-			else 
+			else
 				encoding = TIXML_ENCODING_LEGACY;
 		}
 
@@ -796,7 +796,7 @@ const char* TiXmlDocument::Parse( const char* p, TiXmlParsingData* prevData, TiX
 }
 
 void TiXmlDocument::SetError( int err, const char* pError, TiXmlParsingData* data, TiXmlEncoding encoding )
-{	
+{
 	// The first error in a chain is more accurate - don't set again!
 	if ( error )
 		return;
@@ -832,7 +832,7 @@ TiXmlNode* TiXmlNode::Identify( const char* p, TiXmlEncoding encoding )
 		return 0;
 	}
 
-	// What is this thing? 
+	// What is this thing?
 	// - Elements start with a letter or underscore, but xml is reserved.
 	// - Comments: <!--
 	// - Decleration: <?xml
@@ -915,7 +915,7 @@ void TiXmlElement::StreamIn (std::istream * in, TIXML_STRING * tag)
 			return;
 		}
 		(*tag) += (char) c ;
-		
+
 		if ( c == '>' )
 			break;
 	}
@@ -925,7 +925,7 @@ void TiXmlElement::StreamIn (std::istream * in, TIXML_STRING * tag)
 	// Okay...if we are a "/>" tag, then we're done. We've read a complete tag.
 	// If not, identify and stream.
 
-	if (    tag->at( tag->length() - 1 ) == '>' 
+	if (    tag->at( tag->length() - 1 ) == '>'
 		 && tag->at( tag->length() - 2 ) == '/' )
 	{
 		// All good!
@@ -943,7 +943,7 @@ void TiXmlElement::StreamIn (std::istream * in, TIXML_STRING * tag)
 			StreamWhiteSpace( in, tag );
 
 			// Do we have text?
-			if ( in->good() && in->peek() != '<' ) 
+			if ( in->good() && in->peek() != '<' )
 			{
 				// Yep, text.
 				TiXmlText text( "" );
@@ -976,7 +976,7 @@ void TiXmlElement::StreamIn (std::istream * in, TIXML_STRING * tag)
 						document->SetError( TIXML_ERROR_EMBEDDED_NULL, 0, 0, TIXML_ENCODING_UNKNOWN );
 					return;
 				}
-				
+
 				if ( c == '>' )
 					break;
 
@@ -1095,7 +1095,7 @@ const char* TiXmlElement::Parse( const char* p, TiXmlParsingData* data, TiXmlEnc
 			// Empty tag.
 			if ( *p  != '>' )
 			{
-				if ( document ) document->SetError( TIXML_ERROR_PARSING_EMPTY, p, data, encoding );		
+				if ( document ) document->SetError( TIXML_ERROR_PARSING_EMPTY, p, data, encoding );
 				return 0;
 			}
 			return (p+1);
@@ -1117,7 +1117,7 @@ const char* TiXmlElement::Parse( const char* p, TiXmlParsingData* data, TiXmlEnc
 			// We should find the end tag now
 			// note that:
 			// </foo > and
-			// </foo> 
+			// </foo>
 			// are both valid end tags.
 			if ( StringEqual( p, endTag.c_str(), false, encoding ) )
 			{
@@ -1211,8 +1211,8 @@ const char* TiXmlElement::ReadValue( const char* p, TiXmlParsingData* data, TiXm
 				LinkEndChild( textNode );
 			else
 				delete textNode;
-		} 
-		else 
+		}
+		else
 		{
 			// We hit a '<'
 			// Have we hit a new element or an end tag? This could also be
@@ -1228,7 +1228,7 @@ const char* TiXmlElement::ReadValue( const char* p, TiXmlParsingData* data, TiXm
 				{
 					p = node->Parse( p, data, encoding );
 					LinkEndChild( node );
-				}				
+				}
 				else
 				{
 					return 0;
@@ -1242,7 +1242,7 @@ const char* TiXmlElement::ReadValue( const char* p, TiXmlParsingData* data, TiXm
 	if ( !p )
 	{
 		if ( document ) document->SetError( TIXML_ERROR_READING_ELEMENT_VALUE, 0, 0, encoding );
-	}	
+	}
 	return p;
 }
 
@@ -1252,7 +1252,7 @@ void TiXmlUnknown::StreamIn( std::istream * in, TIXML_STRING * tag )
 {
 	while ( in->good() )
 	{
-		int c = in->get();	
+		int c = in->get();
 		if ( c <= 0 )
 		{
 			TiXmlDocument* document = GetDocument();
@@ -1265,7 +1265,7 @@ void TiXmlUnknown::StreamIn( std::istream * in, TIXML_STRING * tag )
 		if ( c == '>' )
 		{
 			// All is well.
-			return;		
+			return;
 		}
 	}
 }
@@ -1298,7 +1298,7 @@ const char* TiXmlUnknown::Parse( const char* p, TiXmlParsingData* data, TiXmlEnc
 
 	if ( !p )
 	{
-		if ( document )	
+		if ( document )
 			document->SetError( TIXML_ERROR_PARSING_UNKNOWN, 0, 0, encoding );
 	}
 	if ( p && *p == '>' )
@@ -1311,7 +1311,7 @@ void TiXmlComment::StreamIn( std::istream * in, TIXML_STRING * tag )
 {
 	while ( in->good() )
 	{
-		int c = in->get();	
+		int c = in->get();
 		if ( c <= 0 )
 		{
 			TiXmlDocument* document = GetDocument();
@@ -1322,12 +1322,12 @@ void TiXmlComment::StreamIn( std::istream * in, TIXML_STRING * tag )
 
 		(*tag) += (char) c;
 
-		if ( c == '>' 
+		if ( c == '>'
 			 && tag->at( tag->length() - 2 ) == '-'
 			 && tag->at( tag->length() - 3 ) == '-' )
 		{
 			// All is well.
-			return;		
+			return;
 		}
 	}
 }
@@ -1363,11 +1363,11 @@ const char* TiXmlComment::Parse( const char* p, TiXmlParsingData* data, TiXmlEnc
 	//
 	// from the XML spec:
 	/*
-	 [Definition: Comments may appear anywhere in a document outside other markup; in addition, 
-	              they may appear within the document type declaration at places allowed by the grammar. 
-				  They are not part of the document's character data; an XML processor MAY, but need not, 
-				  make it possible for an application to retrieve the text of comments. For compatibility, 
-				  the string "--" (double-hyphen) MUST NOT occur within comments.] Parameter entity 
+	 [Definition: Comments may appear anywhere in a document outside other markup; in addition,
+	              they may appear within the document type declaration at places allowed by the grammar.
+				  They are not part of the document's character data; an XML processor MAY, but need not,
+				  make it possible for an application to retrieve the text of comments. For compatibility,
+				  the string "--" (double-hyphen) MUST NOT occur within comments.] Parameter entity
 				  references MUST NOT be recognized within comments.
 
 				  An example of a comment:
@@ -1382,7 +1382,7 @@ const char* TiXmlComment::Parse( const char* p, TiXmlParsingData* data, TiXmlEnc
 		value.append( p, 1 );
 		++p;
 	}
-	if ( p && *p ) 
+	if ( p && *p )
 		p += strlen( endTag );
 
 	return p;
@@ -1421,7 +1421,7 @@ const char* TiXmlAttribute::Parse( const char* p, TiXmlParsingData* data, TiXmlE
 		if ( document ) document->SetError( TIXML_ERROR_READING_ATTRIBUTES, p, data, encoding );
 		return 0;
 	}
-	
+
 	const char* end;
 	const char SINGLE_QUOTE = '\'';
 	const char DOUBLE_QUOTE = '\"';
@@ -1450,7 +1450,7 @@ const char* TiXmlAttribute::Parse( const char* p, TiXmlParsingData* data, TiXmlE
 		{
 			if ( *p == SINGLE_QUOTE || *p == DOUBLE_QUOTE ) {
 				// [ 1451649 ] Attribute values with trailing quotes not handled correctly
-				// We did not have an opening quote but seem to have a 
+				// We did not have an opening quote but seem to have a
 				// closing one. Give up and throw an error.
 				if ( document ) document->SetError( TIXML_ERROR_READING_ATTRIBUTES, p, data, encoding );
 				return 0;
@@ -1467,8 +1467,8 @@ void TiXmlText::StreamIn( std::istream * in, TIXML_STRING * tag )
 {
 	while ( in->good() )
 	{
-		int c = in->peek();	
-		if ( !cdata && (c == '<' ) ) 
+		int c = in->peek();
+		if ( !cdata && (c == '<' ) )
 		{
 			return;
 		}
@@ -1489,7 +1489,7 @@ void TiXmlText::StreamIn( std::istream * in, TIXML_STRING * tag )
 				// terminator of cdata.
 				return;
 			}
-		}    
+		}
 	}
 }
 #endif
@@ -1529,7 +1529,7 @@ const char* TiXmlText::Parse( const char* p, TiXmlParsingData* data, TiXmlEncodi
 			++p;
 		}
 
-		TIXML_STRING dummy; 
+		TIXML_STRING dummy;
 		p = ReadText( p, &dummy, false, endTag, false, encoding );
 		return p;
 	}
@@ -1603,19 +1603,19 @@ const char* TiXmlDeclaration::Parse( const char* p, TiXmlParsingData* data, TiXm
 		if ( StringEqual( p, "version", true, _encoding ) )
 		{
 			TiXmlAttribute attrib;
-			p = attrib.Parse( p, data, _encoding );		
+			p = attrib.Parse( p, data, _encoding );
 			version = attrib.Value();
 		}
 		else if ( StringEqual( p, "encoding", true, _encoding ) )
 		{
 			TiXmlAttribute attrib;
-			p = attrib.Parse( p, data, _encoding );		
+			p = attrib.Parse( p, data, _encoding );
 			encoding = attrib.Value();
 		}
 		else if ( StringEqual( p, "standalone", true, _encoding ) )
 		{
 			TiXmlAttribute attrib;
-			p = attrib.Parse( p, data, _encoding );		
+			p = attrib.Parse( p, data, _encoding );
 			standalone = attrib.Value();
 		}
 		else

--- a/visiLibity/source_code/visilibity.cpp
+++ b/visiLibity/source_code/visilibity.cpp
@@ -45,7 +45,7 @@ License along with VisiLibity.  If not, see <http://www.gnu.org/licenses/>.
 ///Hide helping functions in unnamed namespace (local to .C file).
 namespace
 {
-  
+
 }
 
 
@@ -60,7 +60,7 @@ namespace VisiLibity
       return lower_bound;
     double sample_point;
     double span = upper_bound - lower_bound;
-    sample_point = lower_bound 
+    sample_point = lower_bound
                    + span * static_cast<double>( std::rand() )
                    / static_cast<double>( RAND_MAX );
     return sample_point;
@@ -84,13 +84,13 @@ namespace VisiLibity
     //(1.0-theta)*line_segment_temp.second.  if theta is outside
     //the interval [0,1], then one of the Line_Segment's endpoints
     //must be closest to calling Point.
-    double theta = 
+    double theta =
       ( (line_segment_temp.second().x()-x())
 	*(line_segment_temp.second().x()
-	  -line_segment_temp.first().x()) 
+	  -line_segment_temp.first().x())
 	+ (line_segment_temp.second().y()-y())
 	*(line_segment_temp.second().y()
-	  -line_segment_temp.first().y()) ) 
+	  -line_segment_temp.first().y()) )
       / ( pow(line_segment_temp.second().x()
 	      -line_segment_temp.first().x(),2)
 	  + pow(line_segment_temp.second().y()
@@ -98,10 +98,10 @@ namespace VisiLibity
     //std::cout << "\E[1;37;40m" << "Theta is: " << theta << "\x1b[0m"
     //<< std::endl;
     if( (0.0<=theta) && (theta<=1.0) )
-      return theta*line_segment_temp.first() 
+      return theta*line_segment_temp.first()
 	+ (1.0-theta)*line_segment_temp.second();
     //Else pick closest endpoint.
-    if( distance(*this, line_segment_temp.first()) 
+    if( distance(*this, line_segment_temp.first())
 	< distance(*this, line_segment_temp.second()) )
       return line_segment_temp.first();
     return line_segment_temp.second();
@@ -132,7 +132,7 @@ namespace VisiLibity
 	    && polyline_temp.size() > 0 );
 
     Point running_projection = polyline_temp[0];
-    double running_min = distance(*this, running_projection);    
+    double running_min = distance(*this, running_projection);
     Point point_temp;
     for(unsigned i=0; i<=polyline_temp.size()-1; i++){
       point_temp = projection_onto( Line_Segment(polyline_temp[i],
@@ -148,7 +148,7 @@ namespace VisiLibity
 
   Point Point::projection_onto_vertices_of(const Polygon& polygon_temp) const
   {
-    assert(*this == *this 
+    assert(*this == *this
 	   && polygon_temp.vertices_.size() > 0 );
 
     Point running_projection = polygon_temp[0];
@@ -166,12 +166,12 @@ namespace VisiLibity
   Point Point::projection_onto_vertices_of(const Environment&
 					   environment_temp) const
   {
-    assert(*this == *this 
+    assert(*this == *this
 	   && environment_temp.n() > 0 );
 
-    Point running_projection 
+    Point running_projection
       = projection_onto_vertices_of(environment_temp.outer_boundary_);
-    double running_min = distance(*this, running_projection);   
+    double running_min = distance(*this, running_projection);
     Point point_temp;
     for(unsigned i=0; i<environment_temp.h(); i++){
       point_temp = projection_onto_vertices_of(environment_temp.holes_[i]);
@@ -190,7 +190,7 @@ namespace VisiLibity
 	    && polygon_temp.n() > 0 );
 
     Point running_projection = polygon_temp[0];
-    double running_min = distance(*this, running_projection);    
+    double running_min = distance(*this, running_projection);
     Point point_temp;
     for(unsigned i=0; i<=polygon_temp.n()-1; i++){
       point_temp = projection_onto( Line_Segment(polygon_temp[i],
@@ -210,7 +210,7 @@ namespace VisiLibity
     assert( *this == *this
 	    && environment_temp.n() > 0 );
 
-    Point running_projection 
+    Point running_projection
       = projection_onto_boundary_of(environment_temp.outer_boundary_);
     double running_min = distance(*this, running_projection);
     Point point_temp;
@@ -224,20 +224,20 @@ namespace VisiLibity
     return running_projection;
   }
 
-  
+
   bool Point::on_boundary_of(const Polygon& polygon_temp,
 			     double epsilon) const
   {
     assert( *this == *this
 	    && polygon_temp.vertices_.size() > 0 );
 
-    if( distance(*this, projection_onto_boundary_of(polygon_temp) ) 
+    if( distance(*this, projection_onto_boundary_of(polygon_temp) )
 	<= epsilon ){
       return true;
     }
     return false;
   }
- 
+
 
   bool Point::on_boundary_of(const Environment& environment_temp,
 			     double epsilon) const
@@ -245,12 +245,12 @@ namespace VisiLibity
     assert( *this == *this
 	    && environment_temp.outer_boundary_.n() > 0 );
 
-    if( distance(*this, projection_onto_boundary_of(environment_temp) ) 
+    if( distance(*this, projection_onto_boundary_of(environment_temp) )
 	<= epsilon ){
       return true;
     }
     return false;
-  }    
+  }
 
 
   bool Point::in(const Line_Segment& line_segment_temp,
@@ -270,8 +270,8 @@ namespace VisiLibity
   {
     assert( *this == *this
 	    && line_segment_temp.size() > 0 );
-      
-    return in(line_segment_temp, epsilon) 
+
+    return in(line_segment_temp, epsilon)
       && distance(*this, line_segment_temp.first()) > epsilon
       && distance(*this, line_segment_temp.second()) > epsilon;
   }
@@ -293,21 +293,21 @@ namespace VisiLibity
     // http://www.ecse.rpi.edu/Homepages/wrf/Research/Short_Notes/pnpoly.html
     int i, j; bool c = false;
     for (i = 0, j = n-1; i < n; j = i++){
-      if ( (((polygon_temp[i].y() <= y()) 
-	     && (y() < polygon_temp[j].y())) 
-	    || ((polygon_temp[j].y() <= y()) 
-		 && (y() < polygon_temp[i].y()))) 
-	   && ( x() < (polygon_temp[j].x() 
-		       - polygon_temp[i].x()) 
-		* (y() - polygon_temp[i].y()) 
-		/ (polygon_temp[j].y() 
-		   - polygon_temp[i].y()) 
-		   + polygon_temp[i].x()) )     
+      if ( (((polygon_temp[i].y() <= y())
+	     && (y() < polygon_temp[j].y()))
+	    || ((polygon_temp[j].y() <= y())
+		 && (y() < polygon_temp[i].y())))
+	   && ( x() < (polygon_temp[j].x()
+		       - polygon_temp[i].x())
+		* (y() - polygon_temp[i].y())
+		/ (polygon_temp[j].y()
+		   - polygon_temp[i].y())
+		   + polygon_temp[i].x()) )
 	c = !c;
     }
     return c;
   }
- 
+
 
   bool Point::in(const Environment& environment_temp, double epsilon) const
   {
@@ -335,7 +335,7 @@ namespace VisiLibity
     assert( *this == *this
 	    && line_segment_temp.size() > 0 );
 
-    if( distance(line_segment_temp.first(), *this)<=epsilon 
+    if( distance(line_segment_temp.first(), *this)<=epsilon
 	|| distance(line_segment_temp.second(), *this)<=epsilon )
       return true;
     return false;
@@ -387,7 +387,7 @@ namespace VisiLibity
 
 
   bool operator == (const Point& point1, const Point& point2)
-  { return (  ( point1.x() == point2.x() ) 
+  { return (  ( point1.x() == point2.x() )
 	      && ( point1.y() == point2.y() )  ); }
   bool operator != (const Point& point1, const Point& point2)
   { return !( point1 == point2 ); }
@@ -399,7 +399,7 @@ namespace VisiLibity
       return false;
     if(point1.x() < point2.x())
       return true;
-    else if(  ( point1.x() == point2.x() ) 
+    else if(  ( point1.x() == point2.x() )
 	      && ( point1.y() < point2.y() )  )
       return true;
     return false;
@@ -410,7 +410,7 @@ namespace VisiLibity
       return false;
     if( point1.x() > point2.x() )
       return true;
-    else if(  ( point1.x() == point2.x() ) 
+    else if(  ( point1.x() == point2.x() )
 	      && ( point1.y() > point2.y() )  )
       return true;
     return false;
@@ -444,19 +444,19 @@ namespace VisiLibity
   Point operator * (const Point& point1, const Point& point2)
   {
     return Point( point1.x()*point2.x(),
-		  point1.y()*point2.y() ); 
+		  point1.y()*point2.y() );
   }
 
 
   Point operator * (double scalar, const Point& point2)
   {
     return Point( scalar*point2.x(),
-		  scalar*point2.y()); 
+		  scalar*point2.y());
   }
   Point operator * (const Point& point1, double scalar)
   {
     return Point( scalar*point1.x(),
-		  scalar*point1.y()); 
+		  scalar*point1.y());
   }
 
 
@@ -486,7 +486,7 @@ namespace VisiLibity
     assert( point_temp == point_temp
 	    && line_segment_temp.size() > 0 );
 
-    return distance( point_temp, 
+    return distance( point_temp,
 		     point_temp.projection_onto(line_segment_temp) );
   }
   double distance(const Line_Segment& line_segment_temp,
@@ -502,7 +502,7 @@ namespace VisiLibity
   {
     assert( point_temp == point_temp
 	    && ray_temp == ray_temp );
-    return distance( point_temp, 
+    return distance( point_temp,
 		     point_temp.projection_onto(ray_temp) );
   }
   double distance(const Ray& ray_temp,
@@ -555,9 +555,9 @@ namespace VisiLibity
   double boundary_distance(const Polygon& polygon_temp, const Point& point_temp)
   {
     return boundary_distance(point_temp, polygon_temp);
-  } 
+  }
 
- 
+
   double boundary_distance(const Point& point_temp,
 			   const Environment& environment_temp)
   {
@@ -572,7 +572,7 @@ namespace VisiLibity
 	running_min = distance_temp;
     }
     return running_min;
-  }  
+  }
   double boundary_distance(const Environment& environment_temp,
 			   const Point& point_temp)
   {
@@ -808,7 +808,7 @@ namespace VisiLibity
   bool  operator == (const Line_Segment& line_segment1,
 		     const Line_Segment& line_segment2)
   {
-    if( line_segment1.size() != line_segment2.size() 
+    if( line_segment1.size() != line_segment2.size()
 	|| line_segment1.size() == 0
 	|| line_segment2.size() == 0 )
       return false;
@@ -817,30 +817,30 @@ namespace VisiLibity
       return true;
     else
       return false;
-  } 
+  }
 
 
   bool  operator != (const Line_Segment& line_segment1,
 		     const Line_Segment& line_segment2)
   {
     return !( line_segment1 == line_segment2 );
-  } 
+  }
 
 
-  bool equivalent(Line_Segment line_segment1, 
+  bool equivalent(Line_Segment line_segment1,
 		  Line_Segment line_segment2, double epsilon)
   {
     if( line_segment1.size() != line_segment2.size()
 	|| line_segment1.size() == 0
 	|| line_segment2.size() == 0 )
       return false;
-    else if(   (  distance( line_segment1.first(), 
-			    line_segment2.first() ) <= epsilon  
-		  &&  distance( line_segment1.second(), 
+    else if(   (  distance( line_segment1.first(),
+			    line_segment2.first() ) <= epsilon
+		  &&  distance( line_segment1.second(),
 				 line_segment2.second() ) <= epsilon  )
-	    || (  distance( line_segment1.first(), 
-			    line_segment2.second() ) <= epsilon  
-		  &&  distance( line_segment1.second(), 
+	    || (  distance( line_segment1.first(),
+			    line_segment2.second() ) <= epsilon
+		  &&  distance( line_segment1.second(),
 				 line_segment2.first() ) <= epsilon  )   )
       return true;
     else
@@ -852,7 +852,7 @@ namespace VisiLibity
 		  const Line_Segment& line_segment2)
   {
     assert( line_segment1.size() > 0  &&  line_segment2.size() > 0 );
-    
+
     if(intersect_proper(line_segment1, line_segment2))
       return 0;
     //But if two line segments intersect improperly, the distance
@@ -882,7 +882,7 @@ namespace VisiLibity
     double running_min = distance( line_segment , polygon[0] );
     if( polygon.n() > 1 )
       for(unsigned i=0; i<polygon.n(); i++){
-	double d = distance(  line_segment, 
+	double d = distance(  line_segment,
 			      Line_Segment( polygon[i] , polygon[i+1] )  );
 	if( running_min > d )
 	  running_min = d;
@@ -905,7 +905,7 @@ namespace VisiLibity
     return false;
   }
 
-  
+
   bool intersect_proper(const Line_Segment& line_segment1,
 			const Line_Segment& line_segment2, double epsilon)
   {
@@ -934,16 +934,16 @@ namespace VisiLibity
     //If an endpoint is close enough to the other segment, the
     //intersection is not considered proper.
     if(running_min <= epsilon)
-      return false; 
+      return false;
     //This test is from O'Rourke's "Computational Geometry in C",
     //p.30.  Checks left and right turns.
-    if(  cross(b-a, c-b) * cross(b-a, d-b) < 0   
+    if(  cross(b-a, c-b) * cross(b-a, d-b) < 0
 	 &&   cross(d-c, b-d) * cross(d-c, a-d) < 0  )
       return true;
     return false;
   }
 
-  
+
   Line_Segment intersection(const Line_Segment& line_segment1,
 			    const Line_Segment& line_segment2, double epsilon)
   {
@@ -965,12 +965,12 @@ namespace VisiLibity
     if( intersect_proper(line_segment1, line_segment2, epsilon) ){
       //Use formula from O'Rourke's "Computational Geometry in C", p. 221.
       //Note D=0 iff the line segments are parallel.
-      double D = a.x()*( d.y() - c.y() ) 
-	+ b.x()*( c.y() - d.y() ) 
-	+ d.x()*( b.y() - a.y() ) 
+      double D = a.x()*( d.y() - c.y() )
+	+ b.x()*( c.y() - d.y() )
+	+ d.x()*( b.y() - a.y() )
 	+ c.x()*( a.y() - b.y() );
-      double s = (  a.x()*( d.y() - c.y() ) 
-		    + c.x()*( a.y() - d.y() ) 
+      double s = (  a.x()*( d.y() - c.y() )
+		    + c.x()*( a.y() - d.y() )
 		    + d.x()*( c.y() - a.y() )  ) / D;
       line_segment_temp.set_first( a + s * ( b - a ) );
       return line_segment_temp;
@@ -1040,12 +1040,12 @@ namespace VisiLibity
       return outs;
       break;
     case 1:
-      outs << line_segment_temp.first() << std::endl 
+      outs << line_segment_temp.first() << std::endl
 	   << line_segment_temp.second() << std::endl;
       return outs;
       break;
     case 2:
-      outs << line_segment_temp.first() << std::endl 
+      outs << line_segment_temp.first() << std::endl
 	   << line_segment_temp.second() << std::endl;
       return outs;
     }
@@ -1081,7 +1081,7 @@ namespace VisiLibity
 
 
   void Angle::set(double data_temp)
-  { 
+  {
     *this = Angle(data_temp);
   }
 
@@ -1135,7 +1135,7 @@ namespace VisiLibity
     assert( angle1.get() == angle1.get()
 	    && angle2.get() == angle2.get() );
 
-    double distance1 = std::fabs( angle1.get() 
+    double distance1 = std::fabs( angle1.get()
 				  - angle2.get() );
     double distance2 = 2*M_PI - distance1;
     if(distance1 < distance2)
@@ -1149,7 +1149,7 @@ namespace VisiLibity
     assert( angle1.get() == angle1.get()
 	    && angle2.get() == angle2.get() );
 
-    double distance1 = std::fabs( angle1.get() 
+    double distance1 = std::fabs( angle1.get()
 				  - angle2.get() );
     double distance2 = 2*M_PI - distance1;
     if(angle1 <= angle2){
@@ -1187,7 +1187,7 @@ namespace VisiLibity
     }
     else if( polar_origin_==polar_origin_
 	     && point_temp==point_temp){
-      bearing_ = Angle(  point_temp.y()-polar_origin_temp.y(), 
+      bearing_ = Angle(  point_temp.y()-polar_origin_temp.y(),
 			 point_temp.x()-polar_origin_temp.x()  );
       range_ = distance(polar_origin_temp, point_temp);
     }
@@ -1215,9 +1215,9 @@ namespace VisiLibity
   void Polar_Point::set_range(double range_temp)
   {
     range_ = range_temp;
-    x_ = polar_origin_.x() 
+    x_ = polar_origin_.x()
       + range_*std::cos( bearing_.get() );
-    y_ = polar_origin_.y() 
+    y_ = polar_origin_.y()
       + range_*std::sin( bearing_.get() );
   }
 
@@ -1225,13 +1225,13 @@ namespace VisiLibity
   void Polar_Point::set_bearing(const Angle& bearing_temp)
   {
     bearing_ = bearing_temp;
-    x_ = polar_origin_.x() 
+    x_ = polar_origin_.x()
       + range_*std::cos( bearing_.get() );
-    y_ = polar_origin_.y() 
+    y_ = polar_origin_.y()
              + range_*std::sin( bearing_.get() );
   }
 
-  
+
   bool operator == (const Polar_Point& polar_point1,
 		    const Polar_Point& polar_point2)
   {
@@ -1254,16 +1254,16 @@ namespace VisiLibity
   {
     if( polar_point1.polar_origin() != polar_point1.polar_origin()
 	|| polar_point1.range() != polar_point1.range()
-	|| polar_point1.bearing() != polar_point1.bearing() 
+	|| polar_point1.bearing() != polar_point1.bearing()
 	|| polar_point2.polar_origin() != polar_point2.polar_origin()
 	|| polar_point2.range() != polar_point2.range()
-	|| polar_point2.bearing() != polar_point2.bearing() 
+	|| polar_point2.bearing() != polar_point2.bearing()
 	)
       return false;
 
     if( polar_point1.bearing() > polar_point2.bearing() )
       return true;
-    else if( polar_point1.bearing() == polar_point2.bearing() 
+    else if( polar_point1.bearing() == polar_point2.bearing()
 	     &&  polar_point1.range() > polar_point2.range() )
       return true;
     return false;
@@ -1273,16 +1273,16 @@ namespace VisiLibity
   {
     if( polar_point1.polar_origin() != polar_point1.polar_origin()
 	|| polar_point1.range() != polar_point1.range()
-	|| polar_point1.bearing() != polar_point1.bearing() 
+	|| polar_point1.bearing() != polar_point1.bearing()
 	|| polar_point2.polar_origin() != polar_point2.polar_origin()
 	|| polar_point2.range() != polar_point2.range()
-	|| polar_point2.bearing() != polar_point2.bearing() 
+	|| polar_point2.bearing() != polar_point2.bearing()
 	)
       return false;
 
     if( polar_point1.bearing() < polar_point2.bearing() )
       return true;
-    else if( polar_point1.bearing() == polar_point2.bearing() 
+    else if( polar_point1.bearing() == polar_point2.bearing()
 	     &&  polar_point1.range() < polar_point2.range() )
       return true;
     return false;
@@ -1293,24 +1293,24 @@ namespace VisiLibity
   {
     if( polar_point1.polar_origin() != polar_point1.polar_origin()
 	|| polar_point1.range() != polar_point1.range()
-	|| polar_point1.bearing() != polar_point1.bearing() 
+	|| polar_point1.bearing() != polar_point1.bearing()
 	|| polar_point2.polar_origin() != polar_point2.polar_origin()
 	|| polar_point2.range() != polar_point2.range()
-	|| polar_point2.bearing() != polar_point2.bearing() 
+	|| polar_point2.bearing() != polar_point2.bearing()
 	)
       return false;
 
     return !(polar_point1<polar_point2);
   }
   bool operator <= (const Polar_Point& polar_point1,
-		    const Polar_Point& polar_point2) 
+		    const Polar_Point& polar_point2)
   {
     if( polar_point1.polar_origin() != polar_point1.polar_origin()
 	|| polar_point1.range() != polar_point1.range()
-	|| polar_point1.bearing() != polar_point1.bearing() 
+	|| polar_point1.bearing() != polar_point1.bearing()
 	|| polar_point2.polar_origin() != polar_point2.polar_origin()
 	|| polar_point2.range() != polar_point2.range()
-	|| polar_point2.bearing() != polar_point2.bearing() 
+	|| polar_point2.bearing() != polar_point2.bearing()
 	)
       return false;
 
@@ -1330,8 +1330,8 @@ namespace VisiLibity
 
 
   Ray::Ray(Point base_point_temp, Point bearing_point)
-  { 
-      assert(  !( base_point_temp == bearing_point )  ); 
+  {
+      assert(  !( base_point_temp == bearing_point )  );
 
       base_point_ = base_point_temp;
       bearing_ = Angle( bearing_point.y()-base_point_temp.y(),
@@ -1366,7 +1366,7 @@ namespace VisiLibity
     //First construct a Line_Segment parallel with the Ray which is so
     //long, that it's intersection with line_segment_temp will be
     //equal to the intersection of ray_temp with line_segment_temp.
-    double R = distance(ray_temp.base_point(), line_segment_temp) 
+    double R = distance(ray_temp.base_point(), line_segment_temp)
                + line_segment_temp.length();
     Line_Segment seg_approx =
       Line_Segment(  ray_temp.base_point(), ray_temp.base_point() +
@@ -1460,9 +1460,9 @@ namespace VisiLibity
 
     while( third < vertices_.size() ){
       //if second redundant
-      if(   distance(  Line_Segment( (*this)[first], 
+      if(   distance(  Line_Segment( (*this)[first],
 				     (*this)[third] ) ,
-		       (*this)[second]  ) 
+		       (*this)[second]  )
 	    <= epsilon   ){
 	//=>skip it
 	second = third;
@@ -1532,7 +1532,7 @@ namespace VisiLibity
 
   Polygon::Polygon(const std::vector<Point>& vertices_temp)
   {
-    vertices_ = vertices_temp; 
+    vertices_ = vertices_temp;
   }
 
 
@@ -1553,11 +1553,11 @@ namespace VisiLibity
       //Use cross product to count right turns.
       for(unsigned i=0; i<=n()-1; i++)
 	if( ((*this)[i+1].x()-(*this)[i].x())
-	    *((*this)[i+2].y()-(*this)[i].y()) 
+	    *((*this)[i+2].y()-(*this)[i].y())
 	    - ((*this)[i+1].y()-(*this)[i].y())
 	    *((*this)[i+2].x()-(*this)[i].x()) < 0 )
 	  r_count++;
-      if( area() < 0 ){ 
+      if( area() < 0 ){
 	r_count = n() - r_count;
       }
     }
@@ -1567,25 +1567,25 @@ namespace VisiLibity
 
   bool Polygon::is_simple(double epsilon) const
   {
-    
+
     if(n()==0 || n()==1 || n()==2)
       return false;
 
     //Make sure adjacent edges only intersect at a single point.
     for(unsigned i=0; i<=n()-1; i++)
-      if(  intersection( Line_Segment((*this)[i],(*this)[i+1]) , 
-			 Line_Segment((*this)[i+1],(*this)[i+2]) , 
+      if(  intersection( Line_Segment((*this)[i],(*this)[i+1]) ,
+			 Line_Segment((*this)[i+1],(*this)[i+2]) ,
 			 epsilon ).size() > 1  )
 	return false;
 
     //Make sure nonadjacent edges do not intersect.
     for(unsigned i=0; i<n()-2; i++)
       for(unsigned j=i+2; j<=n()-1; j++)
-	if( 0!=(j+1)%vertices_.size()  
-	    && distance( Line_Segment((*this)[i],(*this)[i+1]) , 
+	if( 0!=(j+1)%vertices_.size()
+	    && distance( Line_Segment((*this)[i],(*this)[i+1]) ,
 			  Line_Segment((*this)[j],(*this)[j+1]) ) <= epsilon  )
 	  return false;
-    
+
     return true;
   }
 
@@ -1607,7 +1607,7 @@ namespace VisiLibity
       return 0;
     for(unsigned i=0; i<n()-1; i++)
       length_temp += distance( vertices_[i] , vertices_[i+1] );
-    length_temp += distance( vertices_[n()-1] , 
+    length_temp += distance( vertices_[n()-1] ,
 			     vertices_[0] );
     return length_temp;
   }
@@ -1619,7 +1619,7 @@ namespace VisiLibity
     if(n()==0)
       return 0;
     for(unsigned i=0; i<=n()-1; i++)
-      area_temp += (*this)[i].x()*(*this)[i+1].y() 
+      area_temp += (*this)[i].x()*(*this)[i+1].y()
 	- (*this)[i+1].x()*(*this)[i].y();
     return area_temp/2.0;
   }
@@ -1631,18 +1631,18 @@ namespace VisiLibity
 
     double area_temp=area();
     if(area_temp==0)
-      { std::cerr << "\x1b[5;31m" 
-	 << "Warning:  tried to compute centoid of polygon with zero area!" 
-	 << "\x1b[0m\n" << "\a \n"; exit(1); } 
+      { std::cerr << "\x1b[5;31m"
+	 << "Warning:  tried to compute centoid of polygon with zero area!"
+	 << "\x1b[0m\n" << "\a \n"; exit(1); }
     double x_temp=0;
     for(unsigned i=0; i<=n()-1; i++)
-      x_temp += ( (*this)[i].x() + (*this)[i+1].x() ) 
-	* ( (*this)[i].x()*(*this)[i+1].y() 
+      x_temp += ( (*this)[i].x() + (*this)[i+1].x() )
+	* ( (*this)[i].x()*(*this)[i+1].y()
 	    - (*this)[i+1].x()*(*this)[i].y() );
     double y_temp=0;
     for(unsigned i=0; i<=n()-1; i++)
-      y_temp += ( (*this)[i].y() + (*this)[i+1].y() ) 
-	* ( (*this)[i].x()*(*this)[i+1].y() 
+      y_temp += ( (*this)[i].y() + (*this)[i+1].y() )
+	* ( (*this)[i].x()*(*this)[i+1].y()
 	    - (*this)[i+1].x()*(*this)[i].y() );
     return Point(x_temp/(6*area_temp), y_temp/(6*area_temp));
   }
@@ -1691,21 +1691,21 @@ namespace VisiLibity
 
     Bounding_Box bounding_box = bbox();
     std::vector<Point> pts_in_polygon; pts_in_polygon.reserve(count);
-    Point pt_temp( uniform_random_sample(bounding_box.x_min, 
+    Point pt_temp( uniform_random_sample(bounding_box.x_min,
 					 bounding_box.x_max),
-		   uniform_random_sample(bounding_box.y_min, 
+		   uniform_random_sample(bounding_box.y_min,
 					 bounding_box.y_max) );
     while(pts_in_polygon.size() < count){
       while(!pt_temp.in(*this, epsilon)){
-	pt_temp.set_x( uniform_random_sample(bounding_box.x_min, 
+	pt_temp.set_x( uniform_random_sample(bounding_box.x_min,
 					     bounding_box.x_max) );
-	pt_temp.set_y( uniform_random_sample(bounding_box.y_min, 
+	pt_temp.set_y( uniform_random_sample(bounding_box.y_min,
 					     bounding_box.y_max) );
       }
       pts_in_polygon.push_back(pt_temp);
-      pt_temp.set_x( uniform_random_sample(bounding_box.x_min, 
+      pt_temp.set_x( uniform_random_sample(bounding_box.x_min,
 					   bounding_box.x_max) );
-      pt_temp.set_y( uniform_random_sample(bounding_box.y_min, 
+      pt_temp.set_y( uniform_random_sample(bounding_box.y_min,
 					   bounding_box.y_max) );
     }
     return pts_in_polygon;
@@ -1760,7 +1760,7 @@ namespace VisiLibity
     //Store new minimal length list of vertices.
     std::vector<Point> vertices_temp;
     vertices_temp.reserve( vertices_.size() );
- 
+
     //Place holders.
     unsigned first  = 0;
     unsigned second = 1;
@@ -1768,9 +1768,9 @@ namespace VisiLibity
 
     while( third <= vertices_.size() ){
       //if second is redundant
-      if(   distance(  Line_Segment( (*this)[first], 
+      if(   distance(  Line_Segment( (*this)[first],
 				     (*this)[third] ) ,
-		       (*this)[second]  ) 
+		       (*this)[second]  )
 	    <= epsilon   ){
 	//=>skip it
 	second = third;
@@ -1787,14 +1787,14 @@ namespace VisiLibity
     }
 
     //decide whether to add original first point
-    if(   distance(  Line_Segment( vertices_temp.front(), 
+    if(   distance(  Line_Segment( vertices_temp.front(),
 				   vertices_temp.back() ) ,
-		     vertices_.front()  ) 
+		     vertices_.front()  )
 	  > epsilon   )
       vertices_temp.push_back( vertices_.front() );
-    
+
     //Update list of vertices.
-    vertices_ = vertices_temp;   
+    vertices_ = vertices_temp;
   }
 
 
@@ -1807,7 +1807,7 @@ namespace VisiLibity
 
   bool operator == (Polygon polygon1, Polygon polygon2)
   {
-    if( polygon1.n() != polygon2.n() 
+    if( polygon1.n() != polygon2.n()
 	|| polygon1.n() == 0
 	|| polygon2.n() == 0 )
       return false;
@@ -1876,8 +1876,8 @@ namespace VisiLibity
 
 
   //Environment
-  
-  
+
+
   Environment::Environment(const std::vector<Polygon>& polygons)
   {
     outer_boundary_ = polygons[0];
@@ -1893,11 +1893,11 @@ namespace VisiLibity
     assert( !fin.fail() );
 
     //Temporary vars for numbers to be read from file.
-    double x_temp, y_temp;  
+    double x_temp, y_temp;
     std::vector<Point> vertices_temp;
 
     //Skip comments
-    while( fin.peek() == '/' ) 
+    while( fin.peek() == '/' )
       fin.ignore(200,'\n');
 
     //Read outer_boundary.
@@ -1906,16 +1906,16 @@ namespace VisiLibity
       //Skip to next line.
       fin.ignore(1);
       if( fin.eof() )
-	{ 
+	{
 	  outer_boundary_.set_vertices(vertices_temp);
-	  fin.close(); 
+	  fin.close();
 	  update_flattened_index_key(); return;
-	}      
+	}
       vertices_temp.push_back( Point(x_temp, y_temp) );
     }
     outer_boundary_.set_vertices(vertices_temp);
     vertices_temp.clear();
-    
+
     //Read holes.
     Polygon polygon_temp;
     while(1){
@@ -1924,13 +1924,13 @@ namespace VisiLibity
 	fin.ignore(200,'\n');
       if( fin.eof() )
 	{ fin.close(); update_flattened_index_key(); return; }
-      while( fin.peek() != '/' ){	
+      while( fin.peek() != '/' ){
 	fin >> x_temp >> y_temp;
 	if( fin.eof() )
-	  { 
+	  {
 	    polygon_temp.set_vertices(vertices_temp);
 	    holes_.push_back(polygon_temp);
-	    fin.close(); 
+	    fin.close();
 	    update_flattened_index_key(); return;
 	  }
 	vertices_temp.push_back( Point(x_temp, y_temp) );
@@ -1978,17 +1978,17 @@ namespace VisiLibity
 
   bool Environment::is_in_standard_form() const
   {
-    if( outer_boundary_.is_in_standard_form() == false 
+    if( outer_boundary_.is_in_standard_form() == false
 	|| outer_boundary_.area() < 0 )
       return false;
     for(unsigned i=0; i<holes_.size(); i++)
-      if( holes_[i].is_in_standard_form() == false 
+      if( holes_[i].is_in_standard_form() == false
 	  || holes_[i].area() > 0 )
 	return false;
     return true;
   }
 
-  
+
   bool Environment::is_valid(double epsilon) const
   {
     if( n() <= 2 )
@@ -1996,33 +1996,33 @@ namespace VisiLibity
 
     //Check all Polygons are simple.
     if( !outer_boundary_.is_simple(epsilon) ){
-      std::cerr << std::endl << "\x1b[31m" 
-		<< "The outer boundary is not simple." 
+      std::cerr << std::endl << "\x1b[31m"
+		<< "The outer boundary is not simple."
 		<<  "\x1b[0m" << std::endl;
       return false;
     }
     for(unsigned i=0; i<h(); i++)
       if( !holes_[i].is_simple(epsilon) ){
-	std::cerr << std::endl << "\x1b[31m" 
-		  << "Hole " << i << " is not simple." 
+	std::cerr << std::endl << "\x1b[31m"
+		  << "Hole " << i << " is not simple."
 		  <<  "\x1b[0m" << std::endl;
-	return false; 
+	return false;
       }
 
     //Check none of the Polygons' boundaries intersect w/in epsilon.
     for(unsigned i=0; i<h(); i++)
       if( boundary_distance(outer_boundary_, holes_[i]) <= epsilon ){
-	std::cerr << std::endl << "\x1b[31m" 
-	  << "The outer boundary intersects the boundary of hole " << i << "." 
+	std::cerr << std::endl << "\x1b[31m"
+	  << "The outer boundary intersects the boundary of hole " << i << "."
 	  <<  "\x1b[0m" << std::endl;
-	return false; 
+	return false;
       }
     for(unsigned i=0; i<h(); i++)
       for(unsigned j=i+1; j<h(); j++)
 	if( boundary_distance(holes_[i], holes_[j]) <= epsilon ){
-	  std::cerr << std::endl << "\x1b[31m" 
-		    << "The boundary of hole " << i 
-		    << " intersects the boundary of hole " << j << "." 
+	  std::cerr << std::endl << "\x1b[31m"
+		    << "The boundary of hole " << i
+		    << " intersects the boundary of hole " << j << "."
 		    <<  "\x1b[0m" << std::endl;
 	  return false;
 	}
@@ -2034,19 +2034,19 @@ namespace VisiLibity
       //Loop over vertices of a hole
       for(unsigned j=0; j<holes_[i].n(); j++){
 	if( !holes_[i][j].in(outer_boundary_, epsilon) ){
-	  std::cerr << std::endl << "\x1b[31m" 
-		    << "Vertex " << j << " of hole " << i 
-		    << " is not within the outer boundary." 
+	  std::cerr << std::endl << "\x1b[31m"
+		    << "Vertex " << j << " of hole " << i
+		    << " is not within the outer boundary."
 		    <<  "\x1b[0m" << std::endl;
-	  return false; 
+	  return false;
 	}
 	//Second loop over holes.
 	for(unsigned k=0; k<h(); k++)
 	  if( i!=k && holes_[i][j].in(holes_[k], epsilon) ){
-	    std::cerr << std::endl << "\x1b[31m" 
-		      << "Vertex " << j 
-		      << " of hole " << i 
-		      << " is in hole " << k << "." 
+	    std::cerr << std::endl << "\x1b[31m"
+		      << "Vertex " << j
+		      << " of hole " << i
+		      << " is in hole " << k << "."
 		      <<  "\x1b[0m" << std::endl;
 	    return false;
 	  }
@@ -2055,21 +2055,21 @@ namespace VisiLibity
 
     //Check outer_boundary is ccw and holes are cw.
     if( outer_boundary_.area() <= 0 ){
-      std::cerr << std::endl << "\x1b[31m" 
-		<< "The outer boundary vertices are not listed ccw." 
+      std::cerr << std::endl << "\x1b[31m"
+		<< "The outer boundary vertices are not listed ccw."
 		<<  "\x1b[0m" << std::endl;
-      return false; 
+      return false;
     }
     for(unsigned i=0; i<h(); i++)
       if( holes_[i].area() >= 0 ){
-	std::cerr << std::endl << "\x1b[31m" 
-		  << "The vertices of hole " << i << " are not listed cw." 
+	std::cerr << std::endl << "\x1b[31m"
+		  << "The vertices of hole " << i << " are not listed cw."
 		  <<  "\x1b[0m" << std::endl;
-	return false; 
+	return false;
       }
 
-    return true; 
-  } 
+    return true;
+  }
 
 
   double Environment::boundary_length() const
@@ -2099,7 +2099,7 @@ namespace VisiLibity
     assert( area() > 0 );
 
     Bounding_Box bounding_box = bbox();
-    std::vector<Point> pts_in_environment; 
+    std::vector<Point> pts_in_environment;
     pts_in_environment.reserve(count);
     Point pt_temp( uniform_random_sample(bounding_box.x_min,
 					 bounding_box.x_max),
@@ -2107,13 +2107,13 @@ namespace VisiLibity
 					 bounding_box.y_max) );
     while(pts_in_environment.size() < count){
       while(!pt_temp.in(*this, epsilon)){
-	pt_temp.set_x( uniform_random_sample(bounding_box.x_min, 
+	pt_temp.set_x( uniform_random_sample(bounding_box.x_min,
 					     bounding_box.x_max) );
 	pt_temp.set_y( uniform_random_sample(bounding_box.y_min,
-					     bounding_box.y_max) );	  
+					     bounding_box.y_max) );
       }
       pts_in_environment.push_back(pt_temp);
-      pt_temp.set_x( uniform_random_sample(bounding_box.x_min, 
+      pt_temp.set_x( uniform_random_sample(bounding_box.x_min,
 					   bounding_box.x_max) );
       pt_temp.set_y( uniform_random_sample(bounding_box.y_min,
 					   bounding_box.y_max) );
@@ -2213,13 +2213,13 @@ namespace VisiLibity
 		  current_node.print();
 		  std::cout << std::endl;
       }
-      
+
       //Check for goal state
       //(if current node corresponds to finish)
       if( current_node.vertex_index == n() + 1 ){
-	
+
 	if( PRINTING_DEBUG_DATA ){
-	  std::cout <<"solution found!" 
+	  std::cout <<"solution found!"
 		    << std::endl
 		    << std::endl;
 	}
@@ -2236,11 +2236,11 @@ namespace VisiLibity
 		  << std::endl
 		  << "Expanding Current Node (Computing Children)"
 		  << std::endl
-		  << "current size of search tree T = " 
+		  << "current size of search tree T = "
 		  << T.size()
 		  << std::endl
 		  << "-------------------------------------------"
-		  << std::endl;      
+		  << std::endl;
       }
 
       //if current_node corresponds to start
@@ -2249,14 +2249,14 @@ namespace VisiLibity
 	for(unsigned i=0; i < n(); i++){
 	  if( start_visible[i] ){
 	    child.vertex_index = i;
-	    child.parent_search_tree_location 
+	    child.parent_search_tree_location
 	      = current_node.search_tree_location;
 	    child.cost_to_come = distance( start , (*this)(i) );
-	    child.estimated_cost_to_go = distance( (*this)(i) , finish );	    
+	    child.estimated_cost_to_go = distance( (*this)(i) , finish );
 	    children.push_back( child );
-	    
+
 	    if( PRINTING_DEBUG_DATA ){
-	      std::cout << std::endl << "computed child: " 
+	      std::cout << std::endl << "computed child: "
 			<< std::endl;
 	      child.print();
 	    }
@@ -2271,7 +2271,7 @@ namespace VisiLibity
 	  if( current_node.vertex_index != i )
 	    if( visibility_graph( current_node.vertex_index , i ) ){
 	      child.vertex_index = i;
-	      child.parent_search_tree_location 
+	      child.parent_search_tree_location
 		= current_node.search_tree_location;
 	      child.cost_to_come = current_node.cost_to_come
 		+ distance( (*this)(current_node.vertex_index),
@@ -2280,40 +2280,40 @@ namespace VisiLibity
 	      children.push_back( child );
 
 	      if( PRINTING_DEBUG_DATA ){
-		std::cout << std::endl << "computed child: " 
+		std::cout << std::endl << "computed child: "
 			  << std::endl;
 		child.print();
 	      }
-	      
+
 	    }
 	}
 	//check if finish is visible
 	if( finish_visible[ current_node.vertex_index ] ){
 	  child.vertex_index = n() + 1;
-	  child.parent_search_tree_location 
+	  child.parent_search_tree_location
 	    = current_node.search_tree_location;
 	  child.cost_to_come = current_node.cost_to_come
 	    + distance( (*this)(current_node.vertex_index) , finish );
-	  child.estimated_cost_to_go = 0;	    
+	  child.estimated_cost_to_go = 0;
 	  children.push_back( child );
 
 	  if( PRINTING_DEBUG_DATA ){
-	    std::cout << std::endl << "computed child: " 
+	    std::cout << std::endl << "computed child: "
 		      << std::endl;
 	    child.print();
 	  }
 
 	}
       }
-      
+
       if( PRINTING_DEBUG_DATA ){
 	std::cout << std::endl
 		  <<"-----------------------------------------"
 		  << std::endl
-		  << "Processing " << children.size() 
+		  << "Processing " << children.size()
 		  << " children" << std::endl
 		  << "-----------------------------------------"
-		  << std::endl;      
+		  << std::endl;
       }
 
       //Process children
@@ -2324,22 +2324,22 @@ namespace VisiLibity
 	child_already_visited = false;
 
 	if( PRINTING_DEBUG_DATA ){
-	  std::cout << std::endl << "current child being processed: " 
+	  std::cout << std::endl << "current child being processed: "
 		    << std::endl;
-	  children_itr->print();	  
+	  children_itr->print();
 	}
 
-	//Check if child state has already been visited 
-	//(by looking in search tree T) 
+	//Check if child state has already been visited
+	//(by looking in search tree T)
 	for( std::list<Shortest_Path_Node>::iterator T_itr = T.begin();
 	     T_itr != T.end(); T_itr++ ){
-	  if( children_itr->vertex_index 
+	  if( children_itr->vertex_index
 	      == T_itr->vertex_index ){
 	    children_itr->search_tree_location = T_itr;
 	    child_already_visited = true;
 	    break;
-	  }    
-	}	
+	  }
+	}
 
 	if( !child_already_visited ){
 	  //Add child to search tree T
@@ -2348,7 +2348,7 @@ namespace VisiLibity
 	  children_itr->search_tree_location = --T.end();
 	  Q.insert( *children_itr );
 	}
-	else if( children_itr->search_tree_location->cost_to_come > 
+	else if( children_itr->search_tree_location->cost_to_come >
 		 children_itr->cost_to_come ){
 	  //redirect parent pointer in search tree
 	  children_itr->search_tree_location->parent_search_tree_location
@@ -2357,16 +2357,16 @@ namespace VisiLibity
 	  children_itr->search_tree_location->cost_to_come
 	    = children_itr->cost_to_come;
 	  //update Q
-	  for(std::set<Shortest_Path_Node>::iterator 
+	  for(std::set<Shortest_Path_Node>::iterator
 		Q_itr = Q.begin();
 	      Q_itr!= Q.end();
 	      Q_itr++){
 	    if( children_itr->vertex_index == Q_itr->vertex_index ){
 	      Q.erase( Q_itr );
 	      break;
-	    }	  
+	    }
 	  }
-	  Q.insert( *children_itr );	  
+	  Q.insert( *children_itr );
 	}
 
 	//If not already visited, insert into Q
@@ -2376,9 +2376,9 @@ namespace VisiLibity
 	if( PRINTING_DEBUG_DATA ){
 	  std::cout << "child already visited? "
 		    << child_already_visited
-		    << std::endl;      
+		    << std::endl;
 	}
-      
+
       }
     }
     //-----------End Main Loop-----------
@@ -2403,7 +2403,7 @@ namespace VisiLibity
 	  std::cout << "backtrace node is "
 		    << std::endl;
 	  backtrace_itr->print();
-	  std::cout << std::endl;      
+	  std::cout << std::endl;
 	}
 
 	if( backtrace_itr->vertex_index < n() )
@@ -2458,7 +2458,7 @@ namespace VisiLibity
     fout.setf(std::ios::showpoint);
     fout.precision(fios_precision_temp);
     fout << "//Environment Model" << std::endl;
-    fout << "//Outer Boundary" << std::endl << outer_boundary_; 
+    fout << "//Outer Boundary" << std::endl << outer_boundary_;
     for(unsigned i=0; i<h(); i++)
       {
 	fout << "//Hole" << std::endl << holes_[i];
@@ -2536,23 +2536,23 @@ namespace VisiLibity
       vertex_count_up_to_current_polygon += (*this)[current_polygon_index].n();
     }
     two.second = k - vertex_count_up_to_last_polygon;
-    
+
     return two;
   }
 
 
-  std::ostream& operator << (std::ostream& outs, 
+  std::ostream& operator << (std::ostream& outs,
 			     const Environment& environment_temp)
   {
     outs << "//Environment Model" << std::endl;
-    outs << "//Outer Boundary" << std::endl << environment_temp[0]; 
+    outs << "//Outer Boundary" << std::endl << environment_temp[0];
     for(unsigned i=1; i<=environment_temp.h(); i++){
       outs << "//Hole" << std::endl << environment_temp[i];
     }
     //outs << "//EOF marker";
     return outs;
   }
-  
+
 
   //Guards
 
@@ -2565,10 +2565,10 @@ namespace VisiLibity
     assert( !fin.fail() );
 
     //Temp vars for numbers to be read from file.
-    double x_temp, y_temp;  
-    
+    double x_temp, y_temp;
+
     //Skip comments
-    while( fin.peek() == '/' ) 
+    while( fin.peek() == '/' )
       fin.ignore(200,'\n');
 
     //Read positions.
@@ -2671,7 +2671,7 @@ namespace VisiLibity
     fout.setf(std::ios::fixed);
     fout.setf(std::ios::showpoint);
     fout.precision(fios_precision_temp);
-    fout << "//Guard Positions" << std::endl; 
+    fout << "//Guard Positions" << std::endl;
     for(unsigned i=0; i<positions_.size(); i++)
       fout << positions_[i].x() << "  " << positions_[i].y() << std::endl;
     //fout << "//EOF marker";
@@ -2693,18 +2693,16 @@ namespace VisiLibity
 
 
   void Guards::snap_to_vertices_of(const Environment& environment_temp,
-				   double epsilon)
+				   double /*epsilon*/)
   {
-    UNUSED(epsilon);
     for(unsigned i=0; i<positions_.size(); i++)
       positions_[i].snap_to_vertices_of(environment_temp);
   }
 
 
   void Guards::snap_to_vertices_of(const Polygon& polygon_temp,
-				   double epsilon)
+				   double /*epsilon*/)
   {
-    UNUSED(epsilon);
     for(unsigned i=0; i<positions_.size(); i++)
       positions_[i].snap_to_vertices_of(polygon_temp);
   }
@@ -2718,9 +2716,8 @@ namespace VisiLibity
 
 
   void Guards::snap_to_boundary_of(const Polygon& polygon_temp,
-				   double epsilon)
+				   double /*epsilon*/)
   {
-    UNUSED(epsilon);
     for(unsigned i=0; i<positions_.size(); i++)
       positions_[i].snap_to_boundary_of(polygon_temp);
   }
@@ -2728,7 +2725,7 @@ namespace VisiLibity
 
   std::ostream& operator << (std::ostream& outs, const Guards& guards)
   {
-    outs << "//Guard Positions" << std::endl; 
+    outs << "//Guard Positions" << std::endl;
     for(unsigned i=0; i<guards.N(); i++)
       outs << guards[i].x() << "  " << guards[i].y() << std::endl;
     //outs << "//EOF marker";
@@ -2742,11 +2739,11 @@ namespace VisiLibity
   bool Visibility_Polygon::is_spike( const Point& Observer,
 				     const Point& point1,
 				     const Point& point2,
-				     const Point& point3, 
+				     const Point& point3,
 				     double epsilon) const
   {
 
-    return(  
+    return(
          //Make sure Observer not colocated with any of the points.
 	   distance( Observer , point1 ) > epsilon
 	   && distance( Observer , point2 ) > epsilon
@@ -2763,20 +2760,20 @@ namespace VisiLibity
 	 //and the pike is sufficiently sharp,
 	   && std::max(  distance( Ray(Observer, point1), point2 ),
 			  distance( Ray(Observer, point3), point2 )  )
-	   <= epsilon  
+	   <= epsilon
 	     );
     //Formerly used
     //std::fabs( Polygon(point1, point2, point3).area() ) < epsilon
   }
 
-  
+
   void Visibility_Polygon::chop_spikes_at_back(const Point& observer,
 					       double epsilon)
   {
     //Eliminate "special case" vertices of the visibility polygon.
     //While the top three vertices form a spike.
     while(  vertices_.size() >= 3
-	    && is_spike( observer, 
+	    && is_spike( observer,
 			  vertices_[vertices_.size()-3],
 			  vertices_[vertices_.size()-2],
 			  vertices_[vertices_.size()-1], epsilon )  ){
@@ -2791,7 +2788,7 @@ namespace VisiLibity
   {
     //Eliminate "special case" vertices of the visibility polygon at
     //wrap-around.  While the there's a spike at the wrap-around,
-    while(  vertices_.size() >= 3 
+    while(  vertices_.size() >= 3
 	    && is_spike( Observer,
 			  vertices_[vertices_.size()-2],
 			  vertices_[vertices_.size()-1],
@@ -2802,23 +2799,22 @@ namespace VisiLibity
   }
 
 
-  void Visibility_Polygon::chop_spikes(const Point& Observer,
+  void Visibility_Polygon::chop_spikes(const Point& /*Observer*/,
 				       double epsilon)
   {
-    UNUSED(Observer);
     std::set<Point> spike_tips;
     std::vector<Point> vertices_temp;
     //Middle point is potentially the tip of a spike
     for(unsigned i=0; i<vertices_.size(); i++)
-      if(   distance(  (*this)[i+2], 
+      if(   distance(  (*this)[i+2],
 		       Line_Segment( (*this)[i], (*this)[i+1] )  )
 	    <= epsilon
 	    ||
-	    distance(  (*this)[i], 
+	    distance(  (*this)[i],
 		       Line_Segment( (*this)[i+1], (*this)[i+2] )  )
 	    <= epsilon   )
 	spike_tips.insert( (*this)[i+1] );
-    
+
     for(unsigned i=0; i<vertices_.size(); i++)
       if( spike_tips.find(vertices_[i]) == spike_tips.end() )
 	vertices_temp.push_back( vertices_[i] );
@@ -2838,24 +2834,24 @@ namespace VisiLibity
 	      << current_vertex.range() << "  "
 	      << current_vertex.is_first << "]" << std::endl;
     std::cout << "1st point of current_vertex's edge [x  y  bearing  range] = ["
-	      << (current_vertex.incident_edge->first).x() << "  " 
+	      << (current_vertex.incident_edge->first).x() << "  "
 	      << (current_vertex.incident_edge->first).y() << "  "
 	      << (current_vertex.incident_edge->first).bearing() << "  "
-	      << (current_vertex.incident_edge->first).range() << "]" 
+	      << (current_vertex.incident_edge->first).range() << "]"
 	      << std::endl;
-    std::cout << "2nd point of current_vertex's edge [x  y  bearing  range] = [" 
-	      << (current_vertex.incident_edge->second).x() << "  " 
+    std::cout << "2nd point of current_vertex's edge [x  y  bearing  range] = ["
+	      << (current_vertex.incident_edge->second).x() << "  "
 	      << (current_vertex.incident_edge->second).y() << "  "
 	      << (current_vertex.incident_edge->second).bearing() << "  "
-	      << (current_vertex.incident_edge->second).range() << "]" 
+	      << (current_vertex.incident_edge->second).range() << "]"
 	      << std::endl;
     std::cout << "          1st point of active_edge [x  y  bearing  range] = ["
-	      << (active_edge->first).x() << "  " 
+	      << (active_edge->first).x() << "  "
 	      << (active_edge->first).y() << "  "
 	      << (active_edge->first).bearing() << "  "
 	      << (active_edge->first).range() << "]" << std::endl;
-    std::cout << "          2nd point of active_edge [x  y  bearing  range] = [" 
-	      << (active_edge->second).x() << "  " 
+    std::cout << "          2nd point of active_edge [x  y  bearing  range] = ["
+	      << (active_edge->second).x() << "  "
 	      << (active_edge->second).y() << "  "
 	      << (active_edge->second).bearing() << "  "
 	      << (active_edge->second).range() << "]" << std::endl;
@@ -2867,10 +2863,10 @@ namespace VisiLibity
 					 double epsilon)
     : observer_(Observer)
   {
-    //Visibility polygon algorithm for environments with holes 
+    //Visibility polygon algorithm for environments with holes
     //Radial line (AKA angular plane) sweep technique.
     //
-    //Based on algorithms described in 
+    //Based on algorithms described in
     //
     //[1] "Automated Camera Layout to Satisfy Task-Specific and
     //Floorplan-Specific Coverage Requirements" by Ugur Murat Erdem
@@ -2897,7 +2893,7 @@ namespace VisiLibity
     //     by vertices of the environment (the order of the snapping
     //     is important).
     //
-    //:WARNING: 
+    //:WARNING:
     //For efficiency, the assertions corresponding to these
     //preconditions have been excluded.
     //
@@ -2915,7 +2911,7 @@ namespace VisiLibity
     //
     //--------PREPROCESSING--------
     //
-     
+
     //Construct a POLAR EDGE LIST from environment_temp's outer
     //boundary and holes.  During this construction, those edges are
     //split which either (1) cross the ray emanating from the Observer
@@ -2934,7 +2930,7 @@ namespace VisiLibity
     Angle right_wall_bearing;
     Angle left_wall_bearing;
     for(unsigned i=0; i<=environment_temp.h(); i++){
-    for(unsigned j=0; j<environment_temp[i].n(); j++){      
+    for(unsigned j=0; j<environment_temp[i].n(); j++){
       ppoint1 = Polar_Point( Observer, environment_temp[i][j] );
       ppoint2 = Polar_Point( Observer, environment_temp[i][j+1] );
 
@@ -2948,7 +2944,7 @@ namespace VisiLibity
 
 	if( ppoint2.bearing() == Angle(0.0) )
 	  ppoint2.set_bearing_to_2pi();
-	
+
 	left_wall_bearing = ppoint1.bearing();
 	right_wall_bearing = ppoint2.bearing();
 
@@ -2985,7 +2981,7 @@ namespace VisiLibity
 	  / ( ppoint1.y() - ppoint2.y() );
 	//If edge crosses the ray emanating horizontal and right of
 	//the Observer.
-	if( 0 < t && t < 1 && 
+	if( 0 < t && t < 1 &&
 	    Observer.x() < t*ppoint1.x() + (1-t)*ppoint2.x() ){
 	  //If first point is above, omit edge because it runs
 	  //'against the grain'.
@@ -2993,7 +2989,7 @@ namespace VisiLibity
 	    continue;
 	  //Otherwise split the edge, making sure angles are assigned
 	  //correctly on each side of the split point.
-	  split_bottom = split_top 
+	  split_bottom = split_top
 	    = Polar_Point(  Observer,
 			    Point( t*ppoint1.x() + (1-t)*ppoint2.x(),
 				   Observer.y() )  );
@@ -3006,7 +3002,7 @@ namespace VisiLibity
 	//If the edge is not horizontal and doesn't cross the ray
 	//emanating horizontal and right of the Observer.
 	else if( ppoint1.bearing() >= ppoint2.bearing()
-		 && ppoint2.bearing() == Angle(0.0) 
+		 && ppoint2.bearing() == Angle(0.0)
 		 && ppoint1.bearing() > Angle(M_PI) )
 	  ppoint2.set_bearing_to_2pi();
 	//Filter out edges which run 'against the grain'.
@@ -3016,16 +3012,16 @@ namespace VisiLibity
 	  continue;
 	elp.push_back(  Polar_Edge( ppoint1, ppoint2 )  );
 	continue;
-      }    
+      }
       //If edge is horizontal (w/in epsilon).
       else{
 	//Filter out edges which run 'against the grain'.
-	if( ppoint1.bearing() >= ppoint2.bearing() ) 
+	if( ppoint1.bearing() >= ppoint2.bearing() )
 	  continue;
 	elp.push_back(  Polar_Edge( ppoint1, ppoint2 )  );
       }
     }}
-  
+
     //Construct a SORTED LIST, q1, OF VERTICES represented by
     //Polar_Point_With_Edge_Info objects.  A
     //Polar_Point_With_Edge_Info is a derived class of Polar_Point
@@ -3042,8 +3038,8 @@ namespace VisiLibity
     std::list<Polar_Point_With_Edge_Info> q1;
     Polar_Point_With_Edge_Info ppoint_wei1, ppoint_wei2;
     std::list<Polar_Edge>::iterator elp_iterator;
-    for(elp_iterator=elp.begin(); 
-	elp_iterator!=elp.end(); 
+    for(elp_iterator=elp.begin();
+	elp_iterator!=elp.end();
 	elp_iterator++){
       ppoint_wei1.set_polar_point( elp_iterator->first );
       ppoint_wei1.incident_edge = elp_iterator;
@@ -3062,7 +3058,7 @@ namespace VisiLibity
 	  ppoint_wei1.set_bearing( Angle(0.0) );
 	  (elp_iterator->first).set_bearing( Angle(0.0) );
 	}
-      } 
+      }
       else if( distance(Observer, ppoint_wei2) <= epsilon ){
 	if( right_wall_bearing > left_wall_bearing ){
 	  ppoint_wei2.set_bearing(right_wall_bearing);
@@ -3077,28 +3073,28 @@ namespace VisiLibity
       q1.push_back(ppoint_wei2);
     }
     //Put event point in correct order.
-    //STL list's sort method is a stable sort. 
+    //STL list's sort method is a stable sort.
     q1.sort();
 
     if(PRINTING_DEBUG_DATA){
-      std::cout << std::endl 
-		<< "\E[1;37;40m" 
+      std::cout << std::endl
+		<< "\E[1;37;40m"
 		<< "COMPUTING VISIBILITY POLYGON " << std::endl
 		<<  "for an Observer located at [x y] = ["
 		<< Observer << "]"
-		<< "\x1b[0m" 
+		<< "\x1b[0m"
 		<< std::endl << std::endl
-		<< "\E[1;37;40m" <<"PREPROCESSING" << "\x1b[0m" 
-		<< std::endl << std::endl 
+		<< "\E[1;37;40m" <<"PREPROCESSING" << "\x1b[0m"
+		<< std::endl << std::endl
 		<< "q1 is" << std::endl;
       std::list<Polar_Point_With_Edge_Info>::iterator q1_itr;
       for(q1_itr=q1.begin(); q1_itr!=q1.end(); q1_itr++){
-	std::cout << "[x  y  bearing  range is_first] = [" 
-		  << q1_itr->x() << "  " 
-		  << q1_itr->y() << "  " 
-		  << q1_itr->bearing() << "  " 
-		  << q1_itr->range() << "  " 
-		  << q1_itr->is_first << "]" 
+	std::cout << "[x  y  bearing  range is_first] = ["
+		  << q1_itr->x() << "  "
+		  << q1_itr->y() << "  "
+		  << q1_itr->bearing() << "  "
+		  << q1_itr->range() << "  "
+		  << q1_itr->is_first << "]"
 		  << std::endl;
       }
     }
@@ -3126,32 +3122,32 @@ namespace VisiLibity
     std::priority_queue<std::list<Polar_Edge>::iterator,
                         std::vector<std::list<Polar_Edge>::iterator>,
                         Incident_Edge_Compare> q2(my_iec);
-   
+
     //Initialize main loop.
     current_vertex = q1.front(); q1.pop_front();
     active_edge = current_vertex.incident_edge;
 
     if(PRINTING_DEBUG_DATA){
       std::cout << std::endl
-		<< "\E[1;37;40m" 
-		<< "INITIALIZATION" 
-		<< "\x1b[0m" 
+		<< "\E[1;37;40m"
+		<< "INITIALIZATION"
+		<< "\x1b[0m"
 		<< std::endl << std::endl
-		<< "\x1b[35m" 
-		<< "Pop first vertex off q1" 
+		<< "\x1b[35m"
+		<< "Pop first vertex off q1"
 		<< "\x1b[0m"
 		<< ", set as current_vertex, \n"
 		<< "and set active_edge to the corresponding "
 		<< "incident edge."
 		<< std::endl;
-      print_cv_and_ae(current_vertex, active_edge); 
+      print_cv_and_ae(current_vertex, active_edge);
     }
 
     //Insert e into q2 as long as it doesn't contain the
     //Observer.
     if( distance(Observer,active_edge->first) > epsilon
 	 && distance(Observer,active_edge->second) > epsilon ){
-     
+
       if(PRINTING_DEBUG_DATA){
 	std::cout << std::endl
 		  << "Push current_vertex's edge onto q2."
@@ -3163,13 +3159,13 @@ namespace VisiLibity
 
     if(PRINTING_DEBUG_DATA){
       std::cout << std::endl
-		<< "\E[32m" 
-		<< "Add current_vertex to visibility polygon." 
-		<< "\x1b[0m" 
+		<< "\E[32m"
+		<< "Add current_vertex to visibility polygon."
+		<< "\x1b[0m"
 		<< std::endl << std::endl
-		<< "\E[1;37;40m" 
-		<< "MAIN LOOP" 
-		<< "\x1b[0m" 
+		<< "\E[1;37;40m"
+		<< "MAIN LOOP"
+		<< "\x1b[0m"
 		<< std::endl;
     }
 
@@ -3186,7 +3182,7 @@ namespace VisiLibity
 
       if(PRINTING_DEBUG_DATA){
 	std::cout << std::endl
-		  << "\x1b[35m" 
+		  << "\x1b[35m"
 		  << "Pop next vertex off q1" << "\x1b[0m"
 		  << " and set as current_vertex."
 		  << std::endl;
@@ -3196,7 +3192,7 @@ namespace VisiLibity
       //---Handle Event Point---
 
       //TYPE 1: current_vertex is the _second_vertex_ of active_edge.
-      if( current_vertex.incident_edge == active_edge 
+      if( current_vertex.incident_edge == active_edge
 	  && !current_vertex.is_first ){
 
 	if(PRINTING_DEBUG_DATA){
@@ -3206,7 +3202,7 @@ namespace VisiLibity
 		    << std::endl;
 	}
 
-	if( !q1.empty() ){ 
+	if( !q1.empty() ){
 	  //If the next vertex in q1 is contiguous.
 	  if( distance( current_vertex, q1.front() ) <= epsilon ){
 
@@ -3223,11 +3219,11 @@ namespace VisiLibity
 
 	if(PRINTING_DEBUG_DATA){
 	  std::cout << std::endl
-		    << "\E[32m" << "Add current_vertex to visibility polygon." 
+		    << "\E[32m" << "Add current_vertex to visibility polygon."
 		    << "\x1b[0m" << std::endl;
 	}
 
-	//Push current_vertex onto visibility polygon 
+	//Push current_vertex onto visibility polygon
 	vertices_.push_back( current_vertex );
 	chop_spikes_at_back(Observer, epsilon);
 
@@ -3238,12 +3234,12 @@ namespace VisiLibity
 	    std::cout << std::endl
 		      << "Examine edge at top of q2." << std::endl
 		      << "1st point of e [x  y  bearing  range] = ["
-		      << (e->first).x() << "  " 
+		      << (e->first).x() << "  "
 		      << (e->first).y() << "  "
 		      << (e->first).bearing() << "  "
 		      << (e->first).range() << "]" << std::endl
-		      << "2nd point of e [x  y  bearing  range] = [" 
-		      << (e->second).x() << "  " 
+		      << "2nd point of e [x  y  bearing  range] = ["
+		      << (e->second).x() << "  "
 		      << (e->second).y() << "  "
 		      << (e->second).bearing() << "  "
 		      << (e->second).range() << "]" << std::endl;
@@ -3252,16 +3248,16 @@ namespace VisiLibity
 	  //If the current_vertex bearing has not passed, in the
 	  //lex. order sense, the bearing of the second point of the
 	  //edge at the front of q2.
-	  if(  ( current_vertex.bearing().get() 
+	  if(  ( current_vertex.bearing().get()
 		 <= e->second.bearing().get() )
 	       //For robustness.
 	       && distance( Ray(Observer, current_vertex.bearing()),
 			     e->second ) >= epsilon
 	       /* was
 	       and std::min( distance(Ray(Observer, current_vertex.bearing()),
-				      e->second), 
+				      e->second),
 			     distance(Ray(Observer, e->second.bearing()),
-				      current_vertex) 
+				      current_vertex)
 			     ) >= epsilon
 	       */
 	       ){
@@ -3271,9 +3267,9 @@ namespace VisiLibity
 				 Line_Segment(e->first,
 					      e->second),
 				 epsilon );
-	    	    
+
 	    //assert( xing.size() > 0 );
-	    
+
 	    if( xing.size() > 0 ){
 	      k = Polar_Point( Observer , xing.first() );
 	    }
@@ -3284,11 +3280,11 @@ namespace VisiLibity
 
 	    if(PRINTING_DEBUG_DATA){
 	      std::cout << std::endl
-			<< "\E[32m" 
-			<< "Add a type 1 k-point to visibility polygon." 
+			<< "\E[32m"
+			<< "Add a type 1 k-point to visibility polygon."
 			<< "\x1b[0m" << std::endl
 			<< std::endl
-			<< "Set active_edge to edge at top of q2." 
+			<< "Set active_edge to edge at top of q2."
 			<< std::endl;
 	    }
 
@@ -3303,7 +3299,7 @@ namespace VisiLibity
 	    std::cout << std::endl
 		      << "Pop edge off top of q2." << std::endl;
 	  }
-	  
+
 	  q2.pop();
 	}
       } //Close Type 1.
@@ -3316,9 +3312,9 @@ namespace VisiLibity
 			     Line_Segment(active_edge->first,
 					  active_edge->second),
 			     epsilon );
-	if(  xing.size() == 0 
+	if(  xing.size() == 0
 	     || ( distance(active_edge->first, Observer) <= epsilon
-		  && active_edge->second.bearing() 
+		  && active_edge->second.bearing()
 		  <= current_vertex.bearing() )
 	     || active_edge->second < current_vertex  ){
 	  k_range = INFINITY;
@@ -3330,28 +3326,28 @@ namespace VisiLibity
 
 	//Incident edge of current_vertex.
 	e = current_vertex.incident_edge;
-	
+
 	if(PRINTING_DEBUG_DATA){
 	  std::cout << std::endl
-		    << "               k_range = " 
-		    << k_range 
+		    << "               k_range = "
+		    << k_range
 		    << " (range of active edge along "
 		    <<   "bearing of current vertex)" << std::endl
-		    << "current_vertex.range() = " 
+		    << "current_vertex.range() = "
 		    << current_vertex.range() << std::endl;
 	}
-	
+
 	//Insert e into q2 as long as it doesn't contain the
 	//Observer.
 	if( distance(Observer, e->first) > epsilon
 	    && distance(Observer, e->second) > epsilon ){
-	 
+
 	  if(PRINTING_DEBUG_DATA){
 	    std::cout << std::endl
 		      << "Push current_vertex's edge onto q2."
 		      << std::endl;
 	  }
-	  
+
 	  q2.push(e);
 	}
 
@@ -3370,7 +3366,7 @@ namespace VisiLibity
 		      << "(2) that edge should not become "
 		      << "the next active_edge."
 		      << std::endl;
-	 
+
 	  }
 
 	} //Close Type 2.
@@ -3379,9 +3375,9 @@ namespace VisiLibity
 	//other than active_edge, and (2) that edge should become the
 	//next active_edge.  This happens, e.g., if that edge is
 	//(rangewise) in front along the current bearing.
-	if(  k_range >= current_vertex.range() 
+	if(  k_range >= current_vertex.range()
 	     ){
-	  
+
 	  if(PRINTING_DEBUG_DATA){
 	    std::cout << std::endl
 		      << "\E[36m" << "TYPE 3:" << "\x1b[0m"
@@ -3398,14 +3394,14 @@ namespace VisiLibity
 	  if( xing.size() > 0
 	      //and k == k
 	      && k_range != INFINITY
-	      && distance(k, current_vertex) > epsilon 
+	      && distance(k, current_vertex) > epsilon
 	      && distance(active_edge->first, Observer) > epsilon
 	      ){
-	   
+
 	    if(PRINTING_DEBUG_DATA){
 	      std::cout << std::endl
-			<< "\E[32m" 
-			<< "Add type 3 k-point to visibility polygon." 
+			<< "\E[32m"
+			<< "Add type 3 k-point to visibility polygon."
 			<< "\x1b[0m" << std::endl;
 	    }
 
@@ -3422,16 +3418,16 @@ namespace VisiLibity
 
 	  if(PRINTING_DEBUG_DATA){
 	    std::cout << std::endl
-		      << "\E[32m" << "Add current_vertex to visibility polygon." 
+		      << "\E[32m" << "Add current_vertex to visibility polygon."
 		      << "\x1b[0m" << std::endl
 		      << std::endl
-		      << "Set active_edge to edge of current_vertex." 
+		      << "Set active_edge to edge of current_vertex."
 		      << std::endl;
 	  }
 
 	} //Close Type 3.
       }
-      
+
       if(PRINTING_DEBUG_DATA){
 	std::cout << std::endl
 		  << "visibility polygon vertices so far are \n"
@@ -3441,18 +3437,18 @@ namespace VisiLibity
     }                            //
                                  //
     //-------END MAIN LOOP-------//
-  
+
     //The Visibility_Polygon should have a minimal representation
     chop_spikes_at_wrap_around( Observer , epsilon );
     eliminate_redundant_vertices( epsilon );
     chop_spikes( Observer, epsilon );
     enforce_standard_form();
-    
+
     if(PRINTING_DEBUG_DATA){
       std::cout << std::endl
 		<< "Final visibility polygon vertices are \n"
 		<< Polygon(vertices_) << std::endl
-		<< std::endl;      
+		<< std::endl;
     }
 
   }
@@ -3481,7 +3477,7 @@ namespace VisiLibity
     //copy each entry
     for(unsigned i=0; i<n_; i++){
     for(unsigned j=0; j<n_; j++){
-      adjacency_matrix_[i][j] 
+      adjacency_matrix_[i][j]
 	= vg2.adjacency_matrix_[i][j];
     }}
   }
@@ -3502,7 +3498,7 @@ namespace VisiLibity
     adjacency_matrix_[0] = new bool[n_*n_];
     for(unsigned i=1; i<n_; i++)
       adjacency_matrix_[i] = adjacency_matrix_[i-1] + n_;
-    
+
     // fill adjacency matrix by checking for inclusion in the
     // visibility polygons
     Polygon polygon_temp;
@@ -3515,8 +3511,8 @@ namespace VisiLibity
 	  adjacency_matrix_[ k1 ][ k1 ] = true;
 	else
 	  adjacency_matrix_[ k1 ][ k2 ] =
-	    adjacency_matrix_[ k2 ][ k1 ] =    
-	    environment(k2).in( polygon_temp , epsilon ); 
+	    adjacency_matrix_[ k2 ][ k1 ] =
+	    environment(k2).in( polygon_temp , epsilon );
       }
     }
   }
@@ -3536,7 +3532,7 @@ namespace VisiLibity
     adjacency_matrix_[0] = new bool[n_*n_];
     for(unsigned i=1; i<n_; i++)
       adjacency_matrix_[i] = adjacency_matrix_[i-1] + n_;
-    
+
     // fill adjacency matrix by checking for inclusion in the
     // visibility polygons
     Polygon polygon_temp;
@@ -3549,32 +3545,32 @@ namespace VisiLibity
 	  adjacency_matrix_[ k1 ][ k1 ] = true;
 	else
 	  adjacency_matrix_[ k1 ][ k2 ] =
-	    adjacency_matrix_[ k2 ][ k1 ] =    
-	    points[k2].in( polygon_temp , epsilon ); 
+	    adjacency_matrix_[ k2 ][ k1 ] =
+	    points[k2].in( polygon_temp , epsilon );
       }
     }
   }
 
-  
+
   Visibility_Graph::Visibility_Graph(const Guards& guards,
-				     const Environment& environment, 
+				     const Environment& environment,
 				     double epsilon)
   {
     *this = Visibility_Graph( guards.positions_,
-			      environment, 
+			      environment,
 			      epsilon );
   }
-  
-  
+
+
   bool Visibility_Graph::operator () (unsigned i1,
 				      unsigned j1,
 				      unsigned i2,
-				      unsigned j2) const 
+				      unsigned j2) const
   {
     return adjacency_matrix_[ two_to_one(i1,j1) ][ two_to_one(i2,j2) ];
   }
   bool Visibility_Graph::operator () (unsigned k1,
-				      unsigned k2) const 
+				      unsigned k2) const
   {
     return adjacency_matrix_[ k1 ][ k2 ];
   }
@@ -3592,19 +3588,19 @@ namespace VisiLibity
   }
 
 
-  Visibility_Graph& Visibility_Graph::operator = 
+  Visibility_Graph& Visibility_Graph::operator =
   (const Visibility_Graph& visibility_graph_temp)
   {
     if( this == &visibility_graph_temp )
       return *this;
-    
+
     n_ = visibility_graph_temp.n_;
     vertex_counts_ = visibility_graph_temp.vertex_counts_;
 
     //resize adjacency_matrix_
     if( adjacency_matrix_ != NULL ){
       delete [] adjacency_matrix_[0];
-      delete [] adjacency_matrix_; 
+      delete [] adjacency_matrix_;
     }
     adjacency_matrix_ = new bool*[n_];
     adjacency_matrix_[0] = new bool[n_*n_];
@@ -3614,14 +3610,14 @@ namespace VisiLibity
     //copy each entry
     for(unsigned i=0; i<n_; i++){
     for(unsigned j=0; j<n_; j++){
-      adjacency_matrix_[i][j] 
+      adjacency_matrix_[i][j]
 	= visibility_graph_temp.adjacency_matrix_[i][j];
     }}
-    
+
     return *this;
   }
-  
-  
+
+
   unsigned Visibility_Graph::two_to_one(unsigned i,
 					unsigned j) const
   {
@@ -3635,11 +3631,11 @@ namespace VisiLibity
   }
 
 
-  Visibility_Graph::~Visibility_Graph()    
-  { 
+  Visibility_Graph::~Visibility_Graph()
+  {
     if( adjacency_matrix_ != NULL ){
       delete [] adjacency_matrix_[0];
-      delete [] adjacency_matrix_; 
+      delete [] adjacency_matrix_;
     }
   }
 

--- a/visiLibity/source_code/visilibity.hpp
+++ b/visiLibity/source_code/visilibity.hpp
@@ -72,8 +72,6 @@ License along with VisiLibity.  If not, see <http://www.gnu.org/licenses/>.
 #include <string>     //string class
 #include <cassert>    //assertions
 
-#define UNUSED(x) [&x]{}()  // c++11 silence warnings
-
 /// VisiLibity's sole namespace
 namespace VisiLibity
 {
@@ -1513,11 +1511,9 @@ namespace VisiLibity
      * \todo  finish this
      */
     std::vector<Polygon> compute_partition_cells( std::vector<Line_Segment>
-                                                  partition_inducing_segments,
-                                                  double epsilon=0.0 )
+                                                  /*partition_inducing_segments*/,
+                                                  double /*epsilon*/ )
     {
-      UNUSED(partition_inducing_segments);
-      UNUSED(epsilon);
       std::vector<Polygon> cells;
       return cells;
     }


### PR DESCRIPTION
When building on gcc9 and clang 8 there where a ton of warnings. I have fix all trivially fixable ones on this PR. (Note this does not build on clang8 w.o. my other PR)
---
Edit: Also I did not yet clear tests from warnings!
---

There are 3 warnings left that cannot be addressed w.o. having a deeper look into it:
1. WaitingArea.cpp:
```
[19/97] Building CXX object CMakeFiles/core.dir/geometry/WaitingArea.cpp.o
/mnt/fast/projects/jpscore/geometry/WaitingArea.cpp:147:27: warning: comparison of integers of different signs: 'std::set<int, std::less<int>, std::allocator<int> >::size_type' (aka 'unsigned long') and 'int' [-Wsign-compare]
     if (pedInside.size() >= maxNumPed){
         ~~~~~~~~~~~~~~~~ ^  ~~~~~~~~~
/mnt/fast/projects/jpscore/geometry/WaitingArea.cpp:155:27: warning: comparison of integers of different signs: 'std::set<int, std::less<int>, std::allocator<int> >::size_type' (aka 'unsigned long') and 'int' [-Wsign-compare]
     if (pedInside.size() < maxNumPed){
         ~~~~~~~~~~~~~~~~ ^ ~~~~~~~~~
/mnt/fast/projects/jpscore/geometry/WaitingArea.cpp:158:27: warning: comparison of integers of different signs: 'std::set<int, std::less<int>, std::allocator<int> >::size_type' (aka 'unsigned long') and 'int' [-Wsign-compare]
     if (pedInside.size() < minNumPed){
         ~~~~~~~~~~~~~~~~ ^ ~~~~~~~~~
/mnt/fast/projects/jpscore/geometry/WaitingArea.cpp:176:28: warning: comparison of integers of different signs: 'std::set<int, std::less<int>, std::allocator<int> >::size_type' (aka 'unsigned long') and 'int' [-Wsign-compare]
     if ((pedInside.size() >= minNumPed) && (startTime < 0. )){
```
The problem here is that the initial state of `minNumPed` and `maxNumPed` is -1 and during a signed unsigned comp. this will be cast into a signed int i.e. on a freshly constructed object of WaitingArea all those checks will behave unexpected!

2. EventManager.cpp 
```
/mnt/fast/projects/jpscore/events/EventManager.cpp:528:24: warning: enumeration value 'Error' not handled in switch [-Wswitch]
               switch (event.GetState()){
                       ^
1 warning generated.
```
Here the `Error` state is no handled, I did not try to fix this because I might unknowingly change the logic. this is better left to someone who knows the code.

3. tinyxmlparser.cpp
```
/mnt/fast/projects/jpscore/tinyxml/tinyxmlparser.cpp:113:10: warning: this statement may fall through [-Wimplicit-fallthrough=]
  113 |    input >>= 6;
      |    ~~~~~~^~~~~
/mnt/fast/projects/jpscore/tinyxml/tinyxmlparser.cpp:114:3: note: here
  114 |   case 3:
      |   ^~~~
/mnt/fast/projects/jpscore/tinyxml/tinyxmlparser.cpp:117:10: warning: this statement may fall through [-Wimplicit-fallthrough=]
  117 |    input >>= 6;
      |    ~~~~~~^~~~~
/mnt/fast/projects/jpscore/tinyxml/tinyxmlparser.cpp:118:3: note: here
  118 |   case 2:
      |   ^~~~
/mnt/fast/projects/jpscore/tinyxml/tinyxmlparser.cpp:121:10: warning: this statement may fall through [-Wimplicit-fallthrough=]
  121 |    input >>= 6;
      |    ~~~~~~^~~~~
/mnt/fast/projects/jpscore/tinyxml/tinyxmlparser.cpp:122:3: note: here
  122 |   case 1:
      |   ^~~~
```
yeah the comment above the code says it all :) `scary scary fall trough`, I probably would try to replace this with libicu to convert between UTF8 and UTF32 instead of doing that myself.

Let me know if this is helpful.

Cheers