### PR TITLE
Change approch to testing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,12 +39,6 @@ check_prefix_path()
 ################################################################################
 # Optional features
 ################################################################################
-set(BUILD_TESTING OFF CACHE BOOL "Build with integration tests")
-print_var(BUILD_TESTING)
-
-set(BUILD_CPPUNIT_TEST OFF CACHE BOOL "Build with unit tests")
-print_var(BUILD_CPPUNIT_TEST)
-
 set(BUILD_DOC OFF CACHE BOOL "Build doxygen documentation")
 print_var(BUILD_DOC)
 
@@ -54,12 +48,6 @@ print_var(JPSFIRE)
 set(USE_OPENMP ON CACHE BOOL "Build with OpenMP")
 print_var(USE_OPENMP)
 
-set(BUILD_WITH_ASAN OFF CACHE BOOL
-  "Build with address sanitizer support. Linux / macOS only.")
-print_var(BUILD_WITH_ASAN)
-if(BUILD_WITH_ASAN AND ${CMAKE_SYSTEM} MATCHES "Windows")
-    message(FATAL_ERROR "Address sanitizer builds are not supported on Windows")
-endif()
 ################################################################################
 # Compilation flags
 ################################################################################
@@ -167,10 +155,18 @@ else()
 endif()
 
 find_package(Threads REQUIRED)
+find_package(PythonInterp 3 REQUIRED)
 
-if(BUILD_TESTING)
-    find_package(PythonInterp 3 REQUIRED)
+################################################################################
+# ASAN support clang/gcc (macOS/linux only)
+################################################################################
+if(${CMAKE_SYSTEM} MATCHES "Windows")
+    message(STATUS "Omitting unsupported asan builds on windows")
+    set(BUILD_WITH_ASAN OFF)
+else()
+    set(BUILD_WITH_ASAN ON)
 endif()
+include(asan)
 
 ################################################################################
 # VCS info
@@ -250,9 +246,7 @@ endif(BUILD_DOC)
 ################################################################################
 # Testing
 ################################################################################
-if(BUILD_CPPUNIT_TEST OR BUILD_TESTING)
-    enable_testing()
-endif()
+enable_testing()
 
 ################################################################################
 # Add libraries / executables
@@ -262,10 +256,43 @@ add_subdirectory(jpscore)
 
 
 ################################################################################
-# Integration tests
+# system tests
 ################################################################################
-if (BUILD_TESTING)
-    list(APPEND clean_geometry_tests
+list(APPEND clean_geometry_tests
+    ${CMAKE_SOURCE_DIR}/systemtest/test_geometry/clean_geometry/inifile1.xml
+    ${CMAKE_SOURCE_DIR}/systemtest/test_geometry/clean_geometry/inifile2.xml
+    ${CMAKE_SOURCE_DIR}/systemtest/test_geometry/clean_geometry/inifile3.xml
+    ${CMAKE_SOURCE_DIR}/systemtest/test_geometry/clean_geometry/inifile4.xml
+    ${CMAKE_SOURCE_DIR}/systemtest/test_geometry/clean_geometry/inifile5.xml
+    ${CMAKE_SOURCE_DIR}/systemtest/test_geometry/clean_geometry/inifile6.xml
+    ${CMAKE_SOURCE_DIR}/systemtest/test_geometry/clean_geometry/inifile7.xml
+    ${CMAKE_SOURCE_DIR}/systemtest/test_geometry/clean_geometry/inifile8.xml
+    ${CMAKE_SOURCE_DIR}/systemtest/test_geometry/clean_geometry/inifile9-1.xml
+    ${CMAKE_SOURCE_DIR}/systemtest/test_geometry/clean_geometry/inifile9-2.xml
+    ${CMAKE_SOURCE_DIR}/systemtest/test_geometry/clean_geometry/inifile10.xml
+)
+foreach(file ${clean_geometry_tests})
+    get_filename_component(test ${file} NAME_WE)
+    add_test(
+        NAME geometry-${test}
+        COMMAND $<TARGET_FILE:jpscore> ${file}
+    )
+endforeach()
+
+file(GLOB_RECURSE test_py_files "${CMAKE_SOURCE_DIR}/Utest/*runtest_*.py")
+foreach (file ${test_py_files})
+    get_filename_component(test ${file} NAME_WE)
+    add_test(
+        NAME ${test}
+        COMMAND ${PYTHON_EXECUTABLE} ${file}
+    )
+endforeach ()
+
+################################################################################
+# system tests with asan
+################################################################################
+if(BUILD_WITH_ASAN)
+    list(APPEND asan_geometry_tests
         ${CMAKE_SOURCE_DIR}/systemtest/test_geometry/clean_geometry/inifile1.xml
         ${CMAKE_SOURCE_DIR}/systemtest/test_geometry/clean_geometry/inifile2.xml
         ${CMAKE_SOURCE_DIR}/systemtest/test_geometry/clean_geometry/inifile3.xml
@@ -278,23 +305,14 @@ if (BUILD_TESTING)
         ${CMAKE_SOURCE_DIR}/systemtest/test_geometry/clean_geometry/inifile9-2.xml
         ${CMAKE_SOURCE_DIR}/systemtest/test_geometry/clean_geometry/inifile10.xml
     )
-    foreach(file ${clean_geometry_tests})
+    foreach(file ${asan_geometry_tests})
         get_filename_component(test ${file} NAME_WE)
         add_test(
-            NAME geometry-${test}
-            COMMAND $<TARGET_FILE:jpscore> ${file}
+            NAME geometry-${test}_asan
+            COMMAND $<TARGET_FILE:jpscore_asan> ${file}
         )
     endforeach()
-
-    file(GLOB_RECURSE test_py_files "${CMAKE_SOURCE_DIR}/Utest/*runtest_*.py")
-    foreach (file ${test_py_files})
-        get_filename_component(test ${file} NAME_WE)
-        add_test(
-            NAME ${test}
-            COMMAND ${PYTHON_EXECUTABLE} ${file}
-        )
-    endforeach ()
-endif (BUILD_TESTING)
+endif()
 
 ################################################################################
 # Packaging with CPack

--- a/jpscore/CMakeLists.txt
+++ b/jpscore/CMakeLists.txt
@@ -6,26 +6,23 @@ add_executable(jpscore
     forms/jpscore.rc
     forms/JPScore.ico
 )
+
 target_compile_options(jpscore PRIVATE
     ${COMMON_COMPILE_OPTIONS}
 )
+
 target_link_libraries(jpscore
     core
     Threads::Threads
     spdlog::spdlog
     fmt::fmt
+    $<$<PLATFORM_ID:Windows>:wsock32>
 )
 
-if (WIN32)
-    target_link_libraries(jpscore core wsock32)
-endif (WIN32)
-
-
-if(WIN32)
-  if(MSVC)
-    set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT jpscore)
-    message(STATUS "set start project for VS")
-  endif()
+if(WIN32 AND MSVC)
+    set_property(
+        DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        PROPERTY VS_STARTUP_PROJECT jpscore)
 endif()
 
 ################################################################################
