### PR TITLE
Replaces crossing pointer with plain member variable

### DIFF
--- a/geometry/Goal.cpp
+++ b/geometry/Goal.cpp
@@ -41,10 +41,6 @@ Goal::Goal()
      _subRoomID = -1;
 }
 
-Goal::~Goal()
-{
-}
-
 void Goal::AddWall(const Wall& w)
 {
      _walls.push_back(w);
@@ -240,8 +236,6 @@ bool Goal::ConvertLineToPoly()
           _crossing.SetPoint2(tmp_line.GetCentre());
      }
 
-
-//     std::cout << "Crossing goal: " << _crossing.GetUniqueID() << _crossing.toString() << std::endl;
      return true;
 }
 

--- a/geometry/Goal.cpp
+++ b/geometry/Goal.cpp
@@ -37,14 +37,12 @@ Goal::Goal()
      _isFinalGoal=0;
      _walls = std::vector<Wall > ();
      _poly = std::vector<Point > ();
-     _crossing = new Crossing();
      _roomID = -1;
      _subRoomID = -1;
 }
 
 Goal::~Goal()
 {
-
 }
 
 void Goal::AddWall(const Wall& w)
@@ -70,7 +68,7 @@ int Goal::GetId() const
 void Goal::SetId(int id)
 {
      _id = id;
-     _crossing->SetID(id);
+     _crossing.SetID(id);
 }
 
 const std::vector<Point>& Goal::GetPolygon() const
@@ -234,16 +232,16 @@ bool Goal::ConvertLineToPoly()
           point1 = tmp +  diff * 0.95;
           point2 = tmp +  diff * 0.05;
 
-          _crossing->SetPoint1(point1);
-          _crossing->SetPoint2(point2);
+          _crossing.SetPoint1(point1);
+          _crossing.SetPoint2(point2);
      }else{
-          _crossing->SetPoint1(_poly[0]);
+          _crossing.SetPoint1(_poly[0]);
           Line tmp_line(_poly[_poly.size()/2], _poly[(_poly.size()/2)+1], 0);
-          _crossing->SetPoint2(tmp_line.GetCentre());
+          _crossing.SetPoint2(tmp_line.GetCentre());
      }
 
 
-//     std::cout << "Crossing goal: " << _crossing->GetUniqueID() << _crossing->toString() << std::endl;
+//     std::cout << "Crossing goal: " << _crossing.GetUniqueID() << _crossing.toString() << std::endl;
      return true;
 }
 
@@ -296,7 +294,7 @@ void  Goal::ComputeCentroid()
 
 Crossing* Goal::GetCentreCrossing()
 {
-     return _crossing;
+     return &_crossing;
 }
 
 //bool Goal::IsInsideGoal(Pedestrian* ped) const

--- a/geometry/Goal.h
+++ b/geometry/Goal.h
@@ -65,7 +65,7 @@ public:
 
 public:
      Goal();
-     virtual ~Goal();
+     virtual ~Goal() = default;
 
      /**
       * Set/Get the obstacles' caption

--- a/geometry/Goal.h
+++ b/geometry/Goal.h
@@ -26,6 +26,7 @@
  **/
 #pragma once
 
+#include "Crossing.h"
 #include "Point.h"
 
 #include <boost/polygon/polygon.hpp>
@@ -37,7 +38,6 @@
 //forward declarations
 class Wall;
 class Point;
-class Crossing;
 
 namespace bg = boost::geometry;
 typedef bg::model::polygon<Point, false, false> polygon_type;
@@ -54,7 +54,7 @@ protected:
     std::string _caption;
     std::vector<Wall> _walls;
     std::vector<Point> _poly;
-    Crossing* _crossing;
+    Crossing _crossing;
 
     polygon_type _boostPoly;
     bool _inside;


### PR DESCRIPTION
This Crossing belongs to a certain goal. No need for dynamic allocation
here.