### PR TITLE
Fixes bug for unknown direction strategy

### DIFF
--- a/libcore/src/IO/IniFileParser.cpp
+++ b/libcore/src/IO/IniFileParser.cpp
@@ -1248,7 +1248,6 @@ bool IniFileParser::ParseStrategyNodeToObject(const TiXmlNode & strategyNode)
                     Logging::Error(fmt::format(
                         check_fmt("Unknown exit_crossing_strategy <{}>"), pExitStrategy));
                     Logging::Warning("The default exit_crossing_strategy <2> will be used");
-                    return true;
                     break;
             }
         } else {


### PR DESCRIPTION
When exit crossing strategy is unknown, the default direction strategy
is created but never set on the direction strategy manager. Removing
the return fixes this.