### PR TITLE
 Fixes for compilation on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,13 @@ print_var(BUILD_DOC)
 set(JPSFIRE OFF CACHE BOOL "Build with jpsfire support")
 print_var(JPSFIRE)
 
-set(USE_OPENMP ON CACHE BOOL "Build with OpenMP")
+# Due to old OpenMP implementation in MSVC we disable OpenMP on Windows for the moment.
+if(${CMAKE_SYSTEM} MATCHES "Windows")
+    set(USE_OPENMP Off)
+    message(WARNING "OpenMP is disabled on Windows")
+else()
+    set(USE_OPENMP ON CACHE BOOL "Build with OpenMP")
+endif()
 print_var(USE_OPENMP)
 
 set(BUILD_WITH_ASAN OFF CACHE BOOL
@@ -75,8 +81,7 @@ list(APPEND COMMON_COMPILE_OPTIONS
     $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:-Wall>
     $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:-Wextra>
     $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:-fdiagnostics-color=always>
-    $<$<CXX_COMPILER_ID:MSVC>:/W4>
-    $<$<CXX_COMPILER_ID:MSVC>:/WX>
+    $<$<CXX_COMPILER_ID:MSVC>:/W2>
     $<$<CXX_COMPILER_ID:MSVC>:/EHsc>
 )
 
@@ -162,7 +167,7 @@ if(USE_OPENMP)
 else()
     list(APPEND COMMON_COMPILE_OPTIONS
         # Disable warnigns about omp pragmas
-        -Wno-unknown-pragmas
+         $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:-Wno-unknown-pragmas>
     )
 endif()
 

--- a/README.md
+++ b/README.md
@@ -53,9 +53,10 @@ cmake -DCMAKE_BUILD_TYPE=Debug -DUSE_OPENMP=OFF <path-to-cmakelists>
 
 The following configuration flags are available:
 
-##### USE_OPENMP defaults to ON
+##### USE_OPENMP defaults to ON (Disabled on Windows)
 Build `jpscore` with OpenMP support, generation will fail if OpenMP cannot be
 found.
+MSVC only support OpenMP 2.0 Standard and is therefor disabled on Windows.
 
 ##### JPSFIRE defaults to OFF
 Build `jpscore` with jpsfire features

--- a/libcore/src/direction/waiting/WaitingRandom.h
+++ b/libcore/src/direction/waiting/WaitingRandom.h
@@ -29,10 +29,11 @@
 #include "WaitingStrategy.h"
 
 #include <cstdlib>
+#include <ctime>
 
 class WaitingRandom : public WaitingStrategy
 {
-    void Init(Building *) override { std::srand(time(0)); };
+    void Init(Building *) override { std::srand(std::time(0)); };
 
     Point GetWaitingPosition(Room * room, Pedestrian * ped) override;
 };


### PR DESCRIPTION
- Set Windows warning level to 2 and disabled treat warning as error
- Disabled OpenMP on Windows due to old OpenMP Standard used in MSVC
- Fixed missing std namespace and include for time method