### PR TITLE
Add sanitizer support for Linux/macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,12 @@ print_var(AIROUTER)
 set(USE_OPENMP ON CACHE BOOL "Build with OpenMP")
 print_var(USE_OPENMP)
 
+set(BUILD_WITH_ASAN OFF CACHE BOOL
+  "Build with address sanitizer support. Linux / macOS only.")
+print_var(BUILD_WITH_ASAN)
+if(BUILD_WITH_ASAN AND ${CMAKE_SYSTEM} MATCHES "Windows")
+    message(FATAL_ERROR "Address sanitizer builds are not supported on Windows")
+endif()
 ################################################################################
 # Compilation flags
 ################################################################################
@@ -523,6 +529,60 @@ if(WIN32)
   endif()
 endif()
 
+################################################################################
+# Build jspcore_asan executable - jpscore with address sanitizer
+################################################################################
+if(BUILD_WITH_ASAN)
+    get_target_property(core_source core SOURCES)
+    get_target_property(core_compile_options core COMPILE_OPTIONS)
+    get_target_property(core_compile_definitions core COMPILE_DEFINITIONS)
+    get_target_property(core_link_libraries core LINK_LIBRARIES)
+    get_target_property(core_include_directories core INCLUDE_DIRECTORIES)
+
+    add_library(core_asan STATIC
+        ${core_source}
+    )
+
+    target_compile_options(core_asan PRIVATE
+        ${core_compile_options}
+        -fno-omit-frame-pointer
+        -fno-optimize-sibling-calls
+        -fsanitize=address
+    )
+
+    target_compile_definitions(core_asan PRIVATE
+        ${core_compile_definitions}
+    )
+
+    target_link_libraries(core_asan
+        ${core_link_libraries}
+    )
+
+  target_include_directories(core_asan PUBLIC
+        ${core_include_directories}
+    )
+
+    get_target_property(jpscore_source jpscore SOURCES)
+    get_target_property(jpscore_compile_options jpscore COMPILE_OPTIONS)
+    get_target_property(jpscore_link_libraries jpscore LINK_LIBRARIES)
+    list(REMOVE_ITEM jpscore_link_libraries core)
+    list(APPEND jpscore_link_libraries core_asan)
+    add_executable(jpscore_asan
+        ${jpscore_source}
+    )
+
+    target_compile_options(jpscore_asan PRIVATE
+        ${jpscore_compile_options}
+        -fno-omit-frame-pointer
+        -fno-optimize-sibling-calls
+        -fsanitize=address
+    )
+
+    target_link_libraries(jpscore_asan
+        ${jpscore_link_libraries}
+        -fsanitize=address
+    )
+endif()
 ################################################################################
 # Testing
 ################################################################################

--- a/README.md
+++ b/README.md
@@ -71,6 +71,11 @@ Build unit tests and add them to ctest
 ##### BUILD_TESTING defaults to OFF
 Build full system tests and add them to ctest
 
+##### BUILD_WITH_ASAN defaults to OFF (Does not support Windows)
+Build an additional target `jpscore_asan` with address and undefined behavior
+sanitizer enabled. Note there is an approx. 2x slowdown when using 
+`jpscore_asan` over `jpscore`
+
 ## Quick start
 
 See [installation and configuration](http://jupedsim.org/jpscore/2016-11-02-quickstart.html)


### PR DESCRIPTION
If -DBUILD_WITH_ASAN=ON is passed to cmake an additional executable
jpscore_asan will be build that uses the address and undefined behavior
sanitizer to check for leaks and other issues. No windows support.

Can be build in release but debug is strongly recommended.

Usage:
Build jpscore_asan, the executable works just like jpscore but
experiences a slowdown of approx. 2x. When running additional output
will be generated nforming about found undefined behavior or memory
leaks. Usage compared to jpscore is unchanged.

This will produce output like this:
```
==8089==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 464 byte(s) in 2 object(s) allocated from:
    #0 0x7ff78607517f in operator new(unsigned long) (/usr/lib/x86_64-linux-gnu/libasan.so.5+0x10e17f)
    #1 0x558082d4e88b in Goal::Goal() /mnt/fast/projects/jpscore/geometry/Goal.cpp:44
    #2 0x558082e3c508 in GeoFileParser::parseGoalNode(TiXmlElement*) /mnt/fast/projects/jpscore/IO/GeoFileParser.cpp:687
    #3 0x558082e2d5b5 in GeoFileParser::LoadRoutingInfo(Building*) /mnt/fast/projects/jpscore/IO/GeoFileParser.cpp:374
    #4 0x558082e1a7f4 in GeoFileParser::LoadBuilding(Building*) /mnt/fast/projects/jpscore/IO/GeoFileParser.cpp:42
    #5 0x558082caf329 in Building::Building(Configuration*, PedDistributor&) /mnt/fast/projects/jpscore/geometry/Building.cpp:85
    #6 0x558081bbd5fe in Simulation::InitArgs() /mnt/fast/projects/jpscore/Simulation.cpp:239
    #7 0x55808155cefb in main /mnt/fast/projects/jpscore/main.cpp:75
    #8 0x7ff784f58b6a in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x26b6a)
```