### PR TITLE
Fix crash on empty routing element

### DIFF
--- a/IO/Trajectories.cpp
+++ b/IO/Trajectories.cpp
@@ -121,15 +121,13 @@ static fs::path getGoalFileName(const fs::path & projectFile)
         return ret;
     }
     TiXmlNode * xRootNode = doc.RootElement();
-    if(!xRootNode->FirstChild("routing")) {
-        return ret;
-    }
-    //load goals and routes
-    TiXmlNode * xGoalsNode     = xRootNode->FirstChild("routing")->FirstChild("goals");
-    TiXmlNode * xGoalsNodeFile = xGoalsNode->FirstChild("file");
-    if(xGoalsNodeFile) {
-        ret = xGoalsNodeFile->FirstChild()->ValueStr();
-        Logging::Info(fmt::format("goal file <{}>", ret.string()));
+    if(auto routingNode = xRootNode->FirstChild("routing")) {
+        if(auto goalsNode = routingNode->FirstChild("goals")) {
+            if(auto fileNode = goalsNode->FirstChild("file")) {
+                ret = fileNode->ValueStr();
+                Logging::Info(fmt::format("goal file <{}>", ret.string()));
+            }
+        }
     }
     return ret;
 }


### PR DESCRIPTION
Empty routing element in ini.xml (which is valid according to XSD) led
to a crash.

Now properly validates existance of child lelemnts before tryitng to
access element content.

Fixes: #524

NOTE: This will fix the issue @anna-braun  reported BUT there is still another issue lurking i.e. with the example you provided this will still crash but later due to a different issue :( 