### PR TITLE
Fix compile error on clang

### DIFF
--- a/tinyxml/tinyxmlparser.cpp
+++ b/tinyxml/tinyxmlparser.cpp
@@ -125,7 +125,6 @@ void TiXmlBase::ConvertUTF32ToUTF8( unsigned long input, char* output, int* leng
 		case 1:
 			--output;
 			*output = (char)(input | FIRST_BYTE_MARK[*length]);
-			[[fallthrough]];
 	}
 }
 


### PR DESCRIPTION
Last falltrough statement was misplaced and caused a compile error on
clang. [[falltrough]] has to precede the case to continue to.