### PR TITLE
Make all paths typesafe by using fs::path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -262,6 +262,7 @@ set(source_files
     events/EventManager.cpp
     forms/jpscore.rc
     general/ArgumentParser.cpp
+    general/Filesystem.cpp
     geometry/Building.cpp
     geometry/Crossing.cpp
     geometry/Goal.cpp

--- a/IO/GeoFileParser.cpp
+++ b/IO/GeoFileParser.cpp
@@ -59,12 +59,12 @@ void GeoFileParser::LoadBuilding(Building* building)
 bool GeoFileParser::LoadGeometry(Building* building)
 {
 
-     fs::path rootDir(_configuration->GetProjectRootDir());
+     const fs::path& rootDir(_configuration->GetProjectRootDir());
 
-     std::string geoFilenameWithPath = (rootDir/fs::path(_configuration->GetGeometryFile())).string();
+     const fs::path geoFilenameWithPath =  rootDir / _configuration->GetGeometryFile();
      std::cout << "\nLoadGeometry: file: " << geoFilenameWithPath << "\n";
 
-     TiXmlDocument docGeo(geoFilenameWithPath);
+     TiXmlDocument docGeo(geoFilenameWithPath.c_str());
      if (!docGeo.LoadFile()) {
           Log->Write("ERROR: \t%s", docGeo.ErrorDesc());
           Log->Write("\t could not parse the geometry file");
@@ -349,7 +349,7 @@ bool GeoFileParser::LoadRoutingInfo(Building* building)
 {
      //TODO read schedule
 
-     TiXmlDocument docRouting(_configuration->GetProjectFile());
+     TiXmlDocument docRouting(_configuration->GetProjectFile().c_str());
      if (!docRouting.LoadFile()) {
           Log->Write("ERROR: \t%s", docRouting.ErrorDesc());
           Log->Write("ERROR: \t could not parse the routing file");
@@ -521,7 +521,7 @@ bool GeoFileParser::LoadTrafficInfo(Building* building)
 
      Log->Write("INFO:\tLoading the traffic info");
 
-     TiXmlDocument doc(_configuration->GetProjectFile());
+     TiXmlDocument doc(_configuration->GetProjectFile().c_str());
      if (!doc.LoadFile()) {
           Log->Write("ERROR: \t%s", doc.ErrorDesc());
           Log->Write("ERROR: \t could not parse the project file");
@@ -945,7 +945,7 @@ bool GeoFileParser::LoadTrainInfo(Building* building)
 {
      Log->Write("--------\nINFO:\tLoading the train info");
 
-     TiXmlDocument doc(_configuration->GetProjectFile());
+     TiXmlDocument doc(_configuration->GetProjectFile().c_str());
      if (!doc.LoadFile()) {
           Log->Write("ERROR: \t%s", doc.ErrorDesc());
           Log->Write("ERROR: \t could not parse the project file");

--- a/IO/GeoFileParser.cpp
+++ b/IO/GeoFileParser.cpp
@@ -64,7 +64,7 @@ bool GeoFileParser::LoadGeometry(Building* building)
      const fs::path geoFilenameWithPath =  rootDir / _configuration->GetGeometryFile();
      std::cout << "\nLoadGeometry: file: " << geoFilenameWithPath << "\n";
 
-     TiXmlDocument docGeo(geoFilenameWithPath.c_str());
+     TiXmlDocument docGeo(geoFilenameWithPath.string());
      if (!docGeo.LoadFile()) {
           Log->Write("ERROR: \t%s", docGeo.ErrorDesc());
           Log->Write("\t could not parse the geometry file");
@@ -349,7 +349,7 @@ bool GeoFileParser::LoadRoutingInfo(Building* building)
 {
      //TODO read schedule
 
-     TiXmlDocument docRouting(_configuration->GetProjectFile().c_str());
+     TiXmlDocument docRouting(_configuration->GetProjectFile().string());
      if (!docRouting.LoadFile()) {
           Log->Write("ERROR: \t%s", docRouting.ErrorDesc());
           Log->Write("ERROR: \t could not parse the routing file");
@@ -521,7 +521,7 @@ bool GeoFileParser::LoadTrafficInfo(Building* building)
 
      Log->Write("INFO:\tLoading the traffic info");
 
-     TiXmlDocument doc(_configuration->GetProjectFile().c_str());
+     TiXmlDocument doc(_configuration->GetProjectFile().string());
      if (!doc.LoadFile()) {
           Log->Write("ERROR: \t%s", doc.ErrorDesc());
           Log->Write("ERROR: \t could not parse the project file");
@@ -945,7 +945,7 @@ bool GeoFileParser::LoadTrainInfo(Building* building)
 {
      Log->Write("--------\nINFO:\tLoading the train info");
 
-     TiXmlDocument doc(_configuration->GetProjectFile().c_str());
+     TiXmlDocument doc(_configuration->GetProjectFile().string());
      if (!doc.LoadFile()) {
           Log->Write("ERROR: \t%s", doc.ErrorDesc());
           Log->Write("ERROR: \t could not parse the project file");

--- a/IO/IODispatcher.cpp
+++ b/IO/IODispatcher.cpp
@@ -331,11 +331,11 @@ TrajectoriesFLAT::TrajectoriesFLAT() : Trajectories()
 {
 }
 
-std::string getSourceFileName(const std::string & GetProjectFile)
+static fs::path getSourceFileName(const fs::path& projectFile)
 {
-     std::string ret="";
+     fs::path ret{};
 
-     TiXmlDocument doc(GetProjectFile);
+     TiXmlDocument doc(projectFile.c_str());
      if (!doc.LoadFile()) {
           Log->Write("ERROR: \t%s", doc.ErrorDesc());
           Log->Write("ERROR: \tGetSourceFileName could not parse the project file");
@@ -360,11 +360,11 @@ std::string getSourceFileName(const std::string & GetProjectFile)
     return ret;
 }
 
-std::string getEventFileName(const std::string & GetProjectFile)
+static fs::path getEventFileName(const fs::path& projectFile)
 {
-     std::string ret="";
+     fs::path ret{};
 
-     TiXmlDocument doc(GetProjectFile);
+     TiXmlDocument doc(projectFile.c_str());
      if (!doc.LoadFile()) {
           Log->Write("ERROR: \t%s", doc.ErrorDesc());
           Log->Write("ERROR: \tGetEventFileName could not parse the project file");
@@ -374,7 +374,7 @@ std::string getEventFileName(const std::string & GetProjectFile)
      std::string eventfile = "";
      if (xMainNode->FirstChild("events_file")) {
           ret = xMainNode->FirstChild("events_file")->FirstChild()->ValueStr();
-          Log->Write("INFO: \tevents <" + ret + ">");
+          Log->Write("INFO: \tevents <" + ret.string() + ">");
      } else {
           Log->Write("INFO: \tNo events found");
           return ret;
@@ -387,11 +387,11 @@ std::string getEventFileName(const std::string & GetProjectFile)
  // </train_constraints>
 
 
-std::string getTrainTimeTableFileName(const std::string & GetProjectFile)
+static fs::path getTrainTimeTableFileName(const fs::path& projectFile)
 {
-     std::string ret="";
+     fs::path ret{};
 
-     TiXmlDocument doc(GetProjectFile);
+     TiXmlDocument doc(projectFile.c_str());
      if (!doc.LoadFile()) {
           Log->Write("ERROR: \t%s", doc.ErrorDesc());
           Log->Write("ERROR: \tGetTrainTimeTable could not parse the project file");
@@ -404,7 +404,7 @@ std::string getTrainTimeTableFileName(const std::string & GetProjectFile)
 
           if(xFileNode)
                ret = xFileNode->FirstChild()->ValueStr();
-          Log->Write("INFO: \ttrain_time_table <" + ret + ">");
+          Log->Write("INFO: \ttrain_time_table <" + ret.string() + ">");
      } else {
           Log->Write("INFO: \tNo events no ttt file found");
           return ret;
@@ -412,12 +412,11 @@ std::string getTrainTimeTableFileName(const std::string & GetProjectFile)
      return ret;
 }
 
-
-std::string getTrainTypeFileName(const std::string & GetProjectFile)
+static fs::path getTrainTypeFileName(const fs::path& projectFile)
 {
-     std::string ret="";
+     fs::path ret{};
 
-     TiXmlDocument doc(GetProjectFile);
+     TiXmlDocument doc(projectFile.c_str());
      if (!doc.LoadFile()) {
           Log->Write("ERROR: \t%s", doc.ErrorDesc());
           Log->Write("ERROR: \tGetTrainType could not parse the project file");
@@ -429,18 +428,19 @@ std::string getTrainTypeFileName(const std::string & GetProjectFile)
           auto xFileNode = xMainNode->FirstChild("train_constraints")->FirstChild("train_types");
           if(xFileNode)
                ret = xFileNode->FirstChild()->ValueStr();
-          Log->Write("INFO: \ttrain_types <" + ret + ">");
+          Log->Write("INFO: \ttrain_types <" + ret.string() + ">");
      } else {
           Log->Write("INFO: \tNo events no train types file found");
           return ret;
      }
      return ret;
 }
-std::string getGoalFileName(const std::string & GetProjectFile)
-{
-     std::string ret="";
 
-     TiXmlDocument doc(GetProjectFile);
+static fs::path getGoalFileName(const fs::path& projectFile)
+{
+     fs::path ret{};
+
+     TiXmlDocument doc(projectFile.c_str());
      if (!doc.LoadFile()) {
           Log->Write("ERROR: \t%s", doc.ErrorDesc());
           Log->Write("ERROR: \tGetSourceFileName could not parse the project file");
@@ -461,15 +461,9 @@ std::string getGoalFileName(const std::string & GetProjectFile)
      return ret;
 }
 
-
 void TrajectoriesFLAT::WriteHeader(long nPeds, double fps, Building* building, int seed, int count)
 {
-     std::string sourceFileName = getSourceFileName(building->GetProjectFilename());
-     std::string goalFileName = getGoalFileName(building->GetProjectFilename());
-     std::string eventFileName = getEventFileName(building->GetProjectFilename());
-     std::string trainTimeTableFileName = getTrainTimeTableFileName(building->GetProjectFilename());
-     std::string trainTypeFileName = getTrainTypeFileName(building->GetProjectFilename());
-     fs::path projRoot(building->GetProjectRootDir());
+     const fs::path projRoot(building->GetProjectRootDir());
 
      (void) seed; (void) nPeds;
      char tmp[500] = "";
@@ -479,36 +473,46 @@ void TrajectoriesFLAT::WriteHeader(long nPeds, double fps, Building* building, i
      Write(tmp);
      sprintf(tmp, "#framerate: %0.2f",fps);
      Write(tmp);
-     std::string tmpGeo= (projRoot/fs::path(building->GetGeometryFilename())).string();
+     const fs::path tmpGeo = projRoot / building->GetGeometryFilename();
      sprintf(tmp,"#geometry: %s",  tmpGeo.c_str());
      Write(tmp);
-     if(sourceFileName != "")
+
+     if(const fs::path sourceFileName = getSourceFileName(building->GetProjectFilename());
+          !sourceFileName.empty())
      {
-          std::string tmpSource= (projRoot/fs::path(sourceFileName)).string();
+          const fs::path tmpSource = projRoot / sourceFileName;
           sprintf(tmp,"#sources: %s", tmpSource.c_str());
           Write(tmp);
      }
-     if(goalFileName != "")
+
+     if(const fs::path goalFileName = getGoalFileName(building->GetProjectFilename());
+          !goalFileName.empty())
      {
-          std::string tmpGoal= (projRoot/fs::path(goalFileName)).string();
+          const fs::path tmpGoal = projRoot / goalFileName;
           sprintf(tmp,"#goals: %s", tmpGoal.c_str());
           Write(tmp);
      }
-     if( eventFileName != "")
+
+     if(const fs::path eventFileName = getEventFileName(building->GetProjectFilename());
+          !eventFileName.empty())
      {
-          std::string tmpEvent= (projRoot/fs::path(eventFileName)).string();
+          const fs::path tmpEvent = projRoot / eventFileName;
           sprintf(tmp,"#events: %s", tmpEvent.c_str());
           Write(tmp);
      }
-     if( trainTimeTableFileName  != "")
+
+     if(const fs::path  trainTimeTableFileName = getTrainTimeTableFileName(building->GetProjectFilename());
+          !trainTimeTableFileName.empty())
      {
-          std::string tmpTTT= (projRoot/fs::path(trainTimeTableFileName)).string();
+          const fs::path tmpTTT = projRoot / trainTimeTableFileName;
           sprintf(tmp,"#trainTimeTable: %s", tmpTTT.c_str());
           Write(tmp);
      }
-     if( trainTypeFileName  != "")
+
+     if(const fs::path  trainTypeFileName = getTrainTypeFileName(building->GetProjectFilename());
+          !trainTypeFileName.empty())
      {
-          std::string tmpTT= (projRoot/fs::path(trainTypeFileName)).string();
+          const fs::path tmpTT = projRoot / trainTypeFileName;
           sprintf(tmp,"#trainType: %s", tmpTT.c_str());
           Write(tmp);
      }
@@ -697,20 +701,19 @@ void TrajectoriesJPSV06::WriteGeometry(Building* building)
      //     Write(embed_geometry);
 
      //set the content of the file
-     std::string fileName=building->GetProjectRootDir()+"/"+building->GetGeometryFilename().c_str();
-     std::string embed_geometry;
-     std::string tmp; //lines to drop
-     std::ifstream t(fileName.c_str());
-     std::getline(t,tmp); //drop the first line <?xml version="1.0" encoding="UTF-8"?>
+     const fs::path fileName =
+          building->GetProjectRootDir() / building->GetGeometryFilename();
+     std::ifstream t(fileName.string());
+     std::string dropedLine;
+     std::getline(t, dropedLine); //drop the first line <?xml version="1.0" encoding="UTF-8"?>
      std::stringstream buffer;
      buffer << t.rdbuf();
-     embed_geometry=buffer.str();
+     std::string embed_geometry = buffer.str();
 
      //write the hlines
      std::string embed_hlines;
      embed_hlines.append("\n\t<hlines>");
-     for (const auto& hline: building->GetAllHlines())
-     {
+     for (const auto& hline: building->GetAllHlines()) {
           embed_hlines.append(hline.second->GetDescription());
      }
      embed_hlines.append("\n\t</hlines>");
@@ -725,16 +728,6 @@ void TrajectoriesJPSV06::WriteGeometry(Building* building)
      ReplaceStringInPlace(embed_geometry,"</geometry>",embed_hlines);
 
      Write(embed_geometry);
-
-     //     Write("\t<AttributeDescription>");
-     //     Write("\t\t<property tag=\"x\" description=\"xPosition\"/>");
-     //     Write("\t\t<property tag=\"y\" description=\"yPosition\"/>");
-     //     Write("\t\t<property tag=\"z\" description=\"zPosition\"/>");
-     //     Write("\t\t<property tag=\"rA\" description=\"radiusA\"/>");
-     //     Write("\t\t<property tag=\"rB\" description=\"radiusB\"/>");
-     //     Write("\t\t<property tag=\"eC\" description=\"ellipseColor\"/>");
-     //     Write("\t\t<property tag=\"eO\" description=\"ellipseOrientation\"/>");
-     //     Write("\t</AttributeDescription>\n");
 }
 
 void TrajectoriesJPSV06::WriteFrame(int frameNr, Building* building)

--- a/IO/IODispatcher.cpp
+++ b/IO/IODispatcher.cpp
@@ -146,7 +146,7 @@ void TrajectoriesJPSV04::WriteGeometry(Building* building)
      std::string embed_geometry;
      embed_geometry.append("\t<geometry>\n");
      char file_location[CLENGTH] = "";
-     sprintf(file_location, "\t<file location= \"%s\"/>\n", building->GetGeometryFilename().c_str());
+     sprintf(file_location, "\t<file location= \"%s\"/>\n", building->GetGeometryFilename().string().c_str());
      embed_geometry.append(file_location);
      embed_geometry.append("\t</geometry>\n");
      //Write(embed_geometry);
@@ -335,7 +335,7 @@ static fs::path getSourceFileName(const fs::path& projectFile)
 {
      fs::path ret{};
 
-     TiXmlDocument doc(projectFile.c_str());
+     TiXmlDocument doc(projectFile.string());
      if (!doc.LoadFile()) {
           Log->Write("ERROR: \t%s", doc.ErrorDesc());
           Log->Write("ERROR: \tGetSourceFileName could not parse the project file");
@@ -364,7 +364,7 @@ static fs::path getEventFileName(const fs::path& projectFile)
 {
      fs::path ret{};
 
-     TiXmlDocument doc(projectFile.c_str());
+     TiXmlDocument doc(projectFile.string());
      if (!doc.LoadFile()) {
           Log->Write("ERROR: \t%s", doc.ErrorDesc());
           Log->Write("ERROR: \tGetEventFileName could not parse the project file");
@@ -391,7 +391,7 @@ static fs::path getTrainTimeTableFileName(const fs::path& projectFile)
 {
      fs::path ret{};
 
-     TiXmlDocument doc(projectFile.c_str());
+     TiXmlDocument doc(projectFile.string());
      if (!doc.LoadFile()) {
           Log->Write("ERROR: \t%s", doc.ErrorDesc());
           Log->Write("ERROR: \tGetTrainTimeTable could not parse the project file");
@@ -416,7 +416,7 @@ static fs::path getTrainTypeFileName(const fs::path& projectFile)
 {
      fs::path ret{};
 
-     TiXmlDocument doc(projectFile.c_str());
+     TiXmlDocument doc(projectFile.string());
      if (!doc.LoadFile()) {
           Log->Write("ERROR: \t%s", doc.ErrorDesc());
           Log->Write("ERROR: \tGetTrainType could not parse the project file");
@@ -440,7 +440,7 @@ static fs::path getGoalFileName(const fs::path& projectFile)
 {
      fs::path ret{};
 
-     TiXmlDocument doc(projectFile.c_str());
+     TiXmlDocument doc(projectFile.string());
      if (!doc.LoadFile()) {
           Log->Write("ERROR: \t%s", doc.ErrorDesc());
           Log->Write("ERROR: \tGetSourceFileName could not parse the project file");
@@ -456,7 +456,7 @@ static fs::path getGoalFileName(const fs::path& projectFile)
      if(xGoalsNodeFile)
      {
           ret = xGoalsNodeFile->FirstChild()->ValueStr();
-          Log->Write("INFO:\tGoal file <%s> will be parsed", ret.c_str());
+          Log->Write("INFO:\tGoal file <%s> will be parsed", ret.string().c_str());
      }
      return ret;
 }
@@ -474,14 +474,14 @@ void TrajectoriesFLAT::WriteHeader(long nPeds, double fps, Building* building, i
      sprintf(tmp, "#framerate: %0.2f",fps);
      Write(tmp);
      const fs::path tmpGeo = projRoot / building->GetGeometryFilename();
-     sprintf(tmp,"#geometry: %s",  tmpGeo.c_str());
+     sprintf(tmp,"#geometry: %s",  tmpGeo.string().c_str());
      Write(tmp);
 
      if(const fs::path sourceFileName = getSourceFileName(building->GetProjectFilename());
           !sourceFileName.empty())
      {
           const fs::path tmpSource = projRoot / sourceFileName;
-          sprintf(tmp,"#sources: %s", tmpSource.c_str());
+          sprintf(tmp,"#sources: %s", tmpSource.string().c_str());
           Write(tmp);
      }
 
@@ -489,7 +489,7 @@ void TrajectoriesFLAT::WriteHeader(long nPeds, double fps, Building* building, i
           !goalFileName.empty())
      {
           const fs::path tmpGoal = projRoot / goalFileName;
-          sprintf(tmp,"#goals: %s", tmpGoal.c_str());
+          sprintf(tmp,"#goals: %s", tmpGoal.string().c_str());
           Write(tmp);
      }
 
@@ -497,7 +497,7 @@ void TrajectoriesFLAT::WriteHeader(long nPeds, double fps, Building* building, i
           !eventFileName.empty())
      {
           const fs::path tmpEvent = projRoot / eventFileName;
-          sprintf(tmp,"#events: %s", tmpEvent.c_str());
+          sprintf(tmp,"#events: %s", tmpEvent.string().c_str());
           Write(tmp);
      }
 
@@ -505,7 +505,7 @@ void TrajectoriesFLAT::WriteHeader(long nPeds, double fps, Building* building, i
           !trainTimeTableFileName.empty())
      {
           const fs::path tmpTTT = projRoot / trainTimeTableFileName;
-          sprintf(tmp,"#trainTimeTable: %s", tmpTTT.c_str());
+          sprintf(tmp,"#trainTimeTable: %s", tmpTTT.string().c_str());
           Write(tmp);
      }
 
@@ -513,7 +513,7 @@ void TrajectoriesFLAT::WriteHeader(long nPeds, double fps, Building* building, i
           !trainTypeFileName.empty())
      {
           const fs::path tmpTT = projRoot / trainTypeFileName;
-          sprintf(tmp,"#trainType: %s", tmpTT.c_str());
+          sprintf(tmp,"#trainType: %s", tmpTT.string().c_str());
           Write(tmp);
      }
      Write("#ID: the agent ID");
@@ -841,7 +841,7 @@ void TrajectoriesJPSV05::WriteGeometry(Building* building)
      std::string embed_geometry;
      embed_geometry.append("\t<geometry>\n");
      char file_location[CLENGTH] = "";
-     sprintf(file_location, "\t<file location= \"%s\"/>\n", building->GetGeometryFilename().c_str());
+     sprintf(file_location, "\t<file location= \"%s\"/>\n", building->GetGeometryFilename().string().c_str());
      embed_geometry.append(file_location);
      //embed_geometry.append("\t</geometry>\n");
 

--- a/IO/IniFileParser.cpp
+++ b/IO/IniFileParser.cpp
@@ -82,13 +82,13 @@ IniFileParser::IniFileParser(Configuration* config)
 bool IniFileParser::Parse(const fs::path& iniFile)
 {
      Log->Write("INFO: \tLoading and parsing the project file <%s>",
-               iniFile.c_str());
+               iniFile.string().c_str());
      _config->SetProjectFile(iniFile);//TODO in some locations it is called iniFile and in others project file,
      // and as I just realized, I called it configuration. We should be consistent here anything else
      // is confusing [gl march '16]
      _config->SetProjectRootDir(fs::absolute(iniFile.parent_path()));
 
-     TiXmlDocument doc(iniFile.c_str());
+     TiXmlDocument doc(iniFile.string());
      if (!doc.LoadFile()) {
           Log->Write("ERROR: \t%s", doc.ErrorDesc());
           Log->Write("ERROR: \tCould not parse the project file");
@@ -245,7 +245,7 @@ bool IniFileParser::ParseHeader(TiXmlNode* xHeader)
           const fs::path canonicalPath = fs::weakly_canonical(root / logPath);
           _config->SetErrorLogFile(canonicalPath);
           _config->SetLog(2);
-          Log->Write("INFO:\tlogfile <%s>", _config->GetErrorLogFile().c_str());
+          Log->Write("INFO:\tlogfile <%s>", _config->GetErrorLogFile().string().c_str());
      }
      Log->Write("----\nJuPedSim - JPScore\n");
      Log->Write("Current date   : %s %s", __DATE__, __TIME__);
@@ -377,7 +377,7 @@ bool IniFileParser::ParseHeader(TiXmlNode* xHeader)
                     _config->SetOriginalTrajectoriesFile(canonicalTrajPath);
                }
 
-               Log->Write("INFO: \toutput file  <%s>", _config->GetTrajectoriesFile().c_str());
+               Log->Write("INFO: \toutput file  <%s>", _config->GetTrajectoriesFile().string().c_str());
                Log->Write("INFO: \tin format <%s> at <%.0f> frames per seconds",format.c_str(), _config->GetFps());
           }
 

--- a/IO/IniFileParser.h
+++ b/IO/IniFileParser.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include "general/Configuration.h"
+#include "general/Filesystem.h"
 #include "routing/DirectionStrategy.h"
 
 #include <string>
@@ -39,7 +40,7 @@ public:
      IniFileParser(Configuration* config);
      ~IniFileParser(){};
 
-     bool Parse(std::string iniFile);
+     bool Parse(const fs::path& iniFile);
 
 private:
      bool ParseHeader(TiXmlNode* xHeader);

--- a/IO/OutputHandler.cpp
+++ b/IO/OutputHandler.cpp
@@ -143,14 +143,12 @@ void STDIOHandler::Write(const std::string& str)
        }
 }
 
-FileHandler::FileHandler(const char *fn)
+FileHandler::FileHandler(const fs::path& path)
 {
-     _pfp.open(fn);
+     _pfp.open(path.string());
      if (!_pfp.is_open())
      {
-          char tmp[CLENGTH];
-          sprintf(tmp, "Error!!! File [%s] could not be opened!", fn);
-          std::cerr << tmp << std::endl;
+          std::cerr << "Error!!! File " << path << " could not be opened" << std::endl;
           exit(0);
      }
 }

--- a/IO/OutputHandler.h
+++ b/IO/OutputHandler.h
@@ -26,6 +26,7 @@
  **/
 #pragma once
 
+#include "general/Filesystem.h"
 #include "general/Macros.h"
 #ifdef _SIMULATOR
 #include "IO/TraVisToClient.h"
@@ -58,17 +59,17 @@ public:
 
 class STDIOHandler : public OutputHandler {
 public:
-     void Write(const std::string& str);
+     void Write(const std::string& str) override;
 };
 
 class FileHandler : public OutputHandler {
 private:
      std::ofstream _pfp;
 public:
-     FileHandler(const char *fn);
-     virtual ~FileHandler();
-     void Write(const std::string& str);
-     void Write(const char *string,...);
+     FileHandler(const fs::path& path);
+     ~FileHandler() override;
+     void Write(const std::string& str) override;
+     void Write(const char *string,...) override;
 };
 
 #ifdef _SIMULATOR
@@ -79,8 +80,8 @@ private:
 
 public:
      SocketHandler(const std::string& host, int port);
-     virtual ~SocketHandler();
-     void Write(const std::string& str);
+     ~SocketHandler() override;
+     void Write(const std::string& str) override;
 
      //Some tags are broken
      std::vector<std::string> brokentags;

--- a/IO/PedDistributionParser.cpp
+++ b/IO/PedDistributionParser.cpp
@@ -41,7 +41,7 @@ bool PedDistributionParser::LoadPedDistribution(std::vector<std::shared_ptr<Star
 {
     Log->Write("INFO: \tLoading and parsing the persons attributes");
 
-    TiXmlDocument doc(_configuration->GetProjectFile());
+    TiXmlDocument doc(_configuration->GetProjectFile().c_str());
 
     if (!doc.LoadFile()) {
         Log->Write("ERROR: \t%s", doc.ErrorDesc());

--- a/IO/PedDistributionParser.cpp
+++ b/IO/PedDistributionParser.cpp
@@ -41,7 +41,7 @@ bool PedDistributionParser::LoadPedDistribution(std::vector<std::shared_ptr<Star
 {
     Log->Write("INFO: \tLoading and parsing the persons attributes");
 
-    TiXmlDocument doc(_configuration->GetProjectFile().c_str());
+    TiXmlDocument doc(_configuration->GetProjectFile().string());
 
     if (!doc.LoadFile()) {
         Log->Write("ERROR: \t%s", doc.ErrorDesc());

--- a/JPSfire/A_smoke_sensor/SmokeSensor.cpp
+++ b/JPSfire/A_smoke_sensor/SmokeSensor.cpp
@@ -41,15 +41,15 @@
 SmokeSensor::SmokeSensor(const Building *b) : AbstractSensor(b)
 {
     _building = b;
-    LoadJPSfireInfo(_building->GetProjectFilename());
+    LoadJPSfireInfo();
 
 }
 
 SmokeSensor::~SmokeSensor() = default;
 
-bool SmokeSensor::LoadJPSfireInfo(const std::string projectFilename)
+bool SmokeSensor::LoadJPSfireInfo()
 {
-    TiXmlDocument doc(projectFilename);
+    TiXmlDocument doc(_building->GetProjectFilename().c_str());
     if (!doc.LoadFile()) {
          Log->Write("ERROR: \t%s", doc.ErrorDesc());
          Log->Write("ERROR: \t could not parse the project file");

--- a/JPSfire/A_smoke_sensor/SmokeSensor.cpp
+++ b/JPSfire/A_smoke_sensor/SmokeSensor.cpp
@@ -49,7 +49,7 @@ SmokeSensor::~SmokeSensor() = default;
 
 bool SmokeSensor::LoadJPSfireInfo()
 {
-    TiXmlDocument doc(_building->GetProjectFilename().c_str());
+    TiXmlDocument doc(_building->GetProjectFilename().string());
     if (!doc.LoadFile()) {
          Log->Write("ERROR: \t%s", doc.ErrorDesc());
          Log->Write("ERROR: \t could not parse the project file");

--- a/JPSfire/A_smoke_sensor/SmokeSensor.h
+++ b/JPSfire/A_smoke_sensor/SmokeSensor.h
@@ -41,7 +41,6 @@ public:
 
     virtual ~SmokeSensor();
 
-    bool LoadJPSfireInfo(const std::string projectFilename);
 
     std::string GetName() const;
     void execute(const Pedestrian *, CognitiveMap&) const;
@@ -49,6 +48,7 @@ public:
     void set_FMStorage(const std::shared_ptr<FDSMeshStorage> fmStorage);
     const std::shared_ptr<FDSMeshStorage> get_FMStorage();
 private:
+    bool LoadJPSfireInfo();
     const Building* _building;
     std::shared_ptr<FDSMeshStorage> _FMStorage;
 };

--- a/JPSfire/C_toxicity_analysis/ToxicityAnalysis.cpp
+++ b/JPSfire/C_toxicity_analysis/ToxicityAnalysis.cpp
@@ -201,7 +201,7 @@ void ToxicityAnalysis::InitializeWriteOut()
      std::string ToxAnalysisXML =  "toxicity_output_" + p.stem().string() + p.extension().string();
      fs::path t(ToxAnalysisXML);
      t = p.parent_path() / t;
-     _outputhandler = std::make_shared<ToxicityOutputHandler>(t.string().c_str());
+     _outputhandler = std::make_shared<ToxicityOutputHandler>(t);
      _outputhandler->WriteToFileHeader();
 }
 

--- a/JPSfire/C_toxicity_analysis/ToxicityOutputhandler.cpp
+++ b/JPSfire/C_toxicity_analysis/ToxicityOutputhandler.cpp
@@ -1,10 +1,9 @@
 #include "ToxicityOutputhandler.h"
 
 
-ToxicityOutputHandler::ToxicityOutputHandler(const char *fn):FileHandler(fn)
-{
-
-}
+ToxicityOutputHandler::ToxicityOutputHandler(const fs::path& file)
+    :FileHandler(file)
+{}
 
 ToxicityOutputHandler::~ToxicityOutputHandler()
 {
@@ -23,7 +22,7 @@ void ToxicityOutputHandler::WriteToFileHeader()
     Write(tmp);
 }
 
-void ToxicityOutputHandler::WriteToFile(std::string &string)
+void ToxicityOutputHandler::WriteToFile(const std::string& string)
 {
     Write(string);
 }

--- a/JPSfire/C_toxicity_analysis/ToxicityOutputhandler.h
+++ b/JPSfire/C_toxicity_analysis/ToxicityOutputhandler.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "general/Filesystem.h"
 #include "IO/OutputHandler.h"
 
 #include <string>
@@ -7,9 +8,9 @@
 class ToxicityOutputHandler : public FileHandler
 {
 public:
-    ToxicityOutputHandler(const char *fn);
-    ~ToxicityOutputHandler();
+    ToxicityOutputHandler(const fs::path& file);
+    ~ToxicityOutputHandler() override;
     void WriteToFileHeader();
-    void WriteToFile(std::string& string);
+    void WriteToFile(const std::string& string);
     void WriteToFileFooter();
 };

--- a/Simulation.cpp
+++ b/Simulation.cpp
@@ -97,7 +97,7 @@ bool Simulation::InitArgs()
     }
     case 2: {
         delete Log;
-        Log = new FileHandler(_config->GetErrorLogFile().c_str());
+        Log = new FileHandler(_config->GetErrorLogFile());
     }
         break;
     default:
@@ -154,8 +154,7 @@ bool Simulation::InitArgs()
             break;
         }
         case FORMAT_PLAIN: {
-            auto file = std::make_shared<FileHandler>(
-                 trajPath.c_str());
+            auto file = std::make_shared<FileHandler>(trajPath);
             outputTXT = new TrajectoriesFLAT();
             outputTXT->SetOutputHandler(file);
             _iod->AddIO(outputTXT);
@@ -165,8 +164,7 @@ bool Simulation::InitArgs()
             Log->Write("INFO: \tFormat vtk not yet supported\n");
             auto vtkTraj = trajPath;
             vtkTraj.replace_extension(".vtk");
-            auto file = std::make_shared<FileHandler>(
-                    vtkTraj.c_str());
+            auto file = std::make_shared<FileHandler>(vtkTraj);
             Trajectories* output = new TrajectoriesVTK();
             output->SetOutputHandler(file);
             _iod->AddIO(output);
@@ -458,9 +456,9 @@ void Simulation::PrintStatistics(double simTime)
               statsfile += '_';
             }
             statsfile += _config->GetOriginalTrajectoriesFile().filename().replace_extension("txt");
-            Log->Write("More Information in the file: %s", statsfile.c_str());
+            Log->Write("More Information in the file: %s", statsfile.string().c_str());
             {
-                 FileHandler statOutput(statsfile.c_str());
+                 FileHandler statOutput(statsfile);
                  statOutput.Write("#Simulation time: %.2f", simTime);
                  statOutput.Write("#Flow at exit "+goal->GetCaption()+"( ID "+std::to_string(goal->GetID())+" )");
                  statOutput.Write("#Time (s)  cummulative number of agents \n");
@@ -482,8 +480,8 @@ void Simulation::PrintStatistics(double simTime)
 
                   fs::path statsfile = "flow_crossing_id_"
                        + std::to_string(itr.first/1000) + "_" + std::to_string(itr.first % 1000) +".dat";
-                  Log->Write("More Information in the file: %s", statsfile.c_str());
-                  FileHandler output(statsfile.c_str());
+                  Log->Write("More Information in the file: %s", statsfile.string().c_str());
+                  FileHandler output(statsfile);
                   output.Write("#Simulation time: %.2f", simTime);
                   output.Write("#Flow at crossing " + goal->GetCaption() + "( ID " + std::to_string(goal->GetID())
                                 + " ) in Room ( ID "+ std::to_string(itr.first / 1000) + " )");
@@ -700,11 +698,12 @@ void Simulation::WriteTrajectories()
           const fs::path parent = p.parent_path();
           incrementCountTraj();
           char tmp_traj_name[100];
-          sprintf(tmp_traj_name,"%s_%.4d_%s", stem.c_str(), _countTraj, extention.c_str());
+          sprintf(tmp_traj_name,"%s_%.4d_%s", stem.string().c_str(), _countTraj,
+              extention.string().c_str());
           const fs::path abs_traj_name = parent / fs::path(tmp_traj_name);
           _config->SetTrajectoriesFile(abs_traj_name);
           Log->Write("INFO:\tNew trajectory file <%s>", tmp_traj_name);
-          auto file = std::make_shared<FileHandler>(_config->GetTrajectoriesFile().c_str());
+          auto file = std::make_shared<FileHandler>(_config->GetTrajectoriesFile());
           outputTXT->SetOutputHandler(file);
           _iod->WriteHeader(_nPeds, _fps, _building.get(), _seed, _countTraj);
     }

--- a/Simulation.h
+++ b/Simulation.h
@@ -195,7 +195,7 @@ public:
      void  incrementCountTraj();
 
      bool correctGeometry(std::shared_ptr<Building> building,  std::shared_ptr<TrainTimeTable>);
-     void WriteTrajectories(std::string trajName);
+     void WriteTrajectories();
      bool TrainTraffic();
 
      int _countTraj=0; // count number of TXT trajectories to produce

--- a/events/EventManager.cpp
+++ b/events/EventManager.cpp
@@ -85,7 +85,7 @@ bool EventManager::ReadEventsXml()
 {
      Log->Write("INFO: \tLooking for pre-defined events in other files");
      //get the geometry filename from the project file
-     TiXmlDocument doc(_config->GetProjectFile().c_str());
+     TiXmlDocument doc(_config->GetProjectFile().string());
      if (!doc.LoadFile()) {
           Log->Write("ERROR: \t%s", doc.ErrorDesc());
           Log->Write("ERROR: \t could not parse the project file.");
@@ -129,7 +129,7 @@ bool EventManager::ReadEventsXml()
 
 
      Log->Write("INFO: \tParsing the event file");
-     TiXmlDocument docEvent(eventfile.c_str());
+     TiXmlDocument docEvent(eventfile.string());
      if (!docEvent.LoadFile()) {
           Log->Write("ERROR: \t%s", docEvent.ErrorDesc());
           Log->Write("ERROR: \t could not parse the event file.");
@@ -828,7 +828,7 @@ bool EventManager::ReadSchedule()
 {
      Log->Write("INFO: \tReading schedule");
      //get the geometry filename from the project file
-     TiXmlDocument doc(_config->GetProjectFile().c_str());
+     TiXmlDocument doc(_config->GetProjectFile().string());
      if (!doc.LoadFile()) {
           Log->Write("ERROR: \t%s", doc.ErrorDesc());
           Log->Write("ERROR: \t could not parse the project file.");
@@ -849,7 +849,7 @@ bool EventManager::ReadSchedule()
 
 
      Log->Write("INFO: \tParsing the schedule file");
-     TiXmlDocument docSchedule(scheduleFile.c_str());
+     TiXmlDocument docSchedule(scheduleFile.string());
      if (!docSchedule.LoadFile()) {
           Log->Write("ERROR: \t%s", docSchedule.ErrorDesc());
           Log->Write("ERROR: \t could not parse the schedule file.");

--- a/events/EventManager.cpp
+++ b/events/EventManager.cpp
@@ -50,14 +50,13 @@ using std::map;
 using std::cout;
 using std::endl;
 
-EventManager::EventManager(Building *_b, unsigned int seed)
+EventManager::EventManager(Configuration* config, Building *_b, unsigned int seed)
 {
+     _config = config;
      _building = _b;
      _eventCounter = 0;
      _dynamic = false;
      _lastUpdateTime = 0;
-     _projectFilename=_building->GetProjectFilename();
-     _projectRootDir=_building->GetProjectRootDir();
      _updateFrequency =1 ;//seconds
      _updateRadius =2;//meters
 
@@ -86,7 +85,7 @@ bool EventManager::ReadEventsXml()
 {
      Log->Write("INFO: \tLooking for pre-defined events in other files");
      //get the geometry filename from the project file
-     TiXmlDocument doc(_projectFilename);
+     TiXmlDocument doc(_config->GetProjectFile().c_str());
      if (!doc.LoadFile()) {
           Log->Write("ERROR: \t%s", doc.ErrorDesc());
           Log->Write("ERROR: \t could not parse the project file.");
@@ -95,32 +94,33 @@ bool EventManager::ReadEventsXml()
 
      TiXmlElement* xMainNode = doc.RootElement();
 
-     std::string realtimefile;
      if (xMainNode->FirstChild("event_realtime")) {
-          realtimefile = _projectRootDir
-                    + xMainNode->FirstChild("event_realtime")->FirstChild()->Value();
-          _file = fopen(realtimefile.c_str(), "r");
+          auto realtimefile = _config->GetProjectRootDir()
+                    / xMainNode->FirstChild("event_realtime")->FirstChild()->Value();
+          _file = fopen(realtimefile.string().c_str(), "r");
           if (!_file) {
-               Log->Write("INFO:\tFiles '"+ realtimefile+ "' missing. "
-                          "Realtime interaction with the simulation not possible.");
+               Log->Write("INFO:\tFiles '%s' missing. "
+                          "Realtime interaction with the simulation not possible.",
+                          realtimefile.string().c_str());
           } else {
-               Log->Write("INFO:\tFile '"+ realtimefile+ "' will be monitored for new events.");
+               Log->Write("INFO:\tFile '%s' will be monitored for new events.",
+                    realtimefile.string().c_str());
                _dynamic = true;
           }
      } else {
           Log->Write("INFO: \tNo realtime events found");
      }
 
-     std::string eventfile = "";
+     fs::path eventfile{};
      if (xMainNode->FirstChild("events_file")) {
-          eventfile = _projectRootDir
-                    + xMainNode->FirstChild("events_file")->FirstChild()->Value();
-          Log->Write("INFO: \tevents <" + eventfile + ">");
+          eventfile = _config->GetProjectRootDir()
+                    / xMainNode->FirstChild("events_file")->FirstChild()->Value();
+          Log->Write("INFO: \tevents <" + eventfile.string() + ">");
      } else if (xMainNode->FirstChild("header")){
           if (xMainNode->FirstChild("header")->FirstChild("events_file")) {
-               eventfile = _projectRootDir
-                       +xMainNode->FirstChild("header")->FirstChild("events_file")->FirstChild()->Value();
-               Log->Write("INFO: \tevents <" + eventfile + ">");
+               eventfile = _config->GetProjectRootDir()
+                       / xMainNode->FirstChild("header")->FirstChild("events_file")->FirstChild()->Value();
+               Log->Write("INFO: \tevents <" + eventfile.string() + ">");
           }
      } else {
           Log->Write("INFO: \tNo events found");
@@ -129,7 +129,7 @@ bool EventManager::ReadEventsXml()
 
 
      Log->Write("INFO: \tParsing the event file");
-     TiXmlDocument docEvent(eventfile);
+     TiXmlDocument docEvent(eventfile.c_str());
      if (!docEvent.LoadFile()) {
           Log->Write("ERROR: \t%s", docEvent.ErrorDesc());
           Log->Write("ERROR: \t could not parse the event file.");
@@ -750,11 +750,11 @@ Router * EventManager::CreateRouter(const RoutingStrategy& strategy)
                break;
 
           case ROUTING_FF_GLOBAL_SHORTEST:
-               rout = new FFRouter(ROUTING_FF_GLOBAL_SHORTEST, ROUTING_FF_GLOBAL_SHORTEST, _building->GetConfig()->get_has_specific_goals(), _building->GetConfig());
+               rout = new FFRouter(ROUTING_FF_GLOBAL_SHORTEST, ROUTING_FF_GLOBAL_SHORTEST, _config->get_has_specific_goals(), _config);
                break;
 
           case ROUTING_FF_QUICKEST:
-               rout = new FFRouter(ROUTING_FF_QUICKEST, ROUTING_FF_QUICKEST, _building->GetConfig()->get_has_specific_goals(), _building->GetConfig());
+               rout = new FFRouter(ROUTING_FF_QUICKEST, ROUTING_FF_QUICKEST, _config->get_has_specific_goals(), _config);
                break;
 
           default:
@@ -828,7 +828,7 @@ bool EventManager::ReadSchedule()
 {
      Log->Write("INFO: \tReading schedule");
      //get the geometry filename from the project file
-     TiXmlDocument doc(_projectFilename);
+     TiXmlDocument doc(_config->GetProjectFile().c_str());
      if (!doc.LoadFile()) {
           Log->Write("ERROR: \t%s", doc.ErrorDesc());
           Log->Write("ERROR: \t could not parse the project file.");
@@ -837,11 +837,11 @@ bool EventManager::ReadSchedule()
 
      TiXmlElement* xMainNode = doc.RootElement();
 
-     std::string scheduleFile = "";
+     fs::path scheduleFile = "";
      if (xMainNode->FirstChild("schedule_file")) {
-          scheduleFile = _projectRootDir
-                    + xMainNode->FirstChild("schedule_file")->FirstChild()->Value();
-          Log->Write("INFO: \tevents <" + scheduleFile + ">");
+          scheduleFile = _config->GetProjectRootDir()
+                    / xMainNode->FirstChild("schedule_file")->FirstChild()->Value();
+          Log->Write("INFO: \tevents <" + scheduleFile.string() + ">");
      } else {
           Log->Write("INFO: \tNo events found");
           return true;
@@ -849,7 +849,7 @@ bool EventManager::ReadSchedule()
 
 
      Log->Write("INFO: \tParsing the schedule file");
-     TiXmlDocument docSchedule(scheduleFile);
+     TiXmlDocument docSchedule(scheduleFile.c_str());
      if (!docSchedule.LoadFile()) {
           Log->Write("ERROR: \t%s", docSchedule.ErrorDesc());
           Log->Write("ERROR: \t could not parse the schedule file.");

--- a/events/EventManager.h
+++ b/events/EventManager.h
@@ -26,7 +26,9 @@
  **/
 #pragma once
 
+#include "general/Configuration.h"
 #include "general/Macros.h"
+#include "general/Filesystem.h"
 #include "Event.h"
 
 #include <vector>
@@ -47,7 +49,7 @@ public:
      /**
       * Constructor
       */
-     EventManager(Building *_b, unsigned int seed);
+     EventManager(Configuration* config, Building *_b, unsigned int seed);
 
      /**
       * destructor
@@ -150,10 +152,8 @@ private:
      void CreateSomeEngines();
 
 private:
-
+     Configuration* _config;
      std::vector<Event> _events;
-     std::string _projectFilename;
-     std::string _projectRootDir;
      Building *_building;
      FILE *_file;
      bool _dynamic;

--- a/general/ArgumentParser.cpp
+++ b/general/ArgumentParser.cpp
@@ -129,7 +129,7 @@ bool ArgumentParser::ParseArgs(int argc, char** argv)
                                    _config->SetProjectRootDir(argument5);
                                    _config->SetGeometryFile("geo.xml");
                                    _config->SetProjectFile("ini.xml");
-                                   _config->SetTrajectoriesFile(_config->GetProjectRootDir()+"tra.xml");
+                                   _config->SetTrajectoriesFile(_config->GetProjectRootDir() / "tra.xml");
                                    _config->SetFileFormat(FileFormat::FORMAT_XML_PLAIN);
                                    _config->SetFps(25);
                                    _config->SetDumpScenario(true);

--- a/general/Configuration.h
+++ b/general/Configuration.h
@@ -25,6 +25,7 @@
 
 #include "JPSfire/B_walking_speed/WalkingSpeed.h"
 #include "JPSfire/C_toxicity_analysis/ToxicityAnalysis.h"
+#include "general/Filesystem.h"
 #include "math/OperationalModel.h"
 #include "pedestrian/AgentsParameters.h"
 #include "routing/RoutingEngine.h"
@@ -300,29 +301,29 @@ public:
 
      void SetHostname(std::string hostname) { _hostname = hostname; };
 
-     const std::string& GetTrajectoriesFile() const { return _trajectoriesFile; };
+     const fs::path& GetTrajectoriesFile() const { return _trajectoriesFile; };
 
-     void SetTrajectoriesFile(std::string trajectoriesFile) { _trajectoriesFile = trajectoriesFile; };
+     void SetTrajectoriesFile(const fs::path& trajectoriesFile) { _trajectoriesFile = trajectoriesFile; };
 
-     const std::string& GetOriginalTrajectoriesFile() const { return _originalTrajectoriesFile; };
+     const fs::path& GetOriginalTrajectoriesFile() const { return _originalTrajectoriesFile; };
 
-     void SetOriginalTrajectoriesFile(std::string trajectoriesFile) { _originalTrajectoriesFile = trajectoriesFile; };
+     void SetOriginalTrajectoriesFile(const fs::path& trajectoriesFile) { _originalTrajectoriesFile = trajectoriesFile; };
 
-     const std::string& GetErrorLogFile() const { return _errorLogFile; };
+     const fs::path& GetErrorLogFile() const { return _errorLogFile; };
 
-     void SetErrorLogFile(std::string errorLogFile) { _errorLogFile = errorLogFile; };
+     void SetErrorLogFile(const fs::path& errorLogFile) { _errorLogFile = errorLogFile; };
 
-     const std::string& GetProjectFile() const { return _projectFile; };
+     const fs::path& GetProjectFile() const { return _projectFile; };
 
-     void SetProjectFile(std::string projectFile) { _projectFile = projectFile; };
+     void SetProjectFile(const fs::path& projectFile) { _projectFile = projectFile; };
 
-     const std::string& GetGeometryFile() const { return _geometryFile; };
+     const fs::path& GetGeometryFile() const { return _geometryFile; };
 
-     void SetGeometryFile(std::string geometryFile) { _geometryFile = geometryFile; };
+     void SetGeometryFile(const fs::path& geometryFile) { _geometryFile = geometryFile; };
 
-     const std::string& GetProjectRootDir() const { return _projectRootDir; };
+     const fs::path& GetProjectRootDir() const { return _projectRootDir; };
 
-     void SetProjectRootDir(std::string projectRootDir) { _projectRootDir = projectRootDir; };
+     void SetProjectRootDir(const fs::path& projectRootDir) { _projectRootDir = projectRootDir; };
 
      bool ShowStatistics() const { return _showStatistics; };
 
@@ -415,20 +416,15 @@ private:
 
      int _exit_strat;
 
-//     DirectionSubLocalFloorfield* _dirSubLocal;
-//     DirectionLocalFloorfield* _dirLocal;
-//     DirectionSubLocalFloorfieldTrips* _dirSubLocalTrips;
-//     DirectionSubLocalFloorfieldTripsVoronoi* _dirSubLocalTripsVoronoi;
-
      DirectionStrategy* _dirStrategy;
 
      std::string _hostname;
-     std::string _trajectoriesFile;
-     std::string _originalTrajectoriesFile;
-     std::string _errorLogFile;
-     std::string _projectFile;
-     std::string _geometryFile;
-     std::string _projectRootDir;
+     fs::path _trajectoriesFile;
+     fs::path _originalTrajectoriesFile;
+     fs::path _errorLogFile;
+     fs::path _projectFile;
+     fs::path _geometryFile;
+     fs::path _projectRootDir;
      bool _showStatistics;
 
      mutable RandomNumberGenerator _rdGenerator;

--- a/general/Filesystem.cpp
+++ b/general/Filesystem.cpp
@@ -1,0 +1,10 @@
+#include "Filesystem.h"
+
+// Unfortunately we cannot use path::replace_filename since this is not
+// implemented in boost::filesystem
+fs::path add_prefix_to_filename(
+    const std::string& prefix, const fs::path& file) {
+    std::string newFilename {prefix};
+    newFilename.append(file.filename().string());
+    return file.parent_path() /= newFilename;
+}

--- a/general/Filesystem.h
+++ b/general/Filesystem.h
@@ -7,3 +7,13 @@ namespace fs = boost::filesystem;
 #include <filesystem>
 namespace fs = std::filesystem;
 #endif
+
+/**
+ * Add a prefix to a filename.
+ *
+ * @param prefix to add
+ * @param file to prefix.
+ * @return path wih new prefix for the last element
+ */
+fs::path add_prefix_to_filename(
+    const std::string& prefix, const fs::path& file);

--- a/geometry/Building.cpp
+++ b/geometry/Building.cpp
@@ -852,12 +852,13 @@ bool Building::correct() const {
 
      if(removed)
      {
-          fs::path f("correct_"+this->GetConfig()->GetGeometryFile());
-          //fs::path p(this->GetConfig()->GetProjectRootDir());
-          //p = p / f;
-          std::string filename = f.string();
-          if(SaveGeometry(filename))
-               this->GetConfig()->SetGeometryFile(filename);
+          auto geometryFile = add_prefix_to_filename(
+            "correct_", GetGeometryFilename());
+
+          if(SaveGeometry(geometryFile)) {
+              GetConfig()->SetGeometryFile(geometryFile);
+          }
+
      }
 
     auto t_end = std::chrono::high_resolution_clock::now();
@@ -1051,17 +1052,17 @@ bool Building::ReplaceBigWall(const std::shared_ptr<SubRoom>& subroom, const Wal
 
      return true;
 }
-const std::string& Building::GetProjectFilename() const
+const fs::path& Building::GetProjectFilename() const
 {
      return _configuration->GetProjectFile();
 }
 
-const std::string& Building::GetProjectRootDir() const
+const fs::path& Building::GetProjectRootDir() const
 {
      return _configuration->GetProjectRootDir();
 }
 
-const std::string& Building::GetGeometryFilename() const
+const fs::path& Building::GetGeometryFilename() const
 {
      return _configuration->GetGeometryFile();
 }
@@ -1757,7 +1758,7 @@ Crossing* Building::GetCrossingByUID(int uid) const
         return nullptr;
 }
 
-bool Building::SaveGeometry(const std::string& filename) const
+bool Building::SaveGeometry(const fs::path& filename) const
 {
     std::stringstream geometry;
 
@@ -1861,7 +1862,7 @@ bool Building::SaveGeometry(const std::string& filename) const
 
     //cout<<endl<<geometry.str()<<endl;
 
-    std::ofstream geofile(filename);
+    std::ofstream geofile(filename.string());
     if (geofile.is_open()) {
          geofile << geometry.str();
          Log->Write("INFO:\tfile saved to %s", filename.c_str());

--- a/geometry/Building.h
+++ b/geometry/Building.h
@@ -34,6 +34,7 @@
 #include "Goal.h"
 
 #include "general/Configuration.h"
+#include "general/Filesystem.h"
 
 typedef std::pair<Point, Wall> PointWall;
 
@@ -115,7 +116,6 @@ public:
      std::map<int, std::vector<Wall> > TempRemovedWalls;
      std::map<int, std::vector<Transition> > TempAddedDoors;
 
-//    Building(const std::string &, const std::string &, RoutingEngine &, PedDistributor &, double);
      Building(Configuration* config, PedDistributor& pedDistributor);
      bool resetGeometry(std::shared_ptr<TrainTimeTable> tab);
      /// destructor
@@ -124,8 +124,6 @@ public:
      Configuration* GetConfig() const;
 
      void SetCaption(const std::string& s);
-
-//    void SetRoutingEngine(RoutingEngine *r);
 
      /// delete the ped from the ped vector
      void DeletePedestrian(Pedestrian*& ped);
@@ -266,11 +264,11 @@ public:
 
      bool AddPlatform(std::shared_ptr<Platform> P);
 
-     const std::string& GetProjectRootDir() const;
+     const fs::path& GetProjectRootDir() const;
 
-     const std::string& GetProjectFilename() const;
+     const fs::path& GetProjectFilename() const;
 
-     const std::string& GetGeometryFilename() const;
+     const fs::path& GetGeometryFilename() const;
 
 //    void SetProjectFilename(const std::string &filename);
 //
@@ -283,7 +281,7 @@ public:
       * @param filename the relative location of the file
       * @return true if everything went fine.
       */
-    bool SaveGeometry(const std::string& filename) const;
+    bool SaveGeometry(const fs::path& filename) const;
 
      void WriteToErrorLog() const;
 

--- a/hybrid/HybridSimulationManager.cpp
+++ b/hybrid/HybridSimulationManager.cpp
@@ -81,9 +81,9 @@ bool HybridSimulationManager::Run(Simulation& sim)
      if (_config->GetDumpScenario()) {
           Log->Write("INFO:\tDumping scenario.");
           _config->SetTmax(Pedestrian::GetGlobalTime());
-          sim.GetBuilding()->SaveGeometry(_config->GetProjectRootDir()+_config->GetGeometryFile());
+          sim.GetBuilding()->SaveGeometry(_config->GetProjectRootDir() / _config->GetGeometryFile());
           IniFileWriter* w = new IniFileWriter(_config, &sim, GetSimObserver());
-          w->WriteToFile(_config->GetProjectRootDir()+"ini.xml");
+          w->WriteToFile(_config->GetProjectRootDir() / "ini.xml");
      }
 
      grpc_shutdown();

--- a/hybrid/IniFileWriter.cpp
+++ b/hybrid/IniFileWriter.cpp
@@ -39,7 +39,7 @@ IniFileWriter::IniFileWriter(const Configuration* configuration, Simulation* sim
 
 void IniFileWriter::WriteToFile(std::string file)
 {
-     _fileHandler = std::unique_ptr<FileHandler>(new FileHandler(file.c_str()));
+     _fileHandler = std::unique_ptr<FileHandler>(new FileHandler(file));
      WriteHeader();
 
      WriteBody();

--- a/hybrid/IniFileWriter.cpp
+++ b/hybrid/IniFileWriter.cpp
@@ -118,7 +118,7 @@ void IniFileWriter::WriteTrajectoryOutputDefinition()
           exit(-1);
      }
      str << "\t<trajectories format=\"" << fm << "\" fps=\"" << _configuration->GetFps() << "\">" << std::endl;
-     if (_configuration->GetTrajectoriesFile()!="") {
+     if (!_configuration->GetTrajectoriesFile().empty()) {
           str << "\t\t<file location=\"" << _configuration->GetTrajectoriesFile() << "\"/>" << std::endl;
      }
      else {
@@ -140,7 +140,7 @@ void IniFileWriter::WriteLogFileLocation()
 {
      std::stringstream str;
      str << "\t<!-- output log file location -->" << std::endl;
-     if (_configuration->GetErrorLogFile()!="") {
+     if (!_configuration->GetErrorLogFile().empty()) {
           str << "\t<logfile>" << _configuration->GetErrorLogFile() << "</logfile>" << std::endl;
      }
      else {

--- a/routing/ai_router/AIRouter.cpp
+++ b/routing/ai_router/AIRouter.cpp
@@ -165,14 +165,14 @@ void AIRouter::addOption(const std::string &key, const std::vector<std::string> 
     options.insert(std::make_pair(key, value));
 }
 
-bool AIRouter::LoadRoutingInfos(const std::string &filename)
+bool AIRouter::LoadRoutingInfos(const fs::path &filename)
 {
-    if(filename=="") return true;
+    if(filename.empty()) return true;
 
     Log->Write("INFO:\tLoading extra routing information for the global/quickest path router");
-    Log->Write("INFO:\t  from the file "+filename);
+    Log->Write("INFO:\t  from the file "+filename.string());
 
-    TiXmlDocument docRouting(filename);
+    TiXmlDocument docRouting(filename.c_str());
     if (!docRouting.LoadFile()) {
          Log->Write("ERROR: \t%s", docRouting.ErrorDesc());
          Log->Write("ERROR: \t could not parse the routing file [%s]",filename.c_str());
@@ -240,10 +240,10 @@ bool AIRouter::LoadRoutingInfos(const std::string &filename)
     return true;
 }
 
-std::string AIRouter::GetRoutingInfoFile()
+fs::path AIRouter::GetRoutingInfoFile()
 {
 
-    TiXmlDocument doc(building->GetProjectFilename());
+    TiXmlDocument doc(building->GetProjectFilename().c_str());
     if (!doc.LoadFile()) {
          Log->Write("ERROR: \t%s", doc.ErrorDesc());
          Log->Write("ERROR: \t GlobalRouter: could not parse the project file");
@@ -253,7 +253,7 @@ std::string AIRouter::GetRoutingInfoFile()
     // everything is fine. proceed with parsing
     TiXmlElement* xMainNode = doc.RootElement();
     TiXmlNode* xRouters=xMainNode->FirstChild("route_choice_models");
-    std::string nav_line_file="";
+    fs::path nav_line_file{};
 
     for(TiXmlElement* e = xRouters->FirstChildElement("router"); e;
               e = e->NextSiblingElement("router"))
@@ -271,10 +271,10 @@ std::string AIRouter::GetRoutingInfoFile()
          }
     }
 
-    if (nav_line_file == "")
+    if (nav_line_file.empty())
          return nav_line_file;
     else
-        return building->GetProjectRootDir()+nav_line_file;
+        return building->GetProjectRootDir() / nav_line_file;
 }
 
 void AIRouter::DeleteCortex(const Pedestrian *ped)
@@ -282,11 +282,3 @@ void AIRouter::DeleteCortex(const Pedestrian *ped)
     brain_storage->DeleteCortex(ped);
 
 }
-
-
-
-
-
-
-
-

--- a/routing/ai_router/AIRouter.cpp
+++ b/routing/ai_router/AIRouter.cpp
@@ -172,10 +172,10 @@ bool AIRouter::LoadRoutingInfos(const fs::path &filename)
     Log->Write("INFO:\tLoading extra routing information for the global/quickest path router");
     Log->Write("INFO:\t  from the file "+filename.string());
 
-    TiXmlDocument docRouting(filename.c_str());
+    TiXmlDocument docRouting(filename.string());
     if (!docRouting.LoadFile()) {
          Log->Write("ERROR: \t%s", docRouting.ErrorDesc());
-         Log->Write("ERROR: \t could not parse the routing file [%s]",filename.c_str());
+         Log->Write("ERROR: \t could not parse the routing file [%s]",filename.string().c_str());
          return false;
     }
 
@@ -243,7 +243,7 @@ bool AIRouter::LoadRoutingInfos(const fs::path &filename)
 fs::path AIRouter::GetRoutingInfoFile()
 {
 
-    TiXmlDocument doc(building->GetProjectFilename().c_str());
+    TiXmlDocument doc(building->GetProjectFilename().string());
     if (!doc.LoadFile()) {
          Log->Write("ERROR: \t%s", doc.ErrorDesc());
          Log->Write("ERROR: \t GlobalRouter: could not parse the project file");

--- a/routing/ai_router/AIRouter.h
+++ b/routing/ai_router/AIRouter.h
@@ -28,6 +28,7 @@
 #pragma once
 
 #include "../Router.h"
+#include "general/Filesystem.h"
 
 #include <string>
 #include <unordered_map>
@@ -68,13 +69,13 @@ public:
      /**
       * Load extra routing information e.g navigation lines
       */
-     bool LoadRoutingInfos(const std::string &filename);
+     bool LoadRoutingInfos(const fs::path &filename);
 
      /**
       * Each router is responsible of getting the correct filename
       * and doing other initializations
       */
-     virtual std::string GetRoutingInfoFile();
+     virtual fs::path GetRoutingInfoFile();
 
      /**
      *Deletes everything that is related to a deleted pedestrian

--- a/routing/ai_router/BrainStorage.cpp
+++ b/routing/ai_router/BrainStorage.cpp
@@ -67,10 +67,10 @@ void AIBrainStorage::ParseCogMap(BStorageKeyType ped)
     std::string cMFileName=_cogMapFiles;
     cMFileName.replace(cMFileName.size()-4,4,std::to_string(groupId)+".xml");
 
-    std::string cogMapFilenameWithPath = _building->GetProjectRootDir() + cMFileName;
+    auto cogMapFilenameWithPath = _building->GetProjectRootDir() / cMFileName;
 
-    Log->Write(cogMapFilenameWithPath);
-    TiXmlDocument doccogMap(cogMapFilenameWithPath);
+    Log->Write(cogMapFilenameWithPath.string());
+    TiXmlDocument doccogMap(cogMapFilenameWithPath.c_str());
     if (!doccogMap.LoadFile()) {
          Log->Write("ERROR: \t%s", doccogMap.ErrorDesc());
          Log->Write("\t could not parse the cognitive map file");
@@ -304,10 +304,10 @@ void AIBrainStorage::ParseSigns() {
         Log->Write("INFO: \tNo signs specified \n");
         return;
     }
-    std::string signFilenameWithPath = _building->GetProjectRootDir() + _signFiles;
+    auto signFilenameWithPath = _building->GetProjectRootDir() / _signFiles;
 
-    Log->Write("INFO: \tRead Signs from " + signFilenameWithPath);
-    TiXmlDocument docSigns(signFilenameWithPath);
+    Log->Write("INFO: \tRead Signs from %s", signFilenameWithPath.string().c_str());
+    TiXmlDocument docSigns(signFilenameWithPath.c_str());
     if (!docSigns.LoadFile()) {
         Log->Write("WARNING: \t%s", docSigns.ErrorDesc());
         Log->Write("\t could not parse the sign file");

--- a/routing/ai_router/BrainStorage.cpp
+++ b/routing/ai_router/BrainStorage.cpp
@@ -70,7 +70,7 @@ void AIBrainStorage::ParseCogMap(BStorageKeyType ped)
     auto cogMapFilenameWithPath = _building->GetProjectRootDir() / cMFileName;
 
     Log->Write(cogMapFilenameWithPath.string());
-    TiXmlDocument doccogMap(cogMapFilenameWithPath.c_str());
+    TiXmlDocument doccogMap(cogMapFilenameWithPath.string());
     if (!doccogMap.LoadFile()) {
          Log->Write("ERROR: \t%s", doccogMap.ErrorDesc());
          Log->Write("\t could not parse the cognitive map file");
@@ -307,7 +307,7 @@ void AIBrainStorage::ParseSigns() {
     auto signFilenameWithPath = _building->GetProjectRootDir() / _signFiles;
 
     Log->Write("INFO: \tRead Signs from %s", signFilenameWithPath.string().c_str());
-    TiXmlDocument docSigns(signFilenameWithPath.c_str());
+    TiXmlDocument docSigns(signFilenameWithPath.string());
     if (!docSigns.LoadFile()) {
         Log->Write("WARNING: \t%s", docSigns.ErrorDesc());
         Log->Write("\t could not parse the sign file");

--- a/routing/ff_router/UnivFFviaFM.cpp
+++ b/routing/ff_router/UnivFFviaFM.cpp
@@ -1530,19 +1530,20 @@ void UnivFFviaFM::setSpeedMode(int speedModeArg) {
 }
 
 
-void UnivFFviaFM::writeFF(const std::string& filename, std::vector<int> targetID) {
+void UnivFFviaFM::writeFF(const fs::path& filename, std::vector<int> targetID) {
     Log->Write("INFO: \tWrite Floorfield to file");
-    Log->Write(filename);
+    auto floorfieldFile = _configuration->GetProjectRootDir() / filename;
+    Log->Write(floorfieldFile.string());
     std::ofstream file;
 
-    Log->Write("FloorfieldViaFM::writeFF(): writing to file %s: There are %d targets.", filename.c_str(), targetID.size());
+    Log->Write("FloorfieldViaFM::writeFF(): writing to file %s: There are %d targets.", floorfieldFile.string().c_str(), targetID.size());
 
     // int numX = (int) ((_grid->GetxMax()-_grid->GetxMin())/_grid->Gethx());
     // int numY = (int) ((_grid->GetyMax()-_grid->GetyMin())/_grid->Gethy());
     //int numTotal = numX * numY;
     //std::cerr << numTotal << " numTotal" << std::endl;
     //std::cerr << grid->GetnPoints() << " grid" << std::endl;
-    file.open(_configuration->GetProjectRootDir()+filename);
+    file.open(floorfieldFile.string());
 
     file << "# vtk DataFile Version 3.0" << std::endl;
     file << "Testdata: Fast Marching: Test: " << std::endl;

--- a/routing/ff_router/UnivFFviaFM.cpp
+++ b/routing/ff_router/UnivFFviaFM.cpp
@@ -1598,7 +1598,7 @@ void UnivFFviaFM::writeFF(const fs::path& filename, std::vector<int> targetID) {
               }
               double *costarray = _costFieldWithKey[targetID[iTarget]];
 
-              Log->Write("%s: target number %d: UID %d", filename.c_str(), iTarget, targetID[iTarget]);
+              Log->Write("%s: target number %d: UID %d", filename.string().c_str(), iTarget, targetID[iTarget]);
 
               std::string name = _building->GetTransOrCrossByUID(targetID[iTarget])->GetCaption() + "-" +
                                                                                           std::to_string(targetID[iTarget]);

--- a/routing/ff_router/UnivFFviaFM.h
+++ b/routing/ff_router/UnivFFviaFM.h
@@ -35,6 +35,7 @@
  **/
 #pragma once
 
+#include "general/Filesystem.h"
 #include "general/Macros.h"
 
 #include <string>
@@ -116,7 +117,7 @@ public:
      double getDistance2WallAt(const Point& pos);
      void getDir2WallAt(const Point& pos, Point& p);
 
-     void writeFF(const std::string&, std::vector<int> targetID);
+     void writeFF(const fs::path& filename, std::vector<int> targetID);
 
      void createRectGrid(std::vector<Line>& walls, std::map<int, Line>& doors, double spacing);
      void processGeometry(std::vector<Line>&walls, std::map<int, Line>& doors);

--- a/routing/ff_router_trips/UnivFFviaFMTrips.cpp
+++ b/routing/ff_router_trips/UnivFFviaFMTrips.cpp
@@ -1540,17 +1540,18 @@ void UnivFFviaFMTrips::setSpeedMode(int speedModeArg) {
 }
 
 
-void UnivFFviaFMTrips::writeFF(const std::string& filename, std::vector<int> targetID) {
+void UnivFFviaFMTrips::writeFF(const fs::path& filename, std::vector<int> targetID) {
     Log->Write("INFO: \tWrite Floorfield to file");
-    Log->Write(filename);
+    auto floorfieldFile = _configuration->GetProjectRootDir() / filename;
+    Log->Write(floorfieldFile.string());
     std::ofstream file;
 
-    Log->Write("FloorfieldViaFM::writeFF(): writing to file %s: There are %d targets.", filename.c_str(), targetID.size());
+    Log->Write("FloorfieldViaFM::writeFF(): writing to file %s: There are %d targets.", floorfieldFile.string().c_str(), targetID.size());
 
     //int numTotal = numX * numY;
     //std::cerr << numTotal << " numTotal" << std::endl;
     //std::cerr << grid->GetnPoints() << " grid" << std::endl;
-    file.open(_configuration->GetProjectRootDir()+filename);
+    file.open(floorfieldFile.string());
 
     file << "# vtk DataFile Version 3.0" << std::endl;
     file << "Testdata: Fast Marching: Test: " << std::endl;

--- a/routing/ff_router_trips/UnivFFviaFMTrips.h
+++ b/routing/ff_router_trips/UnivFFviaFMTrips.h
@@ -35,6 +35,7 @@
  **/
 #pragma once
 
+#include "general/Filesystem.h"
 #include "general/Macros.h"
 
 #include <float.h>
@@ -102,7 +103,7 @@ public:
      double getDistance2WallAt(const Point& pos);
      void getDir2WallAt(const Point& pos, Point& p);
 
-     void writeFF(const std::string&, std::vector<int> targetID);
+     void writeFF(const fs::path& filename, std::vector<int> targetID);
 
      void createRectGrid(std::vector<Line>& walls, std::map<int, Line>& doors, double spacing);
      void processGeometry(std::vector<Line>&walls, std::map<int, Line>& doors);

--- a/routing/global_shortest/GlobalRouter.cpp
+++ b/routing/global_shortest/GlobalRouter.cpp
@@ -1331,7 +1331,7 @@ bool GlobalRouter::GenerateNavigationMesh()
 fs::path GlobalRouter::GetRoutingInfoFile()
 {
 
-     TiXmlDocument doc(_building->GetProjectFilename().c_str());
+     TiXmlDocument doc(_building->GetProjectFilename().string());
      if (!doc.LoadFile()) {
           Log->Write("ERROR: \t%s", doc.ErrorDesc());
           Log->Write("ERROR: \t GlobalRouter: could not parse the project file");
@@ -1411,7 +1411,7 @@ bool GlobalRouter::LoadRoutingInfos(const fs::path &filename)
      Log->Write("INFO:\tLoading extra routing information for the global/quickest path router");
      Log->Write("INFO:\t  from the file "+filename.string());
 
-     TiXmlDocument docRouting(filename.c_str());
+     TiXmlDocument docRouting(filename.string());
      if (!docRouting.LoadFile()) {
           Log->Write("ERROR: \t%s", docRouting.ErrorDesc());
           Log->Write("ERROR: \t could not parse the routing file [%s]",filename.c_str());

--- a/routing/global_shortest/GlobalRouter.cpp
+++ b/routing/global_shortest/GlobalRouter.cpp
@@ -1328,10 +1328,10 @@ bool GlobalRouter::GenerateNavigationMesh()
      return true;
 }
 
-std::string GlobalRouter::GetRoutingInfoFile()
+fs::path GlobalRouter::GetRoutingInfoFile()
 {
 
-     TiXmlDocument doc(_building->GetProjectFilename());
+     TiXmlDocument doc(_building->GetProjectFilename().c_str());
      if (!doc.LoadFile()) {
           Log->Write("ERROR: \t%s", doc.ErrorDesc());
           Log->Write("ERROR: \t GlobalRouter: could not parse the project file");
@@ -1400,18 +1400,18 @@ std::string GlobalRouter::GetRoutingInfoFile()
      if (nav_line_file == "")
           return nav_line_file;
      else
-          return _building->GetProjectRootDir()+nav_line_file;
+          return _building->GetProjectRootDir() / nav_line_file;
 }
 
 
-bool GlobalRouter::LoadRoutingInfos(const std::string &filename)
+bool GlobalRouter::LoadRoutingInfos(const fs::path &filename)
 {
-     if(filename=="") return true;
+     if(filename.empty()) return true;
 
      Log->Write("INFO:\tLoading extra routing information for the global/quickest path router");
-     Log->Write("INFO:\t  from the file "+filename);
+     Log->Write("INFO:\t  from the file "+filename.string());
 
-     TiXmlDocument docRouting(filename);
+     TiXmlDocument docRouting(filename.c_str());
      if (!docRouting.LoadFile()) {
           Log->Write("ERROR: \t%s", docRouting.ErrorDesc());
           Log->Write("ERROR: \t could not parse the routing file [%s]",filename.c_str());

--- a/routing/global_shortest/GlobalRouter.h
+++ b/routing/global_shortest/GlobalRouter.h
@@ -28,6 +28,7 @@
 #pragma once
 
 #include "geometry/Building.h"
+#include "general/Filesystem.h"
 #include "routing/Router.h"
 
 #include <cfloat>
@@ -170,13 +171,13 @@ private:
      /**
       * Load extra routing information e.g navigation lines
       */
-     bool LoadRoutingInfos(const std::string &filename);
+     bool LoadRoutingInfos(const fs::path &filename);
 
      /**
       * Each router is responsible of getting the correct filename
       * and doing other initializations
       */
-     virtual std::string GetRoutingInfoFile();
+     virtual fs::path GetRoutingInfoFile();
 
      /**
       * @return true if the supplied line is a wall.

--- a/routing/quickest/QuickestPathRouter.cpp
+++ b/routing/quickest/QuickestPathRouter.cpp
@@ -845,7 +845,7 @@ int QuickestPathRouter::GetBestDefaultRandomExit(Pedestrian* ped)
 
 bool QuickestPathRouter::ParseAdditionalParameters()
 {
-     TiXmlDocument doc(_building->GetProjectFilename().c_str());
+     TiXmlDocument doc(_building->GetProjectFilename().string());
      if (!doc.LoadFile()) {
           Log->Write("ERROR: \t%s", doc.ErrorDesc());
           Log->Write("ERROR: \t GlobalRouter: could not parse the project file");

--- a/routing/quickest/QuickestPathRouter.cpp
+++ b/routing/quickest/QuickestPathRouter.cpp
@@ -845,7 +845,7 @@ int QuickestPathRouter::GetBestDefaultRandomExit(Pedestrian* ped)
 
 bool QuickestPathRouter::ParseAdditionalParameters()
 {
-     TiXmlDocument doc(_building->GetProjectFilename());
+     TiXmlDocument doc(_building->GetProjectFilename().c_str());
      if (!doc.LoadFile()) {
           Log->Write("ERROR: \t%s", doc.ErrorDesc());
           Log->Write("ERROR: \t GlobalRouter: could not parse the project file");

--- a/routing/smoke_router/BrainStorage.cpp
+++ b/routing/smoke_router/BrainStorage.cpp
@@ -85,7 +85,7 @@ void BrainStorage::ParseCogMap(BStorageKeyType ped)
     auto cogMapFilenameWithPath = _building->GetProjectRootDir() / cMFileName;
 
     Log->Write(cogMapFilenameWithPath.string());
-    TiXmlDocument doccogMap(cogMapFilenameWithPath.c_str());
+    TiXmlDocument doccogMap(cogMapFilenameWithPath.string());
     if (!doccogMap.LoadFile()) {
          Log->Write("ERROR: \t%s", doccogMap.ErrorDesc());
          Log->Write("\t could not parse the cognitive map file");

--- a/routing/smoke_router/BrainStorage.cpp
+++ b/routing/smoke_router/BrainStorage.cpp
@@ -82,10 +82,10 @@ void BrainStorage::ParseCogMap(BStorageKeyType ped)
     std::string cMFileName=_cogMapFiles;
     cMFileName.replace(cMFileName.size()-4,4,std::to_string(groupId)+".xml");
 
-    std::string cogMapFilenameWithPath = _building->GetProjectRootDir() + cMFileName;
+    auto cogMapFilenameWithPath = _building->GetProjectRootDir() / cMFileName;
 
-    Log->Write(cogMapFilenameWithPath);
-    TiXmlDocument doccogMap(cogMapFilenameWithPath);
+    Log->Write(cogMapFilenameWithPath.string());
+    TiXmlDocument doccogMap(cogMapFilenameWithPath.c_str());
     if (!doccogMap.LoadFile()) {
          Log->Write("ERROR: \t%s", doccogMap.ErrorDesc());
          Log->Write("\t could not parse the cognitive map file");

--- a/routing/smoke_router/SmokeRouter.cpp
+++ b/routing/smoke_router/SmokeRouter.cpp
@@ -212,7 +212,7 @@ bool SmokeRouter::LoadRoutingInfos(const fs::path &filename)
     Log->Write("INFO:\tLoading extra routing information for the global/quickest path router");
     Log->Write("INFO:\t  from the file "+filename.string());
 
-    TiXmlDocument docRouting(filename.c_str());
+    TiXmlDocument docRouting(filename.string());
     if (!docRouting.LoadFile()) {
          Log->Write("ERROR: \t%s", docRouting.ErrorDesc());
          Log->Write("ERROR: \t could not parse the routing file [%s]",filename.c_str());
@@ -283,7 +283,7 @@ bool SmokeRouter::LoadRoutingInfos(const fs::path &filename)
 fs::path SmokeRouter::GetRoutingInfoFile()
 {
 
-    TiXmlDocument doc(building->GetProjectFilename().c_str());
+    TiXmlDocument doc(building->GetProjectFilename().string());
     if (!doc.LoadFile()) {
          Log->Write("ERROR: \t%s", doc.ErrorDesc());
          Log->Write("ERROR: \t GlobalRouter: could not parse the project file");

--- a/routing/smoke_router/SmokeRouter.cpp
+++ b/routing/smoke_router/SmokeRouter.cpp
@@ -205,14 +205,14 @@ void SmokeRouter::addOption(const std::string &key, const std::vector<std::strin
     options.insert(std::make_pair(key, value));
 }
 
-bool SmokeRouter::LoadRoutingInfos(const std::string &filename)
+bool SmokeRouter::LoadRoutingInfos(const fs::path &filename)
 {
-    if(filename=="") return true;
+    if(filename.empty()) return true;
 
     Log->Write("INFO:\tLoading extra routing information for the global/quickest path router");
-    Log->Write("INFO:\t  from the file "+filename);
+    Log->Write("INFO:\t  from the file "+filename.string());
 
-    TiXmlDocument docRouting(filename);
+    TiXmlDocument docRouting(filename.c_str());
     if (!docRouting.LoadFile()) {
          Log->Write("ERROR: \t%s", docRouting.ErrorDesc());
          Log->Write("ERROR: \t could not parse the routing file [%s]",filename.c_str());
@@ -280,10 +280,10 @@ bool SmokeRouter::LoadRoutingInfos(const std::string &filename)
     return true;
 }
 
-std::string SmokeRouter::GetRoutingInfoFile()
+fs::path SmokeRouter::GetRoutingInfoFile()
 {
 
-    TiXmlDocument doc(building->GetProjectFilename());
+    TiXmlDocument doc(building->GetProjectFilename().c_str());
     if (!doc.LoadFile()) {
          Log->Write("ERROR: \t%s", doc.ErrorDesc());
          Log->Write("ERROR: \t GlobalRouter: could not parse the project file");
@@ -314,5 +314,5 @@ std::string SmokeRouter::GetRoutingInfoFile()
     if (nav_line_file == "")
          return nav_line_file;
     else
-         return building->GetProjectRootDir()+nav_line_file;
+         return building->GetProjectRootDir() / nav_line_file;
 }

--- a/routing/smoke_router/SmokeRouter.h
+++ b/routing/smoke_router/SmokeRouter.h
@@ -27,6 +27,7 @@
  **/
 #pragma once
 
+#include "general/Filesystem.h"
 #include "routing/Router.h"
 
 #include <string>
@@ -69,13 +70,13 @@ public:
      /**
       * Load extra routing information e.g navigation lines
       */
-     bool LoadRoutingInfos(const std::string &filename);
+     bool LoadRoutingInfos(const fs::path &filename);
 
      /**
       * Each router is responsible of getting the correct filename
       * and doing other initializations
       */
-     virtual std::string GetRoutingInfoFile();
+     virtual fs::path GetRoutingInfoFile();
 
 protected:
 


### PR DESCRIPTION
When trying to run `demos/scenario_3_corner` I encountered an issue when `jpscore` was trying to read `corner_routing.xml`. `jpscore` was missing a trailing `/` on the parent path so that the last part of the path and the filename got melded into one aka `scenario_3_cornercorner_routing.xml`.

Since this seems to be common and prevailing issue I am refactoring all use of path / file identifiers to use fs::path instead of strings so that paths can be safely and correctly concatenated on all operating systems.

I am opening the PR since I ~might~ need help to rack down all references to files / paths and I know this not yet complete. Hints where to find references to files are very welcome!