### PR TITLE
Fix build error when enableing JPSFIRE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,28 +7,27 @@
 # -DUSE_DUAL_ABI=ON (default OFF)  https://gcc.gnu.org/onlinedocs/libstdc++/manual/using_dual_abi.html
 # -D Boost_NO_SYSTEM_PATHS=true (default false) -D BOOST_ROOT=PATH_where_to_find_boost
 # -D AIROUTER=true (default false)
-# -D JPSFIRE=true (default false)
+# -D JPSFIRE=ON (default OFF)
 #--------------------------------------------------------------------------
-
+################################################################################
+# Project setup
+################################################################################
 cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
 project(JPScore LANGUAGES CXX)
-
-# Project setup
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
+
+################################################################################
+# Optional features
+################################################################################
+set(JPSFIRE OFF CACHE BOOL "Build with jps fire support")
 
 # Options for  jpscore
 if(NOT AIROUTER)
     set(AIROUTER false)
 else()
     set(AIROUTER true)
-endif()
-
-if(NOT JPSFIRE)
-    set(JPSFIRE false)
-else()
-    set(JPSFIRE true)
 endif()
 
 message(STATUS "BUILD_TESTING01: " ${BUILD_TESTING})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 # Optional features
 ################################################################################
 set(JPSFIRE OFF CACHE BOOL "Build with jps fire support")
+message(STATUS "JPSFIRE=${JPSFIRE}")
 
 # Options for  jpscore
 if(NOT AIROUTER)
@@ -631,11 +632,9 @@ endif()
 if(JPSFIRE)
     SET(source_files ${source_files} ${JPSFIRE_SRC})
     SET(header_files ${header_files} ${JPSFIRE_HDR})
-    message(STATUS "USE JPSFIRE")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DJPSFIRE")
 endif()
 
-message(STATUS "JPSFIRE: ${JPSFIRE}")
 # ----- add here 3th party
 if(JPSFIRE)
     find_package(ZLIB REQUIRED)

--- a/JPSfire/generic/FDSMeshStorage.cpp
+++ b/JPSfire/generic/FDSMeshStorage.cpp
@@ -27,9 +27,6 @@
  *
  **/
 #include "FDSMeshStorage.h"
-//#include <unistd.h>
-//#include <glob.h>
-// #include <filesystem>
 #include <filesystem>
 namespace fs = std::filesystem;
 
@@ -256,7 +253,7 @@ const FDSMesh &FDSMeshStorage::GetFDSMesh(const double &simTime, const double &p
     if (_fMContainer.count(Ztime.string()) == 0) {
         //std::cout << str << std::endl;
         std::cout << "\n time ERROR: requested grid not available: " << Ztime.string() << std::endl;
-        return(EXIT_FAILURE);
+        std::exit(EXIT_FAILURE);
     }
     return _fMContainer.at(Ztime.string());
 
@@ -294,7 +291,7 @@ const FDSMesh &FDSMeshStorage::GetFDSMesh(const double &pedElev, const Point &do
         door_xy = fs::canonical(door_xy).make_preferred();
     if (_fMContainer.count(door_xy.string()) == 0) {
         std::cout << "\n > ERROR: requested sfgrid not available: " << door_xy.string() << std::endl;
-        return(EXIT_FAILURE);
+        std::exit(EXIT_FAILURE);
     }
 
     // if (_fMContainer.count(str) == 1) {


### PR DESCRIPTION
Please have a look at this one: I replaced the faulty return statements with `std::exit(EXIT_FAILURE)` since it looked like this was the actual intention. I did NOT run any tests on this one. JPSFIRE seems to be in a bad state. I just wanted to check for compile issues (which i found) and additional warnings (which there are none, except cnpy)