### PR TITLE
Fix memory/file handle leak

### DIFF
--- a/IO/IODispatcher.h
+++ b/IO/IODispatcher.h
@@ -63,10 +63,8 @@ class Trajectories
 {
 public:
      Trajectories()
-     {
-          _outputHandler = nullptr;
-     };
-     virtual ~Trajectories(){delete _outputHandler;};
+     : _outputHandler(nullptr) {}
+     virtual ~Trajectories() = default;
      virtual void WriteHeader(long nPeds, double fps, Building* building, int seed, int count)=0;
      virtual void WriteGeometry(Building* building)=0;
      virtual void WriteFrame(int frameNr, Building* building)=0;
@@ -77,7 +75,7 @@ public:
      {
           _outputHandler->Write(str);
      }
-     void SetOutputHandler(OutputHandler* outputHandler)
+     void SetOutputHandler(std::shared_ptr<OutputHandler> outputHandler)
      {
           _outputHandler=outputHandler;
      }
@@ -98,7 +96,7 @@ public:
          }
 
 protected:
-     OutputHandler* _outputHandler;
+     std::shared_ptr<OutputHandler> _outputHandler;
 };
 
 

--- a/Simulation.h
+++ b/Simulation.h
@@ -193,7 +193,7 @@ public:
      void  incrementCountTraj();
 
      bool correctGeometry(std::shared_ptr<Building> building,  std::shared_ptr<TrainTimeTable>);
-     bool WriteTrajectories(std::string trajName);
+     void WriteTrajectories(std::string trajName);
      bool TrainTraffic();
 
      int _countTraj=0; // count number of TXT trajectories to produce


### PR DESCRIPTION
Now uses shared_ptr as an interims solution to fix the imediate issue.

This is the second part necessary to fix Issue #309 There are still a few file handles leaking but only a constant amount hence there should be no adverse effect anymore from increasing the number of pedestrians.