### PR TITLE
Reintroduce git info to jpsreport

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -224,7 +224,8 @@ else()
     set(GIT_BRANCH "UNKNONW")
 endif()
 
-list(APPEND GIT_BUILD_INFO_DEFINES
+add_library(git-info INTERFACE)
+target_compile_definitions(git-info INTERFACE
     GIT_COMMIT_HASH="${GIT_SHA1}"
     GIT_COMMIT_DATE="${GIT_DATE}"
     GIT_COMMIT_SUBJECT="${GIT_COMMIT_SUBJECT}"

--- a/jpsreport/CMakeLists.txt
+++ b/jpsreport/CMakeLists.txt
@@ -319,11 +319,13 @@ target_link_libraries(report PUBLIC
     tinyxml
     fs
     Boost::boost
+    git-info
 )
 
 target_compile_definitions(report PUBLIC
     PYTHON="${PYTHON_EXECUTABLE}"
     PYTHON_VERSION="${PYTHON_VERSION_STRING}"
+    JPSREPORT_VERSION="${PROJECT_VERSION}"
 )
 
 add_executable(jpsreport

--- a/jpsreport/general/ArgumentParser.cpp
+++ b/jpsreport/general/ArgumentParser.cpp
@@ -102,11 +102,11 @@ void Logs()
     // first logs will go to stdout
     Log->Write("----\nJuPedSim - JPSreport\n");
     Log->Write("Current date   : %s", currentTime.c_str());
-    // Log->Write("Version        : %s", JPSREPORT_VERSION);
+    Log->Write("Version        : %s", JPSREPORT_VERSION);
     Log->Write("Compiler       : %s (%s)", true_cxx.c_str(), true_cxx_ver.c_str());
-    // Log->Write("Commit hash    : %s", GIT_COMMIT_HASH);
-    // Log->Write("Commit date    : %s", GIT_COMMIT_DATE);
-    // Log->Write("Branch         : %s", GIT_BRANCH);
+    Log->Write("Commit hash    : %s", GIT_COMMIT_HASH);
+    Log->Write("Commit date    : %s", GIT_COMMIT_DATE);
+    Log->Write("Branch         : %s", GIT_BRANCH);
     Log->Write("Python         : %s (%s)\n----\n", PYTHON, PYTHON_VERSION);
 }
 

--- a/libcore/CMakeLists.txt
+++ b/libcore/CMakeLists.txt
@@ -199,7 +199,6 @@ target_compile_options(core PRIVATE
 target_compile_definitions(core PUBLIC
     $<$<BOOL:${JPSFIRE}>:JPSFIRE>
     JPSCORE_VERSION="${PROJECT_VERSION}"
-    ${GIT_BUILD_INFO_DEFINES}
 )
 target_link_libraries(core
     Boost::boost
@@ -212,6 +211,7 @@ target_link_libraries(core
     fs
     spdlog::spdlog
     fmt::fmt
+    git-info
 )
 target_include_directories(core PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/src


### PR DESCRIPTION
jpsreport now again properly reports git commit and change when running.
This was a left-over from the integration.

Fixes: #572