### PR TITLE
Removes boost filesystem used on MacOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,19 +95,12 @@ find_package(spdlog 1.3 REQUIRED CONFIG)
 # CLI11
 find_package(CLI11 1.8 REQUIRED CONFIG)
 
-# CMakes find_pacakge has no support for generator expressions hence we have to
-# do this the hard way
-if(${CMAKE_SYSTEM} MATCHES "Darwin")
-    list(APPEND BOOST_COMPONENTS
-        filesystem
-    )
-endif()
+# Boost
 find_package(Boost 1.65 REQUIRED ${BOOST_COMPONENTS})
 
-# boost filesystem / std::filesystem
+# std::filesystem needs to be linked on gcc < 9
 add_library(fs INTERFACE)
 target_link_libraries(fs INTERFACE
-    $<$<PLATFORM_ID:Darwin>:Boost::filesystem>
     $<$<PLATFORM_ID:Linux>:stdc++fs>
 )
 

--- a/libcore/CMakeLists.txt
+++ b/libcore/CMakeLists.txt
@@ -15,7 +15,6 @@ set(source_files
     src/events/Event.cpp
     src/events/EventManager.cpp
     src/general/ArgumentParser.cpp
-    src/general/Filesystem.cpp
     src/general/Logger.cpp
     src/geometry/Building.cpp
     src/geometry/Crossing.cpp

--- a/libcore/src/Simulation.cpp
+++ b/libcore/src/Simulation.cpp
@@ -469,13 +469,18 @@ double Simulation::RunBody(double maxSimTime)
             //update quickestRouter
             if(geometryChanged) {
                 // debug
-                const std::string prefix = "tmp_" + std::to_string(t) + "_";
-                auto changedGeometryFile =
-                    add_prefix_to_filename(prefix, _config->GetGeometryFile());
-                std::cout << "\nUpdate geometry. New  geometry --> " << changedGeometryFile << "\n";
+                fs::path new_filename("tmp_" + std::to_string(t) + "_");
+                new_filename += _config->GetGeometryFile().filename();
+                fs::path changedGeometryFile = _config->GetGeometryFile();
 
-                std::cout << "Enter correctGeometry: Building Has "
-                          << _building->GetAllTransitions().size() << " Transitions\n";
+                changedGeometryFile.replace_filename(new_filename);
+
+                LOG_INFO("Update geometry. New  geometry --> {}", changedGeometryFile.string());
+
+                LOG_INFO(
+                    "Enter correctGeometry: Building Has {} Transitions.",
+                    _building->GetAllTransitions().size());
+
                 _building->SaveGeometry(changedGeometryFile);
                 _building->GetConfig()->GetDirectionManager()->GetDirectionStrategy()->Init(
                     _building.get());

--- a/libcore/src/general/Filesystem.cpp
+++ b/libcore/src/general/Filesystem.cpp
@@ -1,10 +1,1 @@
 #include "Filesystem.h"
-
-// Unfortunately we cannot use path::replace_filename since this is not
-// implemented in boost::filesystem
-fs::path add_prefix_to_filename(const std::string & prefix, const fs::path & file)
-{
-    std::string newFilename{prefix};
-    newFilename.append(file.filename().string());
-    return file.parent_path() /= newFilename;
-}

--- a/libcore/src/general/Filesystem.cpp
+++ b/libcore/src/general/Filesystem.cpp
@@ -1,1 +1,0 @@
-#include "Filesystem.h"

--- a/libcore/src/general/Filesystem.h
+++ b/libcore/src/general/Filesystem.h
@@ -1,18 +1,4 @@
 #pragma once
 
-#ifdef __APPLE__
-#include <boost/filesystem.hpp>
-namespace fs = boost::filesystem;
-#else
 #include <filesystem>
 namespace fs = std::filesystem;
-#endif
-
-/**
- * Add a prefix to a filename.
- *
- * @param prefix to add
- * @param file to prefix.
- * @return path wih new prefix for the last element
- */
-fs::path add_prefix_to_filename(const std::string & prefix, const fs::path & file);

--- a/libcore/src/geometry/Building.cpp
+++ b/libcore/src/geometry/Building.cpp
@@ -723,10 +723,13 @@ bool Building::correct() const
     }         //r
 
     if(removed) {
-        auto geometryFile = add_prefix_to_filename("correct_", GetGeometryFilename());
+        fs::path newGeometryFile = GetGeometryFilename();
+        fs::path newFilename("correct_");
+        newFilename += newGeometryFile.filename();
+        newGeometryFile.replace_filename(newFilename);
 
-        if(SaveGeometry(geometryFile)) {
-            GetConfig()->SetGeometryFile(geometryFile);
+        if(SaveGeometry(newGeometryFile)) {
+            GetConfig()->SetGeometryFile(newGeometryFile);
         }
     }
 


### PR DESCRIPTION
We do not support MacOS versions prior MacOS Catalina. Since Catalina std::filesystem is available in libc++. That is why we removed all boost filesystem specifics.

Unfortunately the liking of stdc++fs is still required for GCC version less 9.0 and we support GCC 8.0.