### PR TITLE
Fix crash when no trajectories configured

### DIFF
--- a/Simulation.cpp
+++ b/Simulation.cpp
@@ -142,7 +142,10 @@ bool Simulation::InitArgs()
         }
 
         const fs::path & trajPath(_config->GetTrajectoriesFile());
-        fs::create_directories(trajPath.parent_path());
+        const fs::path trajParentPath = trajPath.parent_path();
+        if(!trajParentPath.empty()) {
+            fs::create_directories(trajParentPath);
+        }
         auto file = std::make_shared<FileHandler>(trajPath.c_str());
         _iod->SetOutputHandler(file);
         _iod->SetOptionalOutput(_config->GetOptionalOutputOptions());


### PR DESCRIPTION
In case no trajectoy output file name was given jpscore tried to create
a folder with an empty path resulting in an unhandled exception.