### PR TITLE
Adds output path option to the inifile header

### DIFF
--- a/docs/pages/jpscore/jpscore_inifile.md
+++ b/docs/pages/jpscore/jpscore_inifile.md
@@ -6,7 +6,7 @@ sidebar: jupedsim_sidebar
 folder: jpscore
 permalink: jpscore_inifile.html
 summary:  The project file where the settings for a jpscore simulation are defined. Within this file properties of pedestrians, model parameters, etc can be given.
-last_updated: Dec 31, 2019
+last_updated: Jan 23, 2020
 ---
 
 ## Header
@@ -36,7 +36,12 @@ The header comprises the following elements:
 
 -   `<show_statistics>true</show_statistics>` Show different aggregate statistics e.g. the usage of the doors. (default: false)
 
-
+-   `<output path="output_directory" />`
+    The name and location where the results of the simulation should be stored. The program creates a folder with the 
+    given name and copies all needed files of the simulation to this folder. Additionally the file names in the ini and 
+    geometry file are updated. Resulting in a folder with the results and everything to reproduce a specific simulation. 
+    If no output path is given the folder is named `results`. 
+     
 -  The trajectory file
 
 ```bash

--- a/docs/pages/jpscore/jpscore_introduction.md
+++ b/docs/pages/jpscore/jpscore_introduction.md
@@ -5,7 +5,7 @@ tags: [jpscore, getting_started]
 sidebar: jupedsim_sidebar
 permalink: jpscore_introduction.html
 summary: jpscore is the simulation module of JuPedSim. It's a command line tool to simulate the evacuate of pedestrians in continuous space.
-last_updated: 20, December 2019
+last_updated: Jan 23, 2020
 toc: false
 ---
 
@@ -48,10 +48,10 @@ Taking the 7th demo as input, we run a simulation as follows:
  ./bin/jpscore  demos/corner_ini.xml
 ```
 
-which produces a trajectory file in the same directory. This can be visualized with `jpsvis`
+which produces a trajectory file in the folder `results` in the same directory. This can be visualized with `jpsvis`
 
 ```bash
- jpsvis demos/scenario_7_floorfield/Kobes_traj.xml
+ jpsvis demos/scenario_7_floorfield/results/Kobes_traj.xml
 ```
 
 

--- a/libcore/src/IO/GeoFileParser.cpp
+++ b/libcore/src/IO/GeoFileParser.cpp
@@ -311,6 +311,7 @@ bool GeoFileParser::LoadGeometry(Building * building)
     } // xTransNode
     LOG_INFO("Loading building file successful.");
 
+    ParseExternalFiles(*xRootNode);
     //everything went fine
     return true;
 }
@@ -1091,6 +1092,20 @@ std::shared_ptr<TrainType> GeoFileParser::parseTrainTypeNode(TiXmlElement * e)
         doors,
     });
     return Type;
+}
+
+bool GeoFileParser::ParseExternalFiles(const TiXmlNode & mainNode)
+{
+    // read external transition file
+    if(mainNode.FirstChild("transitions") &&
+       mainNode.FirstChild("transitions")->FirstChild("file")) {
+        fs::path transitionFile =
+            _configuration->GetProjectRootDir() /
+            mainNode.FirstChild("transitions")->FirstChild("file")->FirstChild()->Value();
+        _configuration->SetTransitionFile(fs::weakly_canonical(transitionFile));
+    }
+
+    return true;
 }
 
 GeoFileParser::~GeoFileParser() {}

--- a/libcore/src/IO/GeoFileParser.h
+++ b/libcore/src/IO/GeoFileParser.h
@@ -47,6 +47,7 @@ public:
     bool LoadTrainType(Building * building, TiXmlElement * xRootNode);
     std::shared_ptr<TrainType> parseTrainTypeNode(TiXmlElement * e);
     std::shared_ptr<TrainTimeTable> parseTrainTimeTableNode(TiXmlElement * e);
