### PR TITLE
Fix sigill on clang

### DIFF
--- a/geometry/Crossing.cpp
+++ b/geometry/Crossing.cpp
@@ -337,6 +337,7 @@ bool Crossing::RegulateFlow(double time)
      }
 
      _lastFlowMeasurement = time +  _closingTime;
+     return change;
 }
 
 void Crossing::UpdateTemporaryState(double dt)


### PR DESCRIPTION
Method declared as return bool did not return anything leading to a
sigill core when build with clang