### PR TITLE
Extending integration testing for CI and dev

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -265,35 +265,7 @@ add_subdirectory(jpscore)
 # Integration tests
 ################################################################################
 if (BUILD_TESTING)
-    list(APPEND clean_geometry_tests
-        ${CMAKE_SOURCE_DIR}/systemtest/test_geometry/clean_geometry/inifile1.xml
-        ${CMAKE_SOURCE_DIR}/systemtest/test_geometry/clean_geometry/inifile2.xml
-        ${CMAKE_SOURCE_DIR}/systemtest/test_geometry/clean_geometry/inifile3.xml
-        ${CMAKE_SOURCE_DIR}/systemtest/test_geometry/clean_geometry/inifile4.xml
-        ${CMAKE_SOURCE_DIR}/systemtest/test_geometry/clean_geometry/inifile5.xml
-        ${CMAKE_SOURCE_DIR}/systemtest/test_geometry/clean_geometry/inifile6.xml
-        ${CMAKE_SOURCE_DIR}/systemtest/test_geometry/clean_geometry/inifile7.xml
-        ${CMAKE_SOURCE_DIR}/systemtest/test_geometry/clean_geometry/inifile8.xml
-        ${CMAKE_SOURCE_DIR}/systemtest/test_geometry/clean_geometry/inifile9-1.xml
-        ${CMAKE_SOURCE_DIR}/systemtest/test_geometry/clean_geometry/inifile9-2.xml
-        ${CMAKE_SOURCE_DIR}/systemtest/test_geometry/clean_geometry/inifile10.xml
-    )
-    foreach(file ${clean_geometry_tests})
-        get_filename_component(test ${file} NAME_WE)
-        add_test(
-            NAME geometry-${test}
-            COMMAND $<TARGET_FILE:jpscore> ${file}
-        )
-    endforeach()
-
-    file(GLOB_RECURSE test_py_files "${CMAKE_SOURCE_DIR}/systemtest/*runtest_*.py")
-    foreach (file ${test_py_files})
-        get_filename_component(test ${file} NAME_WE)
-        add_test(
-            NAME ${test}
-            COMMAND ${PYTHON_EXECUTABLE} ${file}
-        )
-    endforeach ()
+  add_subdirectory(systemtest)
 endif (BUILD_TESTING)
 
 ################################################################################

--- a/container/build/Dockerfile
+++ b/container/build/Dockerfile
@@ -15,6 +15,12 @@ RUN apt-get update && apt-get install -y wget \
                        python \
                        python-pip
 
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 6084F3CF814B57C1CF12EFD515CF4D18AF4F7421 && \
+    add-apt-repository "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-9 main" && \
+    apt-get update && \
+    apt-get install -y clang-format-9
+
+
 COPY scripts/setup-deps.sh /opt/
 
 RUN cd /opt && CXX=/usr/bin/g++-8 CC=/usr/bin/gcc-8 ./setup-deps.sh

--- a/container/build/Dockerfile
+++ b/container/build/Dockerfile
@@ -1,9 +1,7 @@
 FROM ubuntu:18.04
-RUN apt-get update
+RUN apt-get update && apt-get install -y software-properties-common
 
-RUN apt-get install -y software-properties-common
-
-RUN apt-get install -y wget \
+RUN apt-get update && apt-get install -y wget \
                        git \
                        g++-8 \
                        clang-8 \
@@ -11,8 +9,17 @@ RUN apt-get install -y wget \
                        make \
                        libboost-dev \
                        libcgal-dev \
-                       clang-format-8
+                       clang-format-8 \
+                       python3 \
+                       python3-pip \
+                       python \
+                       python-pip
 
 COPY scripts/setup-deps.sh /opt/
 
 RUN cd /opt && CXX=/usr/bin/g++-8 CC=/usr/bin/gcc-8 ./setup-deps.sh
+
+RUN pip3 install numpy && \
+    pip3 install matplotlib && \
+    pip3 install pandas && \
+    pip install numpy

