### PR TITLE
Now ignores python cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,10 @@ Utest/Validation/*/inifiles*/
 /Utest/router_tests/test_router_7/inifiles/
 /Utest/router_tests/test_router_8/inifiles/
 Matrix.txt
+
+# Python specific ignores
+__pycache__/
+
 # Compiled Object files
 *.slo
 *.lo


### PR DESCRIPTION
Running python systemtests directly or via ctest leaves a python cache
directory in the source tree. These cache directries are now ignored so
that it will not be added by accident.