### PR TITLE
Remove old style logging

### DIFF
--- a/jpscore/src/main.cpp
+++ b/jpscore/src/main.cpp
@@ -45,9 +45,6 @@
 
 int main(int argc, char ** argv)
 {
-    // default logger
-    Log = new STDIOHandler();
-
     ArgumentParser a;
     if(auto [execution, return_code] = a.Parse(argc, argv);
        execution == ArgumentParser::Execution::ABORT) {
@@ -123,14 +120,9 @@ int main(int argc, char ** argv)
         LOG_INFO("Evac Time {:.2f}s", evacTime);
         LOG_INFO("Realtime Factor {:.2f}x", evacTime / execTime);
         LOG_INFO("Number of Threads {}", config.GetMaxOpenMPThreads());
-        LOG_INFO("Warnings {}", Log->GetWarnings());
-        LOG_INFO("Errors {}", Log->GetErrors());
-        LOG_INFO("Deleted Agents {}", Log->GetDeletedAgents());
     } else {
         LOG_ERROR("Could not start simulation. Check the log for prior errors");
+        return (EXIT_FAILURE);
     }
-    // do the last cleaning
-    delete Log;
-
     return (EXIT_SUCCESS);
 }

--- a/jpsreport/methods/Method_I.cpp
+++ b/jpsreport/methods/Method_I.cpp
@@ -292,7 +292,7 @@ void Method_I::GetIndividualFD(
     }
 }
 
-void Method_I::SetCalculateIndividualFD(bool individualFD)
+void Method_I::SetCalculateIndividualFD(bool /*individualFD*/)
 {
     _calcIndividualFD = true;
 }