@@ -43,9 +40,6 @@ if(BUILD_WITH_ASAN)
 
     target_compile_options(jpscore_asan PRIVATE
         ${jpscore_compile_options}
-        -fno-omit-frame-pointer
-        -fno-optimize-sibling-calls
-        -fsanitize=address
     )
 
     target_compile_definitions(jpscore_asan PRIVATE
@@ -54,7 +48,7 @@ if(BUILD_WITH_ASAN)
 
     target_link_libraries(jpscore_asan
         ${jpscore_link_libraries}
-        -fsanitize=address
+        asan
     )
 endif()
 

--- a/libcore/CMakeLists.txt
+++ b/libcore/CMakeLists.txt
@@ -235,9 +235,6 @@ if(BUILD_WITH_ASAN)
 
     target_compile_options(core_asan PRIVATE
         ${core_compile_options}
-        -fno-omit-frame-pointer
-        -fno-optimize-sibling-calls
-        -fsanitize=address
     )
 
     target_compile_definitions(core_asan PUBLIC
@@ -246,6 +243,7 @@ if(BUILD_WITH_ASAN)
 
     target_link_libraries(core_asan
         ${core_link_libraries}
+        asan
     )
 
     target_include_directories(core_asan PUBLIC
@@ -256,29 +254,31 @@ endif()
 ################################################################################
 # libcore unit tests
 ################################################################################
-if (BUILD_CPPUNIT_TEST)
-    find_package(Catch2 REQUIRED)
+find_package(Catch2 REQUIRED)
 
-    add_executable(unittests
-      test/catch2/geometry/LineTest.cpp
-      test/catch2/geometry/ObstacleTest.cpp
-      test/catch2/geometry/PointTest.cpp
-      test/catch2/geometry/RoomTest.cpp
-      test/catch2/geometry/SubRoomTest.cpp
-      test/catch2/Main.cpp
-      test/catch2/math/MathematicsTest.cpp
-      test/catch2/pedestrian/EllipseTest.cpp
-    )
+add_executable(unittests
+  test/catch2/geometry/LineTest.cpp
+  test/catch2/geometry/ObstacleTest.cpp
+  test/catch2/geometry/PointTest.cpp
+  test/catch2/geometry/RoomTest.cpp
+  test/catch2/geometry/SubRoomTest.cpp
+  test/catch2/Main.cpp
+  test/catch2/math/MathematicsTest.cpp
+  test/catch2/pedestrian/EllipseTest.cpp
+)
 
-    target_link_libraries(unittests Catch2::Catch2 core)
+target_link_libraries(unittests
+    Catch2::Catch2
+    $<$<PLATFORM_ID:Windows>:core>
+    $<$<NOT:$<PLATFORM_ID:Windows>>:core_asan>
+)
 
-    target_compile_options(unittests PRIVATE
-        ${COMMON_COMPILE_OPTIONS}
-    )
+target_compile_options(unittests PRIVATE
+    ${COMMON_COMPILE_OPTIONS}
+)
 
-    include(CTest)
-    include(ParseAndAddCatchTests)
-    set(PARSE_CATCH_TESTS_ADD_TARGET_IN_TEST_NAME Off)
-    set(PARSE_CATCH_TESTS_ADD_TO_CONFIGURE_DEPENDS On)
-    ParseAndAddCatchTests(unittests)
-endif()
+include(CTest)
+include(ParseAndAddCatchTests)
+set(PARSE_CATCH_TESTS_ADD_TARGET_IN_TEST_NAME Off)
+set(PARSE_CATCH_TESTS_ADD_TO_CONFIGURE_DEPENDS On)
+ParseAndAddCatchTests(unittests)


### PR DESCRIPTION
Now tests are always build and instrumented with asan. A set of system
tests now also run with asan enabled.

No asan builds / tests added for windows since it is not available for
msvc at this time.

NOTE: this pr needs #553 to be fixed first (tests now show the issue and thus are failing)