### PR TITLE
Add option to build with tsan

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,13 @@ print_var(BUILD_WITH_ASAN)
 if(BUILD_WITH_ASAN AND ${CMAKE_SYSTEM} MATCHES "Windows")
     message(FATAL_ERROR "Address sanitizer builds are not supported on Windows")
 endif()
+
+set(BUILD_WITH_TSAN OFF CACHE BOOL
+  "Build with thread sanitizer support. Linux / macOS only.")
+print_var(BUILD_WITH_TSAN)
+if(BUILD_WITH_TSAN AND ${CMAKE_SYSTEM} MATCHES "Windows")
+    message(FATAL_ERROR "Thread sanitizer builds are not supported on Windows")
+endif()
 ################################################################################
 # Compilation flags
 ################################################################################
@@ -533,13 +540,15 @@ endif()
 ################################################################################
 # Build jspcore_asan executable - jpscore with address sanitizer
 ################################################################################
-if(BUILD_WITH_ASAN)
+if(BUILD_WITH_ASAN OR BUILD_WITH_TSAN)
     get_target_property(core_source core SOURCES)
     get_target_property(core_compile_options core COMPILE_OPTIONS)
     get_target_property(core_compile_definitions core COMPILE_DEFINITIONS)
     get_target_property(core_link_libraries core LINK_LIBRARIES)
     get_target_property(core_include_directories core INCLUDE_DIRECTORIES)
+endif()
 
+if(BUILD_WITH_ASAN)
     add_library(core_asan STATIC
         ${core_source}
     )
@@ -549,6 +558,7 @@ if(BUILD_WITH_ASAN)
         -fno-omit-frame-pointer
         -fno-optimize-sibling-calls
         -fsanitize=address
+        -fsanitize=undefined
     )
 
     target_compile_definitions(core_asan PRIVATE
@@ -577,11 +587,62 @@ if(BUILD_WITH_ASAN)
         -fno-omit-frame-pointer
         -fno-optimize-sibling-calls
         -fsanitize=address
+        -fsanitize=undefined
     )
 
     target_link_libraries(jpscore_asan
         ${jpscore_link_libraries}
         -fsanitize=address
+        -fsanitize=undefined
+    )
+endif()
+
+################################################################################
+# Build jspcore_tsan executable - jpscore with thread sanitizer
+################################################################################
+if(BUILD_WITH_ASAN)
+    add_library(core_tsan STATIC
+        ${core_source}
+    )
+
+    target_compile_options(core_tsan PRIVATE
+        ${core_compile_options}
+        -fno-omit-frame-pointer
+        -fno-optimize-sibling-calls
+        -fsanitize=thread
+    )
+
+    target_compile_definitions(core_tsan PRIVATE
+        ${core_compile_definitions}
+    )
+
+    target_link_libraries(core_tsan
+        ${core_link_libraries}
+    )
+
+  target_include_directories(core_tsan PUBLIC
+        ${core_include_directories}
+    )
+
+    get_target_property(jpscore_source jpscore SOURCES)
+    get_target_property(jpscore_compile_options jpscore COMPILE_OPTIONS)
+    get_target_property(jpscore_link_libraries jpscore LINK_LIBRARIES)
+    list(REMOVE_ITEM jpscore_link_libraries core)
+    list(APPEND jpscore_link_libraries core_tsan)
+    add_executable(jpscore_tsan
+        ${jpscore_source}
+    )
+
+    target_compile_options(jpscore_tsan PRIVATE
+        ${jpscore_compile_options}
+        -fno-omit-frame-pointer
+        -fno-optimize-sibling-calls
+        -fsanitize=thread
+    )
+
+    target_link_libraries(jpscore_tsan
+        ${jpscore_link_libraries}
+        -fsanitize=thread
     )
 endif()
 ################################################################################

--- a/README.md
+++ b/README.md
@@ -73,8 +73,13 @@ Build full system tests and add them to ctest
 
 ##### BUILD_WITH_ASAN defaults to OFF (Does not support Windows)
 Build an additional target `jpscore_asan` with address and undefined behavior
-sanitizer enabled. Note there is an approx. 2x slowdown when using 
+sanitizer enabled. Note there is an approx. 2x slowdown when using
 `jpscore_asan` over `jpscore`
+
+##### BUILD_WITH_TSAN defaults to OFF (Does not support Windows)
+Build an additional target `jpscore_tsan` with thread sanitizer
+enabled. Note there is an approx. 5-10x slowdown when using
+`jpscore_tsan` over `jpscore`
 
 ## Quick start
 


### PR DESCRIPTION
New cmake option added BUILD_WITH_TSAN (Default=OFF), builds a new
target jpscore_tsan.

Also updates asan target with undefined behaviour sanitizer, since ubsan
and asan can work in conjunction.