--- a/libcore/src/IO/IniFileParser.cpp
+++ b/libcore/src/IO/IniFileParser.cpp
@@ -169,15 +169,6 @@ void IniFileParser::Parse(const fs::path & iniFile)
 
 bool IniFileParser::ParseHeader(TiXmlNode * xHeader)
 {
-    //logfile
-    if(xHeader->FirstChild("logfile")) {
-        const fs::path logPath(xHeader->FirstChild("logfile")->FirstChild()->Value());
-        const fs::path & root(_config->GetProjectRootDir()); // returns an absolute path already
-        const fs::path canonicalPath = fs::weakly_canonical(root / logPath);
-        _config->SetErrorLogFile(canonicalPath);
-        _config->SetLog(2);
-        LOG_INFO("Logfile <{}>", _config->GetErrorLogFile().string());
-    }
     LOG_INFO("JuPedSim - JPScore");
     LOG_INFO("Current date: {} {}", __DATE__, __TIME__);
     LOG_INFO("Version     : {}", JPSCORE_VERSION);

--- a/libcore/src/IO/IniFileParser.h
+++ b/libcore/src/IO/IniFileParser.h
@@ -32,8 +32,6 @@ class TiXmlElement;
 
 class TiXmlNode;
 
-extern OutputHandler * Log;
-
 class IniFileParser
 {
 public:

--- a/libcore/src/IO/OutputHandler.cpp
+++ b/libcore/src/IO/OutputHandler.cpp
@@ -26,85 +26,7 @@
  **/
 #include "OutputHandler.h"
 
-#include <cmath>
 #include <cstdarg> // va_start and va_end
-
-void OutputHandler::incrementWarnings()
-{
-    _nWarnings += 1;
-}
-
-int OutputHandler::GetWarnings()
-{
-    return _nWarnings;
-}
-
-void OutputHandler::incrementErrors()
-{
-    _nErrors += 1;
-}
-
-int OutputHandler::GetErrors()
-{
-    return _nErrors;
-}
-
-
-void OutputHandler::incrementDeletedAgents()
-{
-    _nDeletedAgents += 1;
-}
-
-int OutputHandler::GetDeletedAgents()
-{
-    return _nDeletedAgents;
-}
-
-
-void OutputHandler::Write(const std::string & str)
-{
-    std::cout << std::endl << str;
-}
-
-void OutputHandler::Write(const char * message, ...)
-{
-    char msg[CLENGTH] = "";
-    va_list ap;
-    va_start(ap, message);
-    vsprintf(msg, message, ap);
-    va_end(ap);
-
-    std::string str(msg);
-
-    if(str.find("ERROR") != std::string::npos) {
-        std::cerr << std::endl << msg;
-        std::cerr.flush();
-        incrementErrors();
-    } else if(str.find("WARNING") != std::string::npos) {
-        std::cerr << std::endl << msg;
-        std::cerr.flush();
-        incrementWarnings();
-    } else { // infos
-        std::cout << std::endl << msg;
-        std::cout.flush();
-    }
-}
-
-void STDIOHandler::Write(const std::string & str)
-{
-    if(str.find("ERROR") != std::string::npos) {
-        std::cerr << std::endl << str;
-        std::cerr.flush();
-        incrementErrors();
-    } else if(str.find("WARNING") != std::string::npos) {
-        std::cerr << std::endl << str;
-        std::cerr.flush();
-        incrementWarnings();
-    } else { // infos
-        std::cout << std::endl << str;
-        std::cout.flush();
-    }
-}
 
 FileHandler::FileHandler(const fs::path & path)
 {
@@ -124,12 +46,6 @@ void FileHandler::Write(const std::string & str)
 {
     _pfp << str << std::endl;
     _pfp.flush();
-
-    if(str.find("ERROR") != std::string::npos) {
-        incrementErrors();
-    } else if(str.find("WARNING") != std::string::npos) {
-        incrementWarnings();
-    }
 }
 
 void FileHandler::Write(const char * str_msg, ...)
@@ -141,11 +57,4 @@ void FileHandler::Write(const char * str_msg, ...)
     va_end(ap);
     _pfp << msg << std::endl;
     _pfp.flush();
-
-    std::string str(msg);
-    if(str.find("ERROR") != std::string::npos) {
-        incrementErrors();
-    } else if(str.find("WARNING") != std::string::npos) {
-        incrementWarnings();
-    }
 }

--- a/libcore/src/IO/OutputHandler.h
+++ b/libcore/src/IO/OutputHandler.h
@@ -30,41 +30,16 @@
 #include "general/Macros.h"
 
 #include <fstream>
-#include <iostream>
-#include <vector>
+#include <string>
 
 class OutputHandler
 {
-protected:
-    int _nWarnings;
-    int _nErrors;
-    int _nDeletedAgents;
-
 public:
-    OutputHandler()
-    {
-        _nWarnings      = 0;
-        _nErrors        = 0;
-        _nDeletedAgents = 0;
-    };
-    virtual ~OutputHandler(){};
-
-    int GetWarnings();
-    void incrementWarnings();
-    int GetErrors();
-    void incrementErrors();
-    int GetDeletedAgents();
-    void incrementDeletedAgents();
-
-    virtual void Write(const std::string & str);
-    virtual void Write(const char * string, ...);
+    virtual ~OutputHandler()                     = default;
+    virtual void Write(const std::string & str)  = 0;
+    virtual void Write(const char * string, ...) = 0;
 };
 
-class STDIOHandler : public OutputHandler
-{
-public:
-    void Write(const std::string & str) override;
-};
 
 class FileHandler : public OutputHandler
 {

--- a/libcore/src/JPSfire/A_smoke_sensor/SmokeSensor.cpp
+++ b/libcore/src/JPSfire/A_smoke_sensor/SmokeSensor.cpp
@@ -30,6 +30,7 @@
 #include "JPSfire/generic/FDSMesh.h"
 #include "JPSfire/generic/FDSMeshStorage.h"
 #include "general/Filesystem.h"
+#include "general/Logger.h"
 #include "geometry/Building.h"
 #include "geometry/SubRoom.h"
 #include "pedestrian/Pedestrian.h"
@@ -50,14 +51,13 @@ bool SmokeSensor::LoadJPSfireInfo()
 {
     TiXmlDocument doc(_building->GetProjectFilename().string());
     if(!doc.LoadFile()) {
-        Log->Write("ERROR: \t%s", doc.ErrorDesc());
-        Log->Write("ERROR: \t could not parse the project file");
+        LOG_ERROR("Could not parse project file: {}", doc.ErrorDesc());
         return false;
     }
 
     TiXmlNode * JPSfireNode = doc.RootElement()->FirstChild("JPSfire");
     if(!JPSfireNode) {
-        Log->Write("INFO:\tcould not find any JPSfire information");
+        LOG_INFO("Could not find any JPSfire information");
         return true;
     }
 
@@ -71,9 +71,9 @@ bool SmokeSensor::LoadJPSfireInfo()
             std::string filepath   = file_path.string();
             double updateIntervall = xmltof(JPSfireCompElem->Attribute("update_time"), 0.);
             double finalTime       = xmltof(JPSfireCompElem->Attribute("final_time"), 0.);
-            Log->Write(
-                "INFO:\tJPSfire Module A_smoke_sensor: \n\tdata: %s \n\tupdate time: %.1f s | "
-                "final time: %.1f s",
+            LOG_INFO(
+                "JPSfire Module A_smoke_sensor, tdata: {} tupdate time: {:.1f}s, final time: "
+                "{:.1f}s",
                 filepath.c_str(),
                 updateIntervall,
                 finalTime);

--- a/libcore/src/JPSfire/B_walking_speed/WalkingSpeed.cpp
+++ b/libcore/src/JPSfire/B_walking_speed/WalkingSpeed.cpp
@@ -30,6 +30,7 @@
 #include "JPSfire/generic/FDSMesh.h"
 #include "JPSfire/generic/FDSMeshStorage.h"
 #include "general/Filesystem.h"
+#include "general/Logger.h"
 #include "pedestrian/Pedestrian.h"
 
 #include <tinyxml.h>
@@ -49,14 +50,13 @@ bool WalkingSpeed::LoadJPSfireInfo(const std::string & projectFilename)
 
     TiXmlDocument doc(projectFilename);
     if(!doc.LoadFile()) {
-        Log->Write("ERROR: \t%s", doc.ErrorDesc());
-        Log->Write("ERROR: \t could not parse the project file");
+        LOG_ERROR("Could not parse project file: {}", doc.ErrorDesc());
         return false;
     }
 
     TiXmlNode * JPSfireNode = doc.RootElement()->FirstChild("JPSfire");
     if(!JPSfireNode) {
-        Log->Write("INFO:\tcould not find any JPSfire information");
+        LOG_INFO("Could not find any JPSfire information");
         return true;
     }
 
@@ -78,9 +78,9 @@ bool WalkingSpeed::LoadJPSfireInfo(const std::string & projectFilename)
 
             double updateIntervall = xmltof(JPSfireCompElem->Attribute("update_time"), 0.);
             double finalTime       = xmltof(JPSfireCompElem->Attribute("final_time"), 0.);
-            Log->Write(
-                "INFO:\tJPSfire Module B_walking_speed: \n \tstudy: %s \n\tdata: %s \n\tupdate "
-                "time: %.1f s | final time: %.1f s | irritant: %s",
+            LOG_INFO(
+                "JPSfire Module B_walking_speed, tstudy: {} tdata: {} tupdate time: {:.1f}s, final "
+                "time: {:.1f}s | irritant: {}",
                 study.c_str(),
                 filepath.c_str(),
                 updateIntervall,
@@ -137,7 +137,7 @@ double WalkingSpeed::Jin1978(double & walking_speed, double ExtinctionCoefficien
             walking_speed *
                 (-std::pow(112236.0553, (ExtinctionCoefficient - 0.532027513)) + 0.988158598));
     } else {
-        Log->Write("ERROR:\tSpecify if irritant or non-irritant smoke shall be cosidered");
+        LOG_ERROR("Specify if irritant or non-irritant smoke shall be cosidered");
         exit(EXIT_FAILURE);
     }
     return walking_speed;
@@ -171,9 +171,9 @@ double WalkingSpeed::WalkingInSmoke(const Pedestrian * p, double walking_speed)
         } else if(study == "Fridolf2018") {
             walking_speed = Fridolf2018(walking_speed, ExtinctionCoefficient);
         } else {
-            Log->Write(
-                "ERROR:\tNo study specified. Got <%s>, but only <Frantzich+Nilsson2003> and "
-                "<Jin1978> are available",
+            LOG_ERROR(
+                "No study specified. Got {}, choose from <Frantzich+Nilsson2003>, <Jin1978> or "
+                "<Fridolf2018>",
                 study.c_str());
             exit(EXIT_FAILURE);
         }

--- a/libcore/src/JPSfire/C_toxicity_analysis/ToxicityAnalysis.cpp
+++ b/libcore/src/JPSfire/C_toxicity_analysis/ToxicityAnalysis.cpp
@@ -30,6 +30,7 @@
 #include "JPSfire/generic/FDSMesh.h"
 #include "JPSfire/generic/FDSMeshStorage.h"
 #include "general/Filesystem.h"
+#include "general/Logger.h"
 #include "pedestrian/Pedestrian.h"
 
 #include <tinyxml.h>
@@ -54,14 +55,13 @@ bool ToxicityAnalysis::LoadJPSfireInfo(const std::string projectFilename)
 
     TiXmlDocument doc(projectFilename);
     if(!doc.LoadFile()) {
-        Log->Write("ERROR: \t%s", doc.ErrorDesc());
-        Log->Write("ERROR: \t could not parse the project file");
+        LOG_ERROR("ToxicityAnalysis, could not parse project file: {}", doc.ErrorDesc());
         return false;
     }
 
     TiXmlNode * JPSfireNode = doc.RootElement()->FirstChild("JPSfire");
     if(!JPSfireNode) {
-        Log->Write("INFO:\tcould not find any JPSfire information");
+        LOG_INFO("Could not find any JPSfire information");
         return true;
     }
 
@@ -76,10 +76,10 @@ bool ToxicityAnalysis::LoadJPSfireInfo(const std::string projectFilename)
             double finalTime       = xmltof(JPSfireCompElem->Attribute("final_time"), 0.);
             std::string study      = "";
             std::string irritant   = "";
-            Log->Write(
-                "INFO:\tJPSfire Module C_toxicity_analysis: \n \tdata: %s \n\tupdate time: %.1f s "
-                "| final time: %.1f s",
-                filepath.c_str(),
+            LOG_INFO(
+                "JPSfire Module C_toxicity_analysis, data: {}, update time: {:.1f}s, final time: "
+                "{:.1f}s",
+                filepath,
                 updateIntervall,
                 finalTime);
             //@todo Is there a posibility to pass a variable number of arguments to a function?

--- a/libcore/src/JPSfire/generic/FDSMesh.cpp
+++ b/libcore/src/JPSfire/generic/FDSMesh.cpp
@@ -1,6 +1,7 @@
 #include "FDSMesh.h"
 
 #include "IO/OutputHandler.h"
+#include "general/Logger.h"
 
 #include <cmath>
 #include <cnpy.h>
@@ -187,7 +188,7 @@ void FDSMesh::SetKnotValuesFromFile(const std::string & filename)
     ///open File (reading)
     std::ifstream pFile(filename);
     if(!pFile) {
-        Log->Write("ERROR:\tCould not open FDS slicefile: %s", filename.c_str());
+        LOG_ERROR("Could not open FDS slicefile: {}", filename);
         //return false;
         exit(EXIT_FAILURE);
     }

--- a/libcore/src/JPSfire/generic/FDSMesh.h
+++ b/libcore/src/JPSfire/generic/FDSMesh.h
@@ -4,9 +4,6 @@
 
 #include <string>
 #include <vector>
-//log output
-class OutputHandler;
-extern OutputHandler * Log;
 
 using Matrix = std::vector<std::vector<Knot>>;
 

--- a/libcore/src/JPSfire/generic/FDSMeshStorage.cpp
+++ b/libcore/src/JPSfire/generic/FDSMeshStorage.cpp
@@ -30,6 +30,7 @@
 
 #include "IO/OutputHandler.h"
 #include "general/Filesystem.h"
+#include "general/Logger.h"
 
 
 FDSMeshStorage::FDSMeshStorage() {}
@@ -70,7 +71,7 @@ FDSMeshStorage::FDSMeshStorage(
         CreateFDSMeshes();
         std::cout << "Success!" << std::endl;
     } else {
-        Log->Write("ERROR:\tCould not find directory <%s>\n", _filepath.c_str());
+        LOG_ERROR("Could not find directory {}", _filepath);
         exit(EXIT_FAILURE);
     }
 }
@@ -92,8 +93,7 @@ bool FDSMeshStorage::CreateQuantityList()
         }
     }
     if(_quantitylist.size() == 0) {
-        Log->Write("ERROR:\tCould not find suitable quantities in %s", _filepath.c_str());
-        exit(EXIT_FAILURE);
+        LOG_ERROR("Could not find suitable quantities in {}", _filepath);
         return false;
     }
     std::cout << "_quantitylist.size(): " << _quantitylist.size() << "\n";
@@ -117,7 +117,7 @@ bool FDSMeshStorage::CreateElevationList()
         }
     }
     if(_elevationlist.size() == 0) {
-        Log->Write("ERROR:\tCould not find suitable grid elevations in %s", _filepath.c_str());
+        LOG_ERROR("Could not find suitable grid elevations in {}", _filepath);
         exit(EXIT_FAILURE);
         return false;
     }
@@ -188,9 +188,11 @@ void FDSMeshStorage::CreateTimeList()
         }
 
         if(fs::exists(npz_file) == false) {
-            Log->Write(
-                "ERROR:\tSpecified times are not compliant with JPSfire data " + npz_file.string());
-            std::cout << "\n\nCreateTimeList(): File not found: " << npz_file.string() << std::endl;
+            LOG_ERROR(
+                "Specified times are not compliant with JPSfire data {}. CreateTimeList(): File "
+                "not found: {}",
+                npz_file.string(),
+                npz_file.string());
             exit(EXIT_FAILURE);
         }
         //std::cout << "LEAVING \n" ;

--- a/libcore/src/JPSfire/generic/FDSMeshStorage.h
+++ b/libcore/src/JPSfire/generic/FDSMeshStorage.h
@@ -36,7 +36,6 @@
 
 class Point;
 class OutputHandler;
-extern OutputHandler * Log;
 // Container to store all FDSMeshs. Sorted by simulation's global time
 using FDSMeshContainer = std::unordered_map<std::string, FDSMesh>;
 

--- a/libcore/src/Simulation.cpp
+++ b/libcore/src/Simulation.cpp
@@ -42,7 +42,6 @@
 #include "pedestrian/AgentsSourcesManager.h"
 #include "routing/ff_router/ffRouter.h"
 
-OutputHandler * Log;
 // todo: add these variables to class simulation
 std::map<std::string, std::shared_ptr<TrainType>> TrainTypes;
 std::map<int, std::shared_ptr<TrainTimeTable>> TrainTimeTables;
@@ -85,24 +84,6 @@ long Simulation::GetPedsNumber() const
 
 bool Simulation::InitArgs()
 {
-    switch(_config->GetLog()) {
-        case 0: {
-            break;
-        }
-        case 1: {
-            delete Log;
-            Log = new STDIOHandler();
-            break;
-        }
-        case 2: {
-            delete Log;
-            Log = new FileHandler(_config->GetErrorLogFile());
-        } break;
-        default:
-            LOG_WARNING("Wrong option for Logfile!");
-            return false;
-    }
-
     if(!_config->GetTrajectoriesFile().empty()) {
         switch(_config->GetFileFormat()) {
             case FileFormat::XML:
@@ -314,7 +295,7 @@ void Simulation::UpdateRoutesAndLocations()
 #pragma omp critical(Simulation_Update_pedsToRemove)
             {
                 pedsToRemove.insert(ped);
-                Log->incrementDeletedAgents();
+                // TODO KKZ track deleted peds
             }
         }
 

--- a/libcore/src/events/EventManager.h
+++ b/libcore/src/events/EventManager.h
@@ -41,8 +41,6 @@ class Router;
 class RoutingEngine;
 class OutputHandler;
 
-extern OutputHandler * Log;
-
 class EventManager
 {
 public:

--- a/libcore/src/general/Configuration.h
+++ b/libcore/src/general/Configuration.h
@@ -47,7 +47,6 @@ public:
         _solver           = 1;
         _routingEngine    = std::shared_ptr<RoutingEngine>(new RoutingEngine());
         _maxOpenMPThreads = 1;
-        _log              = 0;
         _seed             = 0;
         _fps              = 8;
         _linkedCellSize   = 2.2;     // meter
@@ -132,10 +131,6 @@ public:
     int GetMaxOpenMPThreads() const { return _maxOpenMPThreads; };
 
     void SetMaxOpenMPThreads(int maxOpenMPThreads) { _maxOpenMPThreads = maxOpenMPThreads; };
-
-    int GetLog() const { return _log; };
-
-    void SetLog(int log) { _log = log; };
 
     unsigned int GetSeed() const { return _seed; };
 
@@ -365,7 +360,6 @@ private:
     int _solver;
     std::shared_ptr<RoutingEngine> _routingEngine;
     int _maxOpenMPThreads;
-    int _log;
     unsigned int _seed;
     double _fps;
     double _linkedCellSize;

--- a/libcore/src/geometry/Line.h
+++ b/libcore/src/geometry/Line.h
@@ -36,9 +36,6 @@
 class OutputHandler;
 class Wall;
 
-// external variables
-extern OutputHandler * Log;
-
 class Line
 {
 private:

--- a/libcore/src/geometry/Room.h
+++ b/libcore/src/geometry/Room.h
@@ -36,9 +36,6 @@
 class OutputHandler;
 class SubRoom;
 
-// external variables
-extern OutputHandler * Log;
-
 class Room
 {
 private:

--- a/libcore/src/pedestrian/AgentsSource.cpp
+++ b/libcore/src/pedestrian/AgentsSource.cpp
@@ -29,6 +29,7 @@
 #include "AgentsSource.h"
 
 #include "Pedestrian.h"
+#include "general/Logger.h"
 
 AgentsSource::AgentsSource(
     int id,
@@ -269,26 +270,30 @@ void AgentsSource::GenerateAgents(std::vector<Pedestrian *> & peds, int count, B
 
 void AgentsSource::Dump() const
 {
-    Log->Write("\n--------------------------");
-    Log->Write("Dumping Source");
-    Log->Write(">> Caption    : %s", this->GetCaption().c_str());
-    Log->Write(">> Source ID  : %d", _id);
-    Log->Write(">> Group ID   : %d", _groupID);
-    Log->Write(">> Frequency  : %d", _frequency);
-    Log->Write(">> Agents Max : %d", _maxAgents);
-    Log->Write(">> Agents Pool: %d", _agents.size());
-    Log->Write(">> Agent id   : %d", this->GetAgentId());
-    Log->Write(">> Time       : %.2f", this->GetPlanTime());
-    Log->Write(">> StartX     : %.2f", this->GetStartX());
-    Log->Write(">> StartY     : %.2f", this->GetStartY());
-    Log->Write(">> Percent    : %.2f", this->GetPercent());
-    Log->Write(">> Rate       : %.2f", this->GetRate());
-    Log->Write(">> N_create   : %d", this->GetChunkAgents());
     auto tmpB = this->GetBoundaries();
-    Log->Write(">> Boundaries : X-axis [%.4f -- %.4f]", tmpB[0], tmpB[1]);
-    Log->Write("                Y-axis [%.4f -- %.4f]", tmpB[2], tmpB[3]);
     auto tmpL = this->GetLifeSpan();
-    Log->Write(">> LifeSpan   : [%d -- %d]", tmpL[0], tmpL[1]);
-    Log->Write("\n--------------------------\n");
-    //getc(stdin);
+    LOG_DEBUG(
+        "Dumping Source: Caption={} SourceID={:d}, GroupID={:d}, Frequency={:d}, AgentsMax={:d}, "
+        "AgentsPool={:d}, AgentID={:d}, Time={:.2f}, Pos=({:.2f},{:.2f}), Percent={:.2f}, "
+        "Rate={:.2f}, N_create={:d}, Boundaries=(XAxis=({:.4f}, {:.4f}), YAxis=({:.4f},{:.4f})), "
+        "LifeSpan=({:d},{:d})",
+        this->GetCaption(),
+        _id,
+        _groupID,
+        _frequency,
+        _maxAgents,
+        _agents.size(),
+        this->GetAgentId(),
+        this->GetPlanTime(),
+        this->GetStartX(),
+        this->GetStartY(),
+        this->GetPercent(),
+        this->GetRate(),
+        this->GetChunkAgents(),
+        tmpB[0],
+        tmpB[1],
+        tmpB[2],
+        tmpB[3],
+        tmpL[0],
+        tmpL[1]);
 }

--- a/libcore/src/pedestrian/AgentsSource.h
+++ b/libcore/src/pedestrian/AgentsSource.h
@@ -37,10 +37,6 @@ class OutputHandler;
 class StartDistribution;
 class Building;
 
-// external variables
-extern OutputHandler * Log;
-
-
 class AgentsSource
 {
 public:

--- a/libcore/src/pedestrian/PedDistributor.cpp
+++ b/libcore/src/pedestrian/PedDistributor.cpp
@@ -28,6 +28,7 @@
 
 #include "IO/PedDistributionParser.h"
 #include "general/Filesystem.h"
+#include "general/Logger.h"
 #include "geometry/SubRoom.h"
 #include "geometry/Wall.h"
 #include "pedestrian/Pedestrian.h"
@@ -79,7 +80,7 @@ const std::vector<std::shared_ptr<AgentsSource>> & PedDistributor::GetAgentsSour
 
 bool PedDistributor::Distribute(Building * building) const
 {
-    Log->Write("INFO: \tInit Distribute");
+    LOG_INFO("Init Distribute");
     int nPeds_is       = 0;
     int nPeds_expected = 0;
 
@@ -122,24 +123,21 @@ bool PedDistributor::Distribute(Building * building) const
                         //empty. May happen if file
                         //is misformed.
                         if(tmpPositions.empty()) {
-                            Log->Write(
-                                "ERROR: \tproblems with file <%s%s>.",
-                                basename.c_str(),
-                                extention.c_str());
+                            LOG_ERROR("problems with file {}{}", basename, extention);
                             return false; //maybe just ignore?
                         } else
                             allFreePosRoom[subroomID] = tmpPositions;
                         fromDirectory = true;
-                        Log->Write(
-                            "INFO: \tDistributing %d pedestrians using file <%s%s>",
+                        LOG_INFO(
+                            "Distributing {:d} pedestrians using file {}{}",
                             dist->GetAgentsNumber(),
-                            basename.c_str(),
-                            extention.c_str());
+                            basename,
+                            extention);
                         break; //leave BOOST_FOREEACH
                     }          //regular file
                 }              // for files
                 if(fromDirectory == false) {
-                    Log->Write("ERROR: \tDistributing pedestrians using file is not successful.");
+                    LOG_ERROR("Distributing pedestrians using file is not successful.");
                     return false;
                 }
             } // check if directory
@@ -197,7 +195,7 @@ bool PedDistributor::Distribute(Building * building) const
             continue;
 
         if(N < 0) {
-            Log->Write("ERROR: \t negative  number of pedestrians!");
+            LOG_ERROR("Negative  number of pedestrians!");
             return false;
         }
 
@@ -205,8 +203,8 @@ bool PedDistributor::Distribute(Building * building) const
 
         int max_pos = allpos.size();
         if(max_pos < N) {
-            Log->Write(
-                "ERROR: \tCannot distribute %d agents in Room %d . Maximum allowed: %d\n",
+            LOG_ERROR(
+                "Cannot distribute {:d} agents in Room {:d} . Maximum allowed: {:d}",
                 N,
                 roomID,
                 allpos.size());
@@ -216,14 +214,14 @@ bool PedDistributor::Distribute(Building * building) const
             continue;
 
         // Distributing
-        Log->Write(
-            "INFO: \tDistributing %d Agents in Room/Subrom [%d/%d]! Maximum allowed: %d",
+        LOG_INFO(
+            "Distributing {:d} Agents in Room/Subrom {:d}/{:d}! Maximum allowed: {:d}",
             N,
             roomID,
             subroomID,
             max_pos);
         DistributeInSubRoom(N, allpos, &pid, dist.get(), building);
-        Log->Write("\t...Done");
+        LOG_INFO("Finished distributing pedestrians");
         nPeds_is += N;
     }
 
@@ -235,7 +233,7 @@ bool PedDistributor::Distribute(Building * building) const
             continue;
         int N = dist->GetAgentsNumber();
         if(N < 0) {
-            Log->Write("ERROR: \t negative or null number of pedestrians! Ignoring");
+            LOG_ERROR("Negative or null number of pedestrians! Ignoring");
             continue;
         }
 
@@ -257,9 +255,9 @@ bool PedDistributor::Distribute(Building * building) const
             max_pos += anz;
         }
         if(max_pos < N) {
-            Log->Write(
-                "ERROR: \t Distribution of %d pedestrians in Room %d not possible! Maximum "
-                "allowed: %d\n",
+            LOG_ERROR(
+                "Distribution of {:d} pedestrians in Room {:d} not possible! Maximum "
+                "allowed: {:d}",
                 N,
                 r->GetID(),
                 max_pos);
@@ -334,10 +332,7 @@ bool PedDistributor::Distribute(Building * building) const
     }
 
     if(nPeds_is != nPeds_expected) {
-        Log->Write(
-            "ERROR:\t only [%d] agents could be distributed out of [%d] requested",
-            nPeds_is,
-            nPeds_expected);
+        LOG_ERROR("Only {:d} of {:d} agents could be distributed", nPeds_is, nPeds_expected);
     }
 
     return (nPeds_is == nPeds_expected);
@@ -514,16 +509,16 @@ PedDistributor::GetPositionsFromFile(std::string filename, int n, std::string un
             continue;
     }
     if(first_ids.size() != (unsigned) n) {
-        Log->Write(
-            "ERROR: \tGetPositionsFromFile: number of peds <%d> does not match number of peds from "
-            "file <%d>",
+        LOG_ERROR(
+            "GetPositionsFromFile: number of peds {:d} does not match number of peds from file "
+            "{:d}",
             n,
             first_ids.size());
 
         positions.clear();
     } else
-        Log->Write(
-            "INFO: \tGetPositionsFromFile: number of peds <%d> in file. To simulate <%d>",
+        LOG_INFO(
+            "GetPositionsFromFile: number of peds {:d} in file. To simulate {:d}",
             first_ids.size(),
             n);
     return positions;

--- a/libcore/src/pedestrian/Pedestrian.cpp
+++ b/libcore/src/pedestrian/Pedestrian.cpp
@@ -28,6 +28,7 @@
 
 #include "JPSfire/generic/FDSMeshStorage.h"
 #include "Knowledge.h"
+#include "general/Logger.h"
 #include "geometry/Building.h"
 #include "geometry/SubRoom.h"
 #include "geometry/WaitingArea.h"
@@ -1051,7 +1052,7 @@ Router * Pedestrian::GetRouter() const
 int Pedestrian::FindRoute()
 {
     if(!_router) {
-        Log->Write("ERROR:\t one or more routers does not exist! Check your router_ids");
+        LOG_ERROR("One or more routers does not exist! Check your router_ids");
         return -1;
     }
     //bool isinsub = (_building->GetAllRooms().at(this->GetRoomID())->GetSubRoom(this->GetSubRoomID())->IsInSubRoom(this));

--- a/libcore/src/pedestrian/StartDistribution.cpp
+++ b/libcore/src/pedestrian/StartDistribution.cpp
@@ -28,6 +28,7 @@
 
 #include "AgentsParameters.h"
 #include "Pedestrian.h"
+#include "general/Logger.h"
 #include "geometry/SubRoom.h"
 
 
@@ -243,15 +244,16 @@ StartDistribution::GenerateAgent(Building * building, int * pid, std::vector<Poi
     }
     if(index == -1) {
         if(positions.size()) {
-            Log->Write(
-                "ERROR:\t Cannot distribute pedestrians in the mentioned area "
-                "[%0.2f,%0.2f,%0.2f,%0.2f]",
+            LOG_ERROR(
+                "Cannot distribute pedestrians in the mentioned area "
+                "[{:2f},{:2f},{:2f},{:2f}], Specifying a subroom_id may help. {:d} positions were "
+                "available. Index {:d}",
                 _xMin,
                 _xMax,
                 _yMin,
-                _yMax);
-            Log->Write("      \t Specifying a subroom_id might help");
-            Log->Write("      \t %d positions were available. Index %d ", positions.size(), index);
+                _yMax,
+                positions.size(),
+                index);
             exit(EXIT_FAILURE);
         }
     } else {
@@ -265,24 +267,22 @@ StartDistribution::GenerateAgent(Building * building, int * pid, std::vector<Poi
             if(building->GetRoom(ped->GetRoomID())
                    ->GetSubRoom(ped->GetSubRoomID())
                    ->IsInSubRoom(start_pos) == false) {
-                Log->Write(
-                    "ERROR: \tStartDistribution::GenerateAgent cannot distribute pedestrian %d in "
-                    "Room %d /Subroom %d at fixed position %s",
+                LOG_ERROR(
+                    "StartDistribution::GenerateAgent cannot distribute pedestrian {:d} in "
+                    "Room {:d} / Subroom {:d} at fixed position {}. Make sure the position is "
+                    "inside the geometry and belongs to the specified room {:d} / subroom {:d}",
                     *pid,
                     GetRoomId(),
                     GetSubroomID(),
-                    start_pos.toString().c_str());
-                Log->Write(
-                    "ERROR: \t Make sure that the position is inside the geometry "
-                    "and belongs to the specified room %d/subroom %d",
+                    start_pos.toString(),
                     ped->GetRoomID(),
                     ped->GetSubRoomID());
                 exit(EXIT_FAILURE);
             }
 
             ped->SetPos(start_pos, true); //true for the initial position
-            Log->Write(
-                "INFO: \t fixed position for ped %d in Room %d %s",
+            LOG_INFO(
+                "fixed position for ped {:d} in Room {:d} {}",
                 *pid,
                 GetRoomId(),
                 start_pos.toString().c_str());
@@ -297,8 +297,8 @@ StartDistribution::GenerateAgent(Building * building, int * pid, std::vector<Poi
 void StartDistribution::SetStartPosition(double x, double y, double z)
 {
     if(_nPeds != 1) {
-        Log->Write("INFO:\t you cannot specify the same start position for many agents");
-        Log->Write("INFO:\t Ignoring the start position");
+        LOG_WARNING("You cannot specify the same start position for many agents. This starting "
+                    "position will be ignored");
         return;
     }
     _startX = x;
@@ -394,8 +394,7 @@ double StartDistribution::GetRiskTolerance()
         if(_distribution_type == "beta") {
             return quantile(_risk_beta_dist, rand_norm);
         }
-        Log->Write(
-            "Warning:\tDistribution Type invalid or not set. Fallback to uniform distribution");
+        LOG_WARNING("Distribution Type invalid or not set. Fallback to uniform distribution");
         return (double) rand_norm; // todo: ar.graf: check if this quick fix executes and why
     }
 }

--- a/libcore/src/routing/RoutingEngine.cpp
+++ b/libcore/src/routing/RoutingEngine.cpp
@@ -26,6 +26,7 @@
  **/
 #include "RoutingEngine.h"
 
+#include "general/Logger.h"
 #include "pedestrian/Pedestrian.h"
 
 RoutingEngine::RoutingEngine() {}
@@ -54,8 +55,7 @@ void RoutingEngine::AddRouter(Router * router)
 {
     for(unsigned int r = 0; r < _routersCollection.size(); r++) {
         if(_routersCollection[r]->GetStrategy() == router->GetStrategy()) {
-            Log->Write("ERROR: \tDuplicate router found with 'id' [%d].", router->GetID());
-            Log->Write("ERROR: \tDouble check your configuration files");
+            LOG_ERROR("Duplicate router found with 'id' [{:d}].", router->GetID());
             exit(EXIT_FAILURE);
         }
     }
@@ -97,7 +97,7 @@ Router * RoutingEngine::GetRouter(int id) const
         if(router->GetID() == id)
             return router;
     }
-    Log->Write("ERROR: \t Could not Find any router with ID:  [%d].", id);
+    LOG_ERROR("Could not Find any router with ID:  [{:d}].", id);
     return /*(Router*)*/ nullptr;
 }
 

--- a/libcore/src/routing/global_shortest/AccessPoint.cpp
+++ b/libcore/src/routing/global_shortest/AccessPoint.cpp
@@ -26,6 +26,8 @@
  **/
 #include "AccessPoint.h"
 
+#include "general/Logger.h"
+
 AccessPoint::AccessPoint(int id, double center[2], double radius)
 {
     _id                = id;
@@ -107,8 +109,7 @@ double AccessPoint::GetDistanceTo(int UID)
 {
     //this is probably a final destination
     if(_mapDestToDist.count(UID) == 0) {
-        Log->Write("ERROR:\tNo route to destination  [ %d ]", UID);
-        Log->Write("ERROR:\tCheck your configuration file");
+        LOG_ERROR("No route to destination  [{:d}]", UID);
         Dump();
         //return 0;
         exit(EXIT_FAILURE);
@@ -136,8 +137,7 @@ int AccessPoint::GetNextApTo(int UID)
 {
     //this is probably a final destination
     if(_mapDestToAp.count(UID) == 0) {
-        Log->Write("ERROR:\tNo route to destination  [ %d ]", UID);
-        Log->Write("ERROR:\t Did you forget to define the goal in the configuration file?");
+        LOG_ERROR("No route to destination  [{:d}]", UID);
         Dump();
         exit(EXIT_FAILURE);
     }

--- a/libcore/src/routing/global_shortest/GlobalRouter.h
+++ b/libcore/src/routing/global_shortest/GlobalRouter.h
@@ -44,9 +44,6 @@ class AccessPoint;
 class Building;
 class OutputHandler;
 
-//log output
-extern OutputHandler * Log;
-
 
 /*!
  * \class GlobalRouter

--- a/libcore/src/routing/quickest/QuickestPathRouter.cpp
+++ b/libcore/src/routing/quickest/QuickestPathRouter.cpp
@@ -26,6 +26,7 @@
  **/
 #include "QuickestPathRouter.h"
 
+#include "general/Logger.h"
 #include "geometry/SubRoom.h"
 #include "geometry/Wall.h"
 #include "mpi/LCGrid.h"
@@ -38,7 +39,7 @@ QuickestPathRouter::~QuickestPathRouter() {}
 
 bool QuickestPathRouter::Init(Building * building)
 {
-    Log->Write("INFO:\tInit Quickest Path Router Engine");
+    LOG_INFO("Init Quickest Path Router Engine");
 
     // prefer path through corridors to path through rooms
     SetEdgeCost(2.0);
@@ -58,7 +59,7 @@ bool QuickestPathRouter::Init(Building * building)
     //WriteGraphGV("routing_graph.gv",FINAL_DEST_OUT,rooms);
     //DumpAccessPoints(1185);
     //exit(0);
-    Log->Write("INFO:\tDone with Quickest Path Router Engine!");
+    LOG_INFO("Done with Quickest Path Router Engine!");
     return true;
 }
 
@@ -280,9 +281,9 @@ bool QuickestPathRouter::SelectReferencePedestrian(
                 *myref = nullptr;
                 *flag  = UNREACHEABLE_EXIT;
                 //done=true; //this line has no effect, cause of return statement below
-                Log->Write(
-                    "ERROR: reference ped cannot be found for ped %d within [%f] "
-                    "m  around the exit [%d]\n",
+                LOG_ERROR(
+                    "reference ped cannot be found for ped {:d} within [{:f}] "
+                    "m  around the exit [{:d}]",
                     myself->GetID(),
                     radius,
                     crossing->GetID());
@@ -560,8 +561,7 @@ double QuickestPathRouter::GetEstimatedTravelTimeVia(Pedestrian * ped, int exiti
     }
 
     if((myref == nullptr) && (flag == REF_PED_FOUND)) {
-        Log->Write("ERROR:\t Fatal Error in Quickest Path Router");
-        Log->Write("      \t reference pedestrians is nullptr");
+        LOG_ERROR("Fatal Error in Quickest Path Router, ref. ped is nullptr");
         time = FLT_MAX;
     }
 
@@ -776,9 +776,9 @@ int QuickestPathRouter::GetBestDefaultRandomExit(Pedestrian * ped)
         return bestAPsID;
     } else {
         if(_building->GetRoom(ped->GetRoomID())->GetCaption() != "outside")
-            Log->Write(
-                "ERROR:\t Cannot find valid destination for ped [%d] located in room [%d] subroom "
-                "[%d] going to destination [%d]",
+            LOG_ERROR(
+                "Cannot find valid destination for ped {:d} located in room {:d} subroom {:d} "
+                "going to destination {:d}",
                 ped->GetID(),
                 ped->GetRoomID(),
                 ped->GetSubRoomID(),
@@ -792,8 +792,7 @@ bool QuickestPathRouter::ParseAdditionalParameters()
 {
     TiXmlDocument doc(_building->GetProjectFilename().string());
     if(!doc.LoadFile()) {
-        Log->Write("ERROR: \t%s", doc.ErrorDesc());
-        Log->Write("ERROR: \t GlobalRouter: could not parse the project file");
+        LOG_ERROR("QuickestPathRouter, could not parse project file: {}", doc.ErrorDesc());
         return false;
     }
 

--- a/libcore/src/routing/quickest/QuickestPathRouter.h
+++ b/libcore/src/routing/quickest/QuickestPathRouter.h
@@ -40,8 +40,6 @@ enum RefSelectionMode { SINGLE = 1, ALL = 2 };
 
 enum DefaultStrategy { LOCAL_SHORTEST = 1, GLOBAL_SHORTEST = 2 };
 
-//log output
-extern OutputHandler * Log;
 /*!
  * \class QuickestPathRouter
  *

--- a/libcore/src/routing/smoke_router/cognitiveMap/cognitivemap.cpp
+++ b/libcore/src/routing/smoke_router/cognitiveMap/cognitivemap.cpp
@@ -1,5 +1,6 @@
 #include "cognitivemap.h"
 
+#include "general/Logger.h"
 #include "geometry/SubRoom.h"
 #include "pedestrian/Pedestrian.h"
 
@@ -303,7 +304,7 @@ double CognitiveMap::ShortestPathDistance(const GraphEdge * edge, const ptrLandm
     VisiLibity::Environment environment(polygons);
     //environment.reverse_holes();
     if(!environment.is_valid()) {
-        Log->Write("Error:\tEnvironment for Visibilitypolygon not valid");
+        LOG_ERROR("Environment for Visibilitypolygon not valid");
         exit(EXIT_FAILURE);
     }
 

--- a/libcore/src/routing/smoke_router/fire_mesh/FireMesh.h
+++ b/libcore/src/routing/smoke_router/fire_mesh/FireMesh.h
@@ -33,9 +33,6 @@
 #include <string>
 #include <vector>
 
-//log output
-extern OutputHandler * Log;
-
 using Matrix = std::vector<std::vector<Knot>>;
 
 class FireMesh

--- a/libcore/src/routing/smoke_router/navigation_graph/GraphEdge.h
+++ b/libcore/src/routing/smoke_router/navigation_graph/GraphEdge.h
@@ -36,9 +36,6 @@ class SubRoom;
 class GraphVertex;
 class Crossing;
 
-//log output
-extern OutputHandler * Log;
-
 /**
  * @brief Graph Edge.
  *

--- a/libcore/src/voronoi-boost/VoronoiPositionGenerator.cpp
+++ b/libcore/src/voronoi-boost/VoronoiPositionGenerator.cpp
@@ -13,6 +13,7 @@ static int global_count = 0;
 //check if all includes are necessary
 #include "../pedestrian/AgentsSourcesManager.h"
 #include "../pedestrian/Pedestrian.h"
+#include "general/Logger.h"
 #include "geometry/Wall.h"
 
 //#include "../pedestrian/StartDistribution.h"
@@ -436,9 +437,8 @@ void VoronoiBestVertexRandMax(
     //now we have the vector of possible vertices and weights and we can choose one randomly
 
     if(partial_sums.empty()) {
-        Log->Write(
-            "Warning: No possible vertices. Maybe BB too small for %d agents?",
-            src->GetChunkAgents());
+        LOG_WARNING(
+            "No possible vertices. Maybe BB too small for {:d} agents?", src->GetChunkAgents());
         //         exit(EXIT_FAILURE); // maybe not exit, just ignore
         // dis = 0;
         return;
@@ -516,9 +516,8 @@ void VoronoiBestVertexGreedy(
             }
     }
     if(possible_vertices.empty()) {
-        Log->Write(
-            "Warning: No possible vertices. Maybe BB too small for %d agents?",
-            src->GetChunkAgents());
+        LOG_WARNING(
+            "No possible vertices. Maybe BB too small for {:d} agents?", src->GetChunkAgents());
         //         exit(EXIT_FAILURE); // maybe not exit, just ignore
         dis = 0;
         return;


### PR DESCRIPTION
HoHoHo! Christmas is a earlyt this year!
```
    ~*~
    /@\
   /%;@\
  o/@,%\o
  /%;`@,\
 '^^^H^^^`
```
Old style logging had several issues and hence has been replaced by
spdlog. New-style logging is already part of the codebase and this
commit removes the remaining old style log calls. Further the log option
is now also gone from the config as logging is now configured ad-hoc
from the command line only.

Fixes: #488