### PR TITLE
Adds Dockerfile for CI build Linux

### DIFF
--- a/container/build/Dockerfile
+++ b/container/build/Dockerfile
@@ -1,0 +1,15 @@
+FROM ubuntu:18.04
+RUN apt-get update
+
+RUN apt-get install -y software-properties-common
+
+RUN apt-get install -y wget \
+                       git \
+                       g++-8 \
+                       clang-8 \
+                       cmake \
+                       make \
+                       libboost-dev \
+                       libboost-test-dev \
+                       libcgal-dev \
+                       clang-format-8


### PR DESCRIPTION
For CI we need a Docker container to run build in isolation. 