--- a/systemtest/CMakeLists.txt
+++ b/systemtest/CMakeLists.txt
@@ -1,0 +1,4 @@
+add_subdirectory(test_geometry)
+add_subdirectory(juelich_tests)
+add_subdirectory(rimea_tests)
+add_subdirectory(router_tests)

--- a/systemtest/juelich_tests/CMakeLists.txt
+++ b/systemtest/juelich_tests/CMakeLists.txt
@@ -1,0 +1,27 @@
+add_test(NAME juelich_test-1 COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/systemtest/juelich_tests/test_1/runtest_juelich_1.py)
+add_test(NAME juelich_test-2 COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/systemtest/juelich_tests/test_2/runtest_juelich_2.py)
+add_test(NAME juelich_test-3 COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/systemtest/juelich_tests/test_3/runtest_juelich_3.py)
+add_test(NAME juelich_test-4 COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/systemtest/juelich_tests/test_4/runtest_juelich_4.py)
+add_test(NAME juelich_test-5 COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/systemtest/juelich_tests/test_5/runtest_juelich_5.py)
+add_test(NAME juelich_test-6 COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/systemtest/juelich_tests/test_6/runtest_juelich_6.py)
+add_test(NAME juelich_test-9 COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/systemtest/juelich_tests/test_9/runtest_juelich_9.py)
+add_test(NAME juelich_test-11 COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/systemtest/juelich_tests/test_11/runtest_juelich_11.py)
+add_test(NAME juelich_test-12 COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/systemtest/juelich_tests/test_12/runtest_juelich_12.py)
+add_test(NAME juelich_test-15 COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/systemtest/juelich_tests/test_15/runtest_juelich_15.py)
+set_tests_properties(
+    juelich_test-1
+    juelich_test-2
+    juelich_test-3
+    juelich_test-4
+    juelich_test-5
+    juelich_test-6
+    juelich_test-9
+    juelich_test-11
+    juelich_test-12
+    juelich_test-15
+    PROPERTIES LABELS "CI:FAST")
+
+
+add_test(NAME juelich_test-8 COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/systemtest/juelich_tests/test_8/runtest_juelich_8.py)
+add_test(NAME juelich_test-10 COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/systemtest/juelich_tests/test_10/runtest_juelich_10.py)
+add_test(NAME juelich_test-14 COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/systemtest/juelich_tests/test_14/runtest_juelich_14.py)

--- a/systemtest/rimea_tests/CMakeLists.txt
+++ b/systemtest/rimea_tests/CMakeLists.txt
@@ -1,7 +1,7 @@
 file(GLOB_RECURSE test_py_files "${CMAKE_SOURCE_DIR}/systemtest/rimea_tests/*runtest_*.py")
 foreach (file ${test_py_files})
     get_filename_component(test ${file} NAME_WE)
-    string(REGEX MATCH "[0-9]+" test_number ${file})
+    string(REGEX MATCH "[0-9]+" test_number ${test})
     add_test(
         NAME rimea_test-${test_number}
         COMMAND ${PYTHON_EXECUTABLE} ${file}

--- a/systemtest/rimea_tests/CMakeLists.txt
+++ b/systemtest/rimea_tests/CMakeLists.txt
@@ -1,0 +1,9 @@
+file(GLOB_RECURSE test_py_files "${CMAKE_SOURCE_DIR}/systemtest/rimea_tests/*runtest_*.py")
+foreach (file ${test_py_files})
+    get_filename_component(test ${file} NAME_WE)
+    string(REGEX MATCH "[0-9]+" test_number ${file})
+    add_test(
+        NAME rimea_test-${test_number}
+        COMMAND ${PYTHON_EXECUTABLE} ${file}
+        )
+endforeach ()

--- a/systemtest/router_tests/CMakeLists.txt
+++ b/systemtest/router_tests/CMakeLists.txt
@@ -1,0 +1,9 @@
+file(GLOB_RECURSE test_py_files "${CMAKE_SOURCE_DIR}/systemtest/router_tests/*runtest_*.py")
+foreach (file ${test_py_files})
+    get_filename_component(test ${file} NAME_WE)
+    string(REGEX MATCH "[0-9]+" test_number ${file})
+    add_test(
+        NAME router_test-${test_number}
+        COMMAND ${PYTHON_EXECUTABLE} ${file}
+        )
+endforeach ()

--- a/systemtest/router_tests/CMakeLists.txt
+++ b/systemtest/router_tests/CMakeLists.txt
@@ -1,7 +1,7 @@
 file(GLOB_RECURSE test_py_files "${CMAKE_SOURCE_DIR}/systemtest/router_tests/*runtest_*.py")
 foreach (file ${test_py_files})
     get_filename_component(test ${file} NAME_WE)
-    string(REGEX MATCH "[0-9]+" test_number ${file})
+    string(REGEX MATCH "[0-9]+" test_number ${test})
     add_test(
         NAME router_test-${test_number}
         COMMAND ${PYTHON_EXECUTABLE} ${file}

--- a/systemtest/test_geometry/CMakeLists.txt
+++ b/systemtest/test_geometry/CMakeLists.txt
@@ -13,7 +13,7 @@ list(APPEND clean_geometry_tests
     )
 foreach(file ${clean_geometry_tests})
     get_filename_component(test ${file} NAME_WE)
-    string(REGEX MATCH "[0-9]+[-0-9]*" test_number ${file})
+    string(REGEX MATCH "[0-9]+[-0-9]*" test_number ${test})
     add_test(
         NAME correct_geometry-${test_number}
         COMMAND $<TARGET_FILE:jpscore> ${file}

--- a/systemtest/test_geometry/CMakeLists.txt
+++ b/systemtest/test_geometry/CMakeLists.txt
@@ -1,0 +1,22 @@
+list(APPEND clean_geometry_tests
+    ${CMAKE_SOURCE_DIR}/systemtest/test_geometry/clean_geometry/inifile1.xml
+    ${CMAKE_SOURCE_DIR}/systemtest/test_geometry/clean_geometry/inifile2.xml
+    ${CMAKE_SOURCE_DIR}/systemtest/test_geometry/clean_geometry/inifile3.xml
+    ${CMAKE_SOURCE_DIR}/systemtest/test_geometry/clean_geometry/inifile4.xml
+    ${CMAKE_SOURCE_DIR}/systemtest/test_geometry/clean_geometry/inifile5.xml
+    ${CMAKE_SOURCE_DIR}/systemtest/test_geometry/clean_geometry/inifile6.xml
+    ${CMAKE_SOURCE_DIR}/systemtest/test_geometry/clean_geometry/inifile7.xml
+    ${CMAKE_SOURCE_DIR}/systemtest/test_geometry/clean_geometry/inifile8.xml
+    ${CMAKE_SOURCE_DIR}/systemtest/test_geometry/clean_geometry/inifile9-1.xml
+    ${CMAKE_SOURCE_DIR}/systemtest/test_geometry/clean_geometry/inifile9-2.xml
+    ${CMAKE_SOURCE_DIR}/systemtest/test_geometry/clean_geometry/inifile10.xml
+    )
+foreach(file ${clean_geometry_tests})
+    get_filename_component(test ${file} NAME_WE)
+    string(REGEX MATCH "[0-9]+[-0-9]*" test_number ${file})
+    add_test(
+        NAME correct_geometry-${test_number}
+        COMMAND $<TARGET_FILE:jpscore> ${file}
+        )
+    set_tests_properties(correct_geometry-${test_number} PROPERTIES LABELS "CI:FAST")
+endforeach()


### PR DESCRIPTION
The Goal of this work was to have a single script running tests in TeamCity and on the command line for developers. Additionally the dependencies for TeamCity must be installed in the Docker image.

- Adds python dependencies to docker container used for the test execution on TeamCity
- Restructures CMake
  - Tests are registered in their systemtest folder 
  - Tests can have different tags (e.g "CI:FAST", "CI:SLOW", "FAST", ....)
  - TeamCity will execute all tests matching the tag "CI:FAST" for each PR
  - Later we will add a nightly executing all tests matching "CI"

