### PR TITLE
Fix memleaks

### DIFF
--- a/IO/progress_bar.cpp
+++ b/IO/progress_bar.cpp
@@ -1,22 +1,24 @@
 #include "progress_bar.hpp"
 #include "string"
-ProgressBar::ProgressBar() {}
-
 ProgressBar::ProgressBar(unsigned long n_, std::string description_, std::ostream& out_){
-    
+
       n = n_;
       frequency_update = n_;
       description = description_;
       out = &out_;
-	
+
       unit_bar = "=";
       unit_space = " ";
       desc_width = description.length();	// character width of description field
-
+#ifdef _WINDOWS
+      SetStyle("|","-");
+#else
+      SetStyle("\u2588", "-"); //for linux
+#endif
 }
 
 void ProgressBar::SetFrequencyUpdate(unsigned long frequency_update_){
-	
+
       if(frequency_update_ > n){
             frequency_update = n;	 // prevents crash if freq_updates_ > n_
       }
@@ -26,7 +28,7 @@ void ProgressBar::SetFrequencyUpdate(unsigned long frequency_update_){
 }
 
 void ProgressBar::SetStyle(const char* unit_bar_, const char* unit_space_){
-	
+
       unit_bar = unit_bar_;
       unit_space = unit_space_;
 }
@@ -75,11 +77,11 @@ void ProgressBar::Progressed(unsigned long idx_)
 
             // calculate the size of the progress bar
 	    int bar_size = GetBarLength();
-    
+
             // calculate percentage of progress
             double progress_percent = idx_* TOTAL_PERCENTAGE/n;
 
-            // calculate the percentage value of a unit bar 
+            // calculate the percentage value of a unit bar
             double percent_per_unit_bar = TOTAL_PERCENTAGE/bar_size;
 
             // display progress bar

--- a/IO/progress_bar.hpp
+++ b/IO/progress_bar.hpp
@@ -39,27 +39,22 @@
 
 class ProgressBar{
 
-public: 
-
-    ProgressBar();
-      ProgressBar(unsigned long n_, std::string description_="", std::ostream& out_=std::cerr);
-
+public:
+    ProgressBar(unsigned long n_, std::string description_="", std::ostream& out_=std::cerr);
     void SetFrequencyUpdate(unsigned long frequency_update_);
-    void SetStyle(const char* unit_bar_, const char* unit_space_);		
-
+    void SetStyle(const char* unit_bar_, const char* unit_space_);
     void Progressed(unsigned long idx_);
 
 private:
-	
+
     unsigned long n;
     unsigned int desc_width;
     unsigned long frequency_update;
     std::ostream* out;
-		
-      std::string description;
+    std::string description;
     const char *unit_bar;
     const char *unit_space;
-		
+
     void ClearBarField();
     int GetConsoleWidth();
     int GetBarLength();

--- a/Simulation.cpp
+++ b/Simulation.cpp
@@ -563,13 +563,7 @@ double Simulation::RunBody(double maxSimTime)
     _nPeds = _building->GetAllPedestrians().size();
     std::cout << "\n";
     std::string description = "Evacutation ";
-    ProgressBar *bar = new ProgressBar(_nPeds, description);
-    // bar->SetFrequencyUpdate(10);
-#ifdef _WINDOWS
-    bar->SetStyle("|","-");
-#else
-    bar->SetStyle("\u2588", "-"); //for linux
-#endif
+    ProgressBar bar(_nPeds, description);
     int initialnPeds = _nPeds;
     // main program loop
     while ((_nPeds || (!_agentSrcManager.IsCompleted()&& _gotSources) ) && t<maxSimTime) {
@@ -646,7 +640,7 @@ double Simulation::RunBody(double maxSimTime)
 
         if(!_gotSources && !_periodic && _config->print_prog_bar())
               // Log->ProgressBar(initialnPeds, initialnPeds-_nPeds, t);
-              bar->Progressed(initialnPeds-_nPeds);
+              bar.Progressed(initialnPeds-_nPeds);
         else
              if ((!_gotSources) &&
                  ((frameNr < 100 &&  frameNr % 10 == 0) ||

--- a/pedestrian/Pedestrian.cpp
+++ b/pedestrian/Pedestrian.cpp
@@ -209,6 +209,7 @@ Pedestrian::~Pedestrian()
      if ((_id>72) && (_id<81)){
           std::cout << "Ped destructor" << std::endl;
      }
+     delete _navLine;
 }
 
 


### PR DESCRIPTION
Fixes two memory leaks that showed up on address sanitizer builds

Sanitizer output:
```
Direct leak of 2160 byte(s) in 30 object(s) allocated from:
    #0 0xfe8112 in operator new(unsigned long) (/mnt/fast/jpsc-build/clang-debug/bin/jpscore_asan+0xfe8112)
    #1 0x10f6225 in Pedestrian::SetExitLine(NavLine const*) /mnt/fast/projects/jpscore/pedestrian/Pedestrian.cpp:283:22
    #2 0x135e0f9 in GlobalRouter::GetBestDefaultRandomExit(Pedestrian*) /mnt/fast/projects/jpscore/routing/global_shortest/GlobalRouter.cpp:837:16
    #3 0x135cb70 in GlobalRouter::FindExit(Pedestrian*) /mnt/fast/projects/jpscore/routing/global_shortest/GlobalRouter.cpp:767:18
    #4 0x10feb52 in Pedestrian::Relocate(std::function<void (Pedestrian const&)>) /mnt/fast/projects/jpscore/pedestrian/Pedestrian.cpp:1240:25
    #5 0x13bedd0 in .omp_outlined._debug__ /mnt/fast/projects/jpscore/Simulation.cpp:389:32
    #6 0x13bfc6c in .omp_outlined. /mnt/fast/projects/jpscore/Simulation.cpp:364:6
    #7 0x7f1cd2190dd2 in __kmp_invoke_microtask (/usr/lib/x86_64-linux-gnu/libomp.so.5+0xa8dd2)
    #8 0x7f1cd212aa32  (/usr/lib/x86_64-linux-gnu/libomp.so.5+0x42a32)

Direct leak of 80 byte(s) in 1 object(s) allocated from:
    #0 0xfe8112 in operator new(unsigned long) (/mnt/fast/jpsc-build/clang-debug/bin/jpscore_asan+0xfe8112)
    #1 0x13ba91b in Simulation::RunBody(double) /mnt/fast/projects/jpscore/Simulation.cpp:566:24
    #2 0x13b9b4c in Simulation::RunStandardSimulation(double) /mnt/fast/projects/jpscore/Simulation.cpp:340:16
    #3 0xfeb8f8 in main /mnt/fast/projects/jpscore/main.cpp:101:28
    #4 0x7f1cd1a7fb6a in __libc_start_main /build/glibc-KRRWSm/glibc-2.29/csu/../csu/libc-start.c:308:16
``` 