+    bool ParseExternalFiles(const TiXmlNode & mainNode);
 
 private:
     Configuration * _configuration;

--- a/libcore/src/IO/IniFileParser.cpp
+++ b/libcore/src/IO/IniFileParser.cpp
@@ -159,6 +159,7 @@ void IniFileParser::Parse(const fs::path & iniFile)
     if(!ParseRoutingStrategies(xRouters, xAgentDistri))
         throw std::logic_error("Error while parsing routing strategies.");
 
+    ParseExternalFiles(*xMainNode);
     LOG_INFO("Parsing the project file completed");
 }
 
@@ -1233,5 +1234,69 @@ bool IniFileParser::ParseFfOpts(const TiXmlNode & strategyNode)
         else
             LOG_INFO("UseWAD: no");
     }
+    return true;
+}
+
+bool IniFileParser::ParseExternalFiles(const TiXmlNode & mainNode)
+{
+    // read external traffic constraints file name
+    if(mainNode.FirstChild("traffic_constraints") &&
+       mainNode.FirstChild("traffic_constraints")->FirstChild("file")) {
+        fs::path trafficFile =
+            _config->GetProjectRootDir() /
+            mainNode.FirstChild("traffic_constraints")->FirstChild("file")->FirstChild()->Value();
+        _config->SetTrafficContraintFile(fs::weakly_canonical(trafficFile));
+    }
+
+    // read external goals file name
+    if(mainNode.FirstChild("routing") && mainNode.FirstChild("routing")->FirstChild("goals") &&
+       mainNode.FirstChild("routing")->FirstChild("goals")->FirstChild("file")) {
+        fs::path goalFile = _config->GetProjectRootDir() / mainNode.FirstChild("routing")
+                                                               ->FirstChild("goals")
+                                                               ->FirstChild("file")
+                                                               ->FirstChild()
+                                                               ->Value();
+        _config->SetGoalFile(fs::weakly_canonical(goalFile));
+    }
+
+    // read external sources file name
+    if(mainNode.FirstChild("agents") &&
+       mainNode.FirstChild("agents")->FirstChild("agents_sources") &&
+       mainNode.FirstChild("agents")->FirstChild("agents_sources")->FirstChild("file")) {
+        fs::path sourceFile = _config->GetProjectRootDir() / mainNode.FirstChild("agents")
+                                                                 ->FirstChild("agents_sources")
+                                                                 ->FirstChild("file")
+                                                                 ->FirstChild()
+                                                                 ->Value();
+        _config->SetSourceFile(fs::weakly_canonical(sourceFile));
+    }
+
+    // read external event file name
+    if(mainNode.FirstChild("events_file")) {
+        fs::path eventFile = _config->GetProjectRootDir() /
+                             mainNode.FirstChild("events_file")->FirstChild()->Value();
+        _config->SetEventFile(fs::weakly_canonical(eventFile));
+    } else if(
+        mainNode.FirstChild("header") && mainNode.FirstChild("header")->FirstChild("events_file")) {
+        fs::path eventFile =
+            _config->GetProjectRootDir() /
+            mainNode.FirstChild("header")->FirstChild("events_file")->FirstChild()->Value();
+        _config->SetEventFile(fs::weakly_canonical(eventFile));
+    }
+
+    // read external schedule file name
+    if(mainNode.FirstChild("schedule_file")) {
+        fs::path scheduleFile = _config->GetProjectRootDir() /
+                                mainNode.FirstChild("schedule_file")->FirstChild()->Value();
+        _config->SetScheduleFile(fs::weakly_canonical(scheduleFile));
+    } else if(
+        mainNode.FirstChild("header") &&
+        mainNode.FirstChild("header")->FirstChild("schedule_file")) {
+        fs::path scheduleFile =
+            _config->GetProjectRootDir() /
+            mainNode.FirstChild("header")->FirstChild("schedule_file")->FirstChild()->Value();
+        _config->SetScheduleFile(fs::weakly_canonical(scheduleFile));
+    }
+
     return true;
 }

