### PR TITLE
Make logging configurable

### DIFF
--- a/general/ArgumentParser.cpp
+++ b/general/ArgumentParser.cpp
@@ -35,18 +35,15 @@ const fs::path & ArgumentParser::IniFilePath() const
     return iniFilePath;
 }
 
+Logging::Level ArgumentParser::LogLevel() const
+{
+    return logLevel;
+}
+
 std::tuple<ArgumentParser::Execution, int> ArgumentParser::Parse(int argc, char * argv[])
 {
     try {
         app.parse(argc, argv);
-        // Silence warnigns about iniFilePathOpt declared as member but never
-        // used. iniFilePathOpt is a member to keep the declaration of all
-        // options in the header file. If there was no iniFilePathOpt member the
-        // add_option(...) call would need to be done the constructor.
-        (void) iniFilePathOpt;
-        if(auto msg = CLI::ExistingFile(iniFilePath.string()); !msg.empty()) {
-            throw CLI::ValidationError(msg);
-        }
     } catch(const CLI::ParseError & e) {
         return {Execution::ABORT, app.exit(e)};
     }

--- a/general/ArgumentParser.h
+++ b/general/ArgumentParser.h
@@ -25,22 +25,44 @@
 #pragma once
 
 #include "general/Filesystem.h"
+#include "general/Logger.h"
 
 #include <CLI/CLI.hpp>
 #include <tuple>
+#include <vector>
 
 class ArgumentParser final
 {
 private:
+    std::vector<std::pair<std::string, Logging::Level>> logLevelMapping{
+        {"debug", Logging::Level::Debug},
+        {"info", Logging::Level::Info},
+        {"warning", Logging::Level::Warning},
+        {"error", Logging::Level::Error},
+        {"off", Logging::Level::Off}};
+
     fs::path iniFilePath{"ini.xml"};
+    Logging::Level logLevel{Logging::Level::Info};
+
     CLI::App app{"JuPedSim"};
-    CLI::Option * iniFilePathOpt = app.add_option("inifile", iniFilePath, "Path to your inifile");
+    CLI::Option * iniFilePathOpt =
+        app.add_option("inifile", iniFilePath, "Path to your inifile. Defaults to 'ini.xml'")
+            ->check(CLI::ExistingFile);
+    CLI::Option * logLevelOpt =
+        app.add_option(
+               "--log-level",
+               logLevel,
+               "Minimum level of log messages to show. Deafults to 'info'")
+            ->transform(CLI::CheckedTransformer(logLevelMapping, CLI::ignore_case));
 
 public:
     enum class Execution { CONTINUE, ABORT };
 
     /// @return inifile argument. If none was parsed this defaults to 'ini.xml'
     const fs::path & IniFilePath() const;
+
+    /// @return desired log level. If none was parsed this defauls to 'Info'
+    Logging::Level LogLevel() const;
 
     /// Parses command line arguments
     /// Parsing ends in one of three states:

--- a/general/Logger.cpp
+++ b/general/Logger.cpp
@@ -34,7 +34,8 @@ void Error(std::string_view msg)
     spdlog::error(msg);
 }
 
-void SetLogLevel(Level level) {
+void SetLogLevel(Level level)
+{
     switch(level) {
         case Level::Debug:
             spdlog::set_level(spdlog::level::debug);

--- a/general/Logger.cpp
+++ b/general/Logger.cpp
@@ -31,7 +31,27 @@ void Warning(std::string_view msg)
 
 void Error(std::string_view msg)
 {
-    spdlog::critical(msg);
+    spdlog::error(msg);
+}
+
+void SetLogLevel(Level level) {
+    switch(level) {
+        case Level::Debug:
+            spdlog::set_level(spdlog::level::debug);
+            break;
+        case Level::Info:
+            spdlog::set_level(spdlog::level::info);
+            break;
+        case Level::Warning:
+            spdlog::set_level(spdlog::level::warn);
+            break;
+        case Level::Error:
+            spdlog::set_level(spdlog::level::err);
+            break;
+        case Level::Off:
+            spdlog::set_level(spdlog::level::off);
+            break;
+    }
 }
 
 Guard::Guard()

--- a/general/Logger.h
+++ b/general/Logger.h
@@ -4,14 +4,7 @@
 
 namespace Logging
 {
-
-enum class Level {
-    Debug,
-    Info,
-    Warning,
-    Error,
-    Off
-};
+enum class Level { Debug, Info, Warning, Error, Off };
 
 void Setup();
 void Teardown();

--- a/general/Logger.h
+++ b/general/Logger.h
@@ -4,13 +4,22 @@
 
 namespace Logging
 {
+
+enum class Level {
+    Debug,
+    Info,
+    Warning,
+    Error,
+    Off
+};
+
 void Setup();
 void Teardown();
-
 void Debug(std::string_view msg);
 void Info(std::string_view msg);
 void Warning(std::string_view msg);
 void Error(std::string_view msg);
+void SetLogLevel(Level level);
 
 struct Guard {
     Guard();

--- a/main.cpp
+++ b/main.cpp
@@ -56,6 +56,7 @@ int main(int argc, char ** argv)
         return return_code;
     }
     Logging::Guard guard;
+    Logging::SetLogLevel(a.LogLevel());
     Logging::Info("Starting JuPedSim - JPScore");
     Logging::Info(fmt::format(check_fmt("Version {}"), JPSCORE_VERSION));
     Logging::Info(fmt::format(check_fmt("Commit id {}"), GIT_COMMIT_HASH));


### PR DESCRIPTION
jpscore learned a new comandline option:
  --log-level=(debug|info|warning|error|off)

New option controls the minimum level of log message to be printed, e.g.
'info' will print 'info', 'warning' and 'error' messages. Use 'off' to
disable logging.