### PR TITLE
Adds clang-format config

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,43 @@
+﻿---
+BasedOnStyle: LLVM
+AccessModifierOffset: '-4'
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: 'true'
+AlignConsecutiveDeclarations: 'true'
+AlignTrailingComments: 'true'
+AllowAllParametersOfDeclarationOnNextLine: 'false'
+AllowShortBlocksOnASingleLine: 'true'
+AllowShortCaseLabelsOnASingleLine: 'false'
+AllowShortFunctionsOnASingleLine: Inline
+AlwaysBreakTemplateDeclarations: 'Yes'
+BinPackArguments: 'false'
+BinPackParameters: 'false'
+BreakBeforeBraces: Linux
+BreakBeforeTernaryOperators: 'false'
+BreakConstructorInitializers: AfterColon
+ColumnLimit: '100'
+CompactNamespaces: 'false'
+ConstructorInitializerAllOnOneLineOrOnePerLine: 'true'
+Cpp11BracedListStyle: 'true'
+FixNamespaceComments: 'true'
+IncludeBlocks: Regroup
+IndentCaseLabels: 'true'
+IndentWidth: '4'
+KeepEmptyLinesAtTheStartOfBlocks: 'false'
+Language: Cpp
+MaxEmptyLinesToKeep: '2'
+NamespaceIndentation: None
+PointerAlignment: Middle
+SortIncludes: 'true'
+SpaceAfterCStyleCast: 'true'
+SpaceAfterTemplateKeyword: 'true'
+SpaceBeforeAssignmentOperators: 'true'
+SpaceBeforeCtorInitializerColon: 'true'
+SpaceBeforeInheritanceColon: 'true'
+SpaceBeforeParens: Never
+SpaceBeforeRangeBasedForLoopColon: 'true'
+Standard: Cpp11
+TabWidth: '4'
+UseTab: Never
+
+...

--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,7 @@ Matrix.txt
 # Hidden files
 .*
 !/.gitignore
+!/.clang-format
 
 # Cmake
 CMakeCache.txt


### PR DESCRIPTION
I created a first clang-format configuration. Please have a look and test if it satisfies you. I am happy to add changes. You can play around with clang format config [here](https://zed0.co.uk/clang-format-configurator/).  Just upload the `.clang-format` configuration file and see the configuration parameters.... 

This is only the configuration file... The reformatting of the repository will be done after we found a consensus on the configuration ;).
@chraibi @gjaeger @schroedtert @Ozaq 