--- a/libcore/src/IO/IniFileParser.h
+++ b/libcore/src/IO/IniFileParser.h
@@ -67,6 +67,8 @@ private:
 
     bool ParseFfOpts(const TiXmlNode & strategyNode);
 
+    bool ParseExternalFiles(const TiXmlNode & xMain);
+
     Configuration * _config;
     int _model;
     std::shared_ptr<DirectionStrategy> _directionStrategy;

--- a/libcore/src/Simulation.cpp
+++ b/libcore/src/Simulation.cpp
@@ -42,6 +42,8 @@
 #include "pedestrian/AgentsSourcesManager.h"
 #include "routing/ff_router/ffRouter.h"
 
+#include <tinyxml.h>
+
 // TODO: add these variables to class simulation
 std::map<std::string, std::shared_ptr<TrainType>> TrainTypes;
 std::map<int, std::shared_ptr<TrainTimeTable>> TrainTimeTables;
@@ -847,6 +849,7 @@ void Simulation::RunFooter()
 {
     // Copy input files used for simulation to output folder for reproducibility
     CopyInputFilesToOutPath();
+    UpdateOutputFiles();
 
     _iod->WriteFooter();
 }
@@ -857,8 +860,152 @@ void Simulation::CopyInputFilesToOutPath()
         _config->GetProjectRootDir() / _config->GetGeometryFile(),
         _config->GetOutputPath(),
         fs::copy_options::overwrite_existing);
+
     fs::copy(
         _config->GetProjectFile(), _config->GetOutputPath(), fs::copy_options::overwrite_existing);
