### PR TITLE
Replace raw pointer array with map for neighborhood computation.

### DIFF
--- a/libcore/src/Simulation.cpp
+++ b/libcore/src/Simulation.cpp
@@ -455,10 +455,10 @@ double Simulation::RunBody(double maxSimTime)
         //process the queue for incoming pedestrians
         ProcessAgentsQueue();
 
-        if(t > Pedestrian::GetMinPremovementTime()) {
-            //update the linked cells
-            _building->UpdateGrid();
+        //update the linked cells
+        _building->UpdateGrid();
 
+        if(t > Pedestrian::GetMinPremovementTime()) {
             // update the positions
             _operationalModel->ComputeNextTimeStep(t, _deltaT, _building.get(), _periodic);
 
@@ -852,7 +852,6 @@ void Simulation::ProcessAgentsQueue()
     for(auto && ped : peds) {
         _building->AddPedestrian(ped);
     }
-    _building->UpdateGrid();
 }
 
 void Simulation::UpdateDoorticks() const {

--- a/libcore/src/mpi/LCGrid.h
+++ b/libcore/src/mpi/LCGrid.h
@@ -59,7 +59,7 @@ private:
     double _gridXmin, _gridXmax, _gridYmin, _gridYmax;
     /// for convenience
     /// will be delete in next versions
-    Pedestrian ** _localPedsCopy;
+    std::map<int, Pedestrian *> _localPedsCopy;
     ///total number of pedestrians
     int _nPeds;
 
@@ -86,11 +86,6 @@ public:
       *Update the cells occupation
       */
     void Update(const std::vector<Pedestrian *> & peds);
-
-    /**
-      * Update this special pedestrian on the grid
-      */
-    void Update(Pedestrian * ped);
 
     /**
       * Make a shallow copy of the initial pedestrians distribution


### PR DESCRIPTION
Instead of using the raw pointer array a map is used for the local copy of the pedestrians for the neighborhood computation. Maybe solving the issue with incredible large memory usuage.

@Ozaq could you send me the simulation with the large memory usage?