+
+    CopyInputFileToOutPath(_config->GetTrafficContraintFile());
+    CopyInputFileToOutPath(_config->GetGoalFile());
+    CopyInputFileToOutPath(_config->GetTransitionFile());
+    CopyInputFileToOutPath(_config->GetEventFile());
+    CopyInputFileToOutPath(_config->GetScheduleFile());
+    CopyInputFileToOutPath(_config->GetSourceFile());
+}
+
+void Simulation::CopyInputFileToOutPath(fs::path file)
+{
+    if(!file.empty() && fs::exists(file)) {
+        fs::copy(file, _config->GetOutputPath(), fs::copy_options::overwrite_existing);
+    }
+}
+
+void Simulation::UpdateOutputFiles()
+{
+    UpdateOutputIniFile();
+    UpdateOutputGeometryFile();
+}
+
+void Simulation::UpdateOutputIniFile()
+{
+    fs::path iniOutputPath = _config->GetOutputPath() / _config->GetProjectFile().filename();
+
+    TiXmlDocument iniOutput(iniOutputPath.string());
+
+    if(!iniOutput.LoadFile()) {
+        LOG_ERROR("Could not parse the ini file.");
+        LOG_ERROR("{}", iniOutput.ErrorDesc());
+    }
+    TiXmlElement * mainNode = iniOutput.RootElement();
+
+    // update geometry file name
+    if(mainNode->FirstChild("geometry")) {
+        mainNode->FirstChild("geometry")
+            ->FirstChild()
+            ->SetValue(_config->GetGeometryFile().filename().string());
+    } else if(
+        mainNode->FirstChild("header") && mainNode->FirstChild("header")->FirstChild("geometry")) {
+        mainNode->FirstChild("header")
+            ->FirstChild("geometry")
+            ->FirstChild()
+            ->SetValue(_config->GetGeometryFile().filename().string());
+    }
+
+    // update new traffic constraint file name
+    if(!_config->GetTrafficContraintFile().empty()) {
+        if(mainNode->FirstChild("traffic_constraints") &&
+           mainNode->FirstChild("traffic_constraints")->FirstChild("file")) {
+            mainNode->FirstChild("traffic_constraints")
+                ->FirstChild("file")
+                ->FirstChild()
+                ->SetValue(_config->GetTrafficContraintFile().filename().string());
+        }
+    }
+
+    // update new goal file name
+    if(!_config->GetGoalFile().empty()) {
+        if(mainNode->FirstChild("routing") &&
+           mainNode->FirstChild("routing")->FirstChild("goals") &&
+           mainNode->FirstChild("routing")->FirstChild("goals")->FirstChild("file")) {
+            mainNode->FirstChild("routing")
+                ->FirstChild("goals")
+                ->FirstChild("file")
+                ->FirstChild()
+                ->SetValue(_config->GetGoalFile().filename().string());
+        }
+    }
+
+    // update new source file name
+    if(!_config->GetSourceFile().empty()) {
+        if(mainNode->FirstChild("agents") &&
+           mainNode->FirstChild("agents")->FirstChild("agents_sources") &&
+           mainNode->FirstChild("agents")->FirstChild("agents_sources")->FirstChild("file")) {
+            mainNode->FirstChild("agents")
+                ->FirstChild("agents_sources")
+                ->FirstChild("file")
+                ->FirstChild()
+                ->SetValue(_config->GetSourceFile().filename().string());
+        }
+    }
+
+    // update new event file name
+    if(!_config->GetEventFile().empty()) {
+        if(mainNode->FirstChild("events_file")) {
+            mainNode->FirstChild("events_file")
+                ->FirstChild()
+                ->SetValue(_config->GetEventFile().filename().string());
+        } else if(
+            mainNode->FirstChild("header") &&
+            mainNode->FirstChild("header")->FirstChild("events_file")) {
+            mainNode->FirstChild("header")
+                ->FirstChild("events_file")
+                ->FirstChild()
+                ->SetValue(_config->GetEventFile().filename().string());
+        }
+    }
+
+    // update new schedule file name
+    if(!_config->GetScheduleFile().empty()) {
+        if(mainNode->FirstChild("schedule_file")) {
+            mainNode->FirstChild("schedule_file")
+                ->FirstChild()
+                ->SetValue(_config->GetScheduleFile().filename().string());
+
+        } else if(
+            mainNode->FirstChild("header") &&
+            mainNode->FirstChild("header")->FirstChild("schedule_file")) {
+            mainNode->FirstChild("header")
+                ->FirstChild("schedule_file")
+                ->FirstChild()
+                ->SetValue(_config->GetScheduleFile().filename().string());
+        }
+    }
+
+    iniOutput.SaveFile(iniOutputPath.string());
+}
+
+void Simulation::UpdateOutputGeometryFile()
+{
+    fs::path geoOutputPath = _config->GetOutputPath() / _config->GetGeometryFile().filename();
+
+    TiXmlDocument geoOutput(geoOutputPath.string());
+
+    if(!geoOutput.LoadFile()) {
+        LOG_ERROR("Could not parse the ini file.");
+        LOG_ERROR("{}", geoOutput.ErrorDesc());
+    }
+    TiXmlElement * mainNode = geoOutput.RootElement();
+
+    if(!_config->GetTransitionFile().empty()) {
+        if(mainNode->FirstChild("transitions") &&
+           mainNode->FirstChild("transitions")->FirstChild("file")) {
+            mainNode->FirstChild("transitions")
+                ->FirstChild("file")
+                ->FirstChild()
+                ->SetValue(_config->GetTransitionFile().filename().string());
+        }
+    }
+
+    geoOutput.SaveFile(geoOutputPath.string());
 }
 
 void Simulation::ProcessAgentsQueue()

--- a/libcore/src/Simulation.cpp
+++ b/libcore/src/Simulation.cpp
@@ -362,6 +362,9 @@ void Simulation::PrintStatistics(double simTime)
                 statsfile += '_';
             }
             statsfile += _config->GetOriginalTrajectoriesFile().filename().replace_extension("txt");
+
+            statsfile = _config->GetOutputPath() / statsfile;
+
             LOG_INFO("More Information in the file: {}", statsfile.string());
             {
                 FileHandler statOutput(statsfile);
@@ -842,7 +845,20 @@ bool Simulation::correctGeometry(
 
 void Simulation::RunFooter()
 {
+    // Copy input files used for simulation to output folder for reproducibility
+    CopyInputFilesToOutPath();
+
     _iod->WriteFooter();
+}
+
+void Simulation::CopyInputFilesToOutPath()
+{
+    fs::copy(
+        _config->GetProjectRootDir() / _config->GetGeometryFile(),
+        _config->GetOutputPath(),
+        fs::copy_options::overwrite_existing);
+    fs::copy(
+        _config->GetProjectFile(), _config->GetOutputPath(), fs::copy_options::overwrite_existing);
 }
 
 void Simulation::ProcessAgentsQueue()

--- a/libcore/src/Simulation.cpp
+++ b/libcore/src/Simulation.cpp
@@ -856,10 +856,13 @@ void Simulation::RunFooter()
 
 void Simulation::CopyInputFilesToOutPath()
 {
-    fs::copy(
-        _config->GetProjectRootDir() / _config->GetGeometryFile(),
-        _config->GetOutputPath(),
-        fs::copy_options::overwrite_existing);
+    // In the case we stored the corrected Geometry already in the output path we do not need to copy it again
+    if(_config->GetOutputPath() != _config->GetGeometryFile().parent_path()) {
+        fs::copy(
+            _config->GetProjectRootDir() / _config->GetGeometryFile(),
+            _config->GetOutputPath(),
+            fs::copy_options::overwrite_existing);
+    }
 
     fs::copy(
         _config->GetProjectFile(), _config->GetOutputPath(), fs::copy_options::overwrite_existing);

--- a/libcore/src/Simulation.h
+++ b/libcore/src/Simulation.h
@@ -133,6 +133,13 @@ public:
     void RunFooter();
 
     /**
+     * Copy all Input Files used to the output path.
+     *
+     * This backs up the input files and makes reproducible results possible.
+     */
+    void CopyInputFilesToOutPath();
+
+    /**
      * Run a standard simulation
      * @return the total simulated/evacuation time
      */

--- a/libcore/src/Simulation.h
+++ b/libcore/src/Simulation.h
@@ -140,6 +140,19 @@ public:
     void CopyInputFilesToOutPath();
 
     /**
+     * Helper function to copy a specific file to the output path.
+     *
+     * @param file File to be copied.
+     */
+    void CopyInputFileToOutPath(fs::path file);
+
+    void UpdateOutputIniFile();
+    void UpdateOutputGeometryFile();
+    /**
+     * Updates the paths to external files in the ini and geometry file in output path.
+     */
+    void UpdateOutputFiles();
+    /**
      * Run a standard simulation
      * @return the total simulated/evacuation time
      */

--- a/libcore/src/general/Configuration.h
+++ b/libcore/src/general/Configuration.h
@@ -325,6 +325,33 @@ public:
 
     void SetGeometryFile(const fs::path & geometryFile) { _geometryFile = geometryFile; };
 
+    const fs::path & GetTransitionFile() const { return _transitionFile; }
+
+    void SetTransitionFile(const fs::path & transitionFile) { _transitionFile = transitionFile; }
+
+    const fs::path & GetGoalFile() const { return _goalFile; }
+
+    void SetGoalFile(const fs::path & goalFile) { _goalFile = goalFile; }
+
+    const fs::path & GetSourceFile() const { return _sourceFile; }
+
+    void SetSourceFile(const fs::path & sourceFile) { _sourceFile = sourceFile; }
+
+    const fs::path & GetTrafficContraintFile() const { return _trafficContraintFile; }
+
+    void SetTrafficContraintFile(const fs::path & trafficContraintFile)
+    {
+        _trafficContraintFile = trafficContraintFile;
+    }
+
+    const fs::path & GetEventFile() const { return _eventFile; }
+
+    void SetEventFile(const fs::path & eventFile) { _eventFile = eventFile; }
+
+    const fs::path & GetScheduleFile() const { return _scheduleFile; }
+
+    void SetScheduleFile(const fs::path & scheduleFile) { _scheduleFile = scheduleFile; }
+
     const fs::path & GetProjectRootDir() const { return _projectRootDir; };
 
     void SetProjectRootDir(const fs::path & projectRootDir) { _projectRootDir = projectRootDir; };
@@ -406,6 +433,12 @@ private:
     fs::path _errorLogFile;
     fs::path _projectFile;
     fs::path _geometryFile;
+    fs::path _transitionFile;
+    fs::path _goalFile;
+    fs::path _sourceFile;
+    fs::path _trafficContraintFile;
+    fs::path _eventFile;
+    fs::path _scheduleFile;
     fs::path _projectRootDir;
     fs::path _outputPath;
     bool _showStatistics;

--- a/libcore/src/general/Configuration.h
+++ b/libcore/src/general/Configuration.h
@@ -286,6 +286,26 @@ public:
         _trajectoriesFile = trajectoriesFile;
     };
 
+    const fs::path & GetOutputPath() const { return _outputPath; };
+
+    void SetOutputPath(const fs::path & outputDir) { _outputPath = outputDir; };
+
+    void ConfigureOutputPath()
+    {
+        // Set default name if none was set
+        if(_outputPath.empty()) {
+            _outputPath = "results";
+        }
+
+        // make absolute path
+        if(_outputPath.is_relative()) {
+            _outputPath = fs::absolute(_outputPath);
+        }
+
+        // checks if directory exists, otherwise creates it.
+        fs::create_directories(_outputPath);
+    }
+
     const fs::path & GetOriginalTrajectoriesFile() const { return _originalTrajectoriesFile; };
 
     void SetOriginalTrajectoriesFile(const fs::path & trajectoriesFile)
@@ -387,6 +407,7 @@ private:
     fs::path _projectFile;
     fs::path _geometryFile;
     fs::path _projectRootDir;
+    fs::path _outputPath;
     bool _showStatistics;
 
     mutable RandomNumberGenerator _rdGenerator;

--- a/libcore/src/geometry/Building.cpp
+++ b/libcore/src/geometry/Building.cpp
@@ -723,7 +723,7 @@ bool Building::correct() const
     }         //r
 
     if(removed) {
-        fs::path newGeometryFile = GetGeometryFilename();
+        fs::path newGeometryFile = GetConfig()->GetOutputPath() / GetGeometryFilename().filename();
         fs::path newFilename("correct_");
         newFilename += newGeometryFile.filename();
         newGeometryFile.replace_filename(newFilename);

--- a/libcore/src/routing/ff_router/UnivFFviaFM.cpp
+++ b/libcore/src/routing/ff_router/UnivFFviaFM.cpp
@@ -1539,8 +1539,8 @@ void UnivFFviaFM::SetSpeedMode(int speedMode)
 
 void UnivFFviaFM::WriteFF(const fs::path & filename, std::vector<int> targetID)
 {
-    fs::create_directory(_configuration->GetProjectRootDir() / "ff_vtk_files");
-    auto floorfieldFile = _configuration->GetProjectRootDir() / "ff_vtk_files" / filename;
+    fs::create_directory(_configuration->GetOutputPath() / "ff_vtk_files");
+    auto floorfieldFile = _configuration->GetOutputPath() / "ff_vtk_files" / filename;
     LOG_INFO(
         "Write Floorfield to file: {:s} with {:d} targets.",
         floorfieldFile.string().c_str(),


### PR DESCRIPTION
Using `<output path="output_directory" />` the output path can be
set. The default value is `results`. This path can be relative to the
current directory (where the simulation is executed) or absolute.

All result files (trajectories and statistics) will be created in this
directory. Additionally the input files will be copied to this
path. After the simulation this folder contains all files needed to
reproduce the simulation.

Currently the folder will be overwritten if it already exists.