### PR TITLE
Clean up EventManager

### DIFF
--- a/demos/scenario_5_events/events_ini.xml
+++ b/demos/scenario_5_events/events_ini.xml
@@ -59,9 +59,9 @@ xsi:noNamespaceSchemaLocation="http://xsd.jupedsim.org/0.6/jps_ini_core.xsd">
   </routing>
 
   <!--persons information and distribution -->
-  <agents operational_model_id="2">
+  <agents operational_model_id="1">
     <agents_distribution>
-      <group group_id="0" agent_parameter_id="1" room_id="0" subroom_id="0" number="1" router_id="1" />
+      <group group_id="0" agent_parameter_id="1" room_id="0" subroom_id="0" number="1" router_id="2"/>
       <!-- <group group_id="1" agent_parameter_id="1" room_id="0" subroom_id="1" number="20" router_id="1" /> -->
       <!-- <group group_id="2" agent_parameter_id="1" room_id="0" subroom_id="2" number="4" router_id="1" /> -->
       <!-- <group group_id="3" agent_parameter_id="1" room_id="0" subroom_id="3" number="20" router_id="1" /> -->

--- a/demos/scenario_5_events/events_ini.xml
+++ b/demos/scenario_5_events/events_ini.xml
@@ -61,7 +61,7 @@ xsi:noNamespaceSchemaLocation="http://xsd.jupedsim.org/0.6/jps_ini_core.xsd">
   <!--persons information and distribution -->
   <agents operational_model_id="1">
     <agents_distribution>
-      <group group_id="0" agent_parameter_id="1" room_id="0" subroom_id="0" number="1" router_id="2"/>
+      <group group_id="0" agent_parameter_id="1" room_id="0" subroom_id="0" number="1" router_id="1"/>
       <!-- <group group_id="1" agent_parameter_id="1" room_id="0" subroom_id="1" number="20" router_id="1" /> -->
       <!-- <group group_id="2" agent_parameter_id="1" room_id="0" subroom_id="2" number="4" router_id="1" /> -->
       <!-- <group group_id="3" agent_parameter_id="1" room_id="0" subroom_id="3" number="20" router_id="1" /> -->

--- a/demos/scenario_5_events/events_list.xml
+++ b/demos/scenario_5_events/events_list.xml
@@ -3,7 +3,7 @@
 <JPScore project="JPS-Project" version="0.6" 
 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 xsi:noNamespaceSchemaLocation="http://xsd.jupedsim.org/0.6/jps_events.xsd">
-  <events update_frequency="2" update_radius="100" agents_color_by_knowledge="true">
+  <events>
     <event time="0" type="door" state="close" id="0" caption="door0" />
     <event time="9" type="door" state="open" id="0" caption="door0" />
     <event time="10" type="door" state="close" id="8" caption="left_exit" />

--- a/docs/pages/jpscore/jpscore_events.md
+++ b/docs/pages/jpscore/jpscore_events.md
@@ -6,19 +6,16 @@ sidebar: jupedsim_sidebar
 folder: jpscore
 permalink: jpscore_events.html
 summary: Definition of the event's file. Events occure in time and trigger certain actions on doors and crossings.
-last_updated: Dec 31, 2019
+last_updated: Jan 25, 2020
 ---
 
 ## Definition
 
 Following properties define an `event`:
 
-- `id`: unique id of the specific door (transition) as defined in the geometry file. See [geometry](jpscore_geometry.html).
-- `update_frequency`:
-- `update_radius`:
-- `agents_color_by_knowledge`:
-- `time`: time of an event
-- `state` can be `close`, `temp_close` or `open`
+- `id` (int): unique id of the specific door (transition) as defined in the geometry file. See [geometry](jpscore_geometry.html).
+- `time` (double): time of an event
+- `state` can be `close`, `temp_close`, `open` or `reset`: defines what event will be applied to the door
 
 
 ## Sample
@@ -29,11 +26,11 @@ Example of an event file:
  <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
  <JPScore project="JPS-Project" version="0.8">
     <events update_frequency="2" update_radius="100" agents_color_by_knowledge="true">
-        <event time="30" type="door" state="close" id="5" />
-        <event time="50" type="door" state="close" id="4" />
-        <event time="70" type="door" state="open" id="4" />
-        <event time="71" type="door" state="close" id="2" />
-        <event time="80" type="door" state="open" id="5" />
+        <event time="30" state="close" id="5" />
+        <event time="50" state="close" id="4" />
+        <event time="70" state="open" id="4" />
+        <event time="71" state="close" id="2" />
+        <event time="80" state="open" id="5" />
     </events>
 </JPScore>
 ```

--- a/libcore/CMakeLists.txt
+++ b/libcore/CMakeLists.txt
@@ -30,6 +30,7 @@ set(source_files
     src/geometry/Transition.cpp
     src/geometry/WaitingArea.cpp
     src/geometry/Wall.cpp
+    src/IO/EventFileParser.cpp
     src/IO/GeoFileParser.cpp
     src/IO/IniFileParser.cpp
     src/IO/OutputHandler.cpp
@@ -115,6 +116,7 @@ set(header_files
     src/geometry/Transition.h
     src/geometry/WaitingArea.h
     src/geometry/Wall.h
+    src/IO/EventFileParser.h
     src/IO/GeoFileParser.h
     src/IO/IniFileParser.h
     src/IO/OutputHandler.h

--- a/libcore/src/IO/EventFileParser.cpp
+++ b/libcore/src/IO/EventFileParser.cpp
@@ -1,0 +1,317 @@
+/**
+ * Copyright (c) 2020 Forschungszentrum Jülich GmbH. All rights reserved.
+ *
+ * \section License
+ * This file is part of JuPedSim.
+ *
+ * JuPedSim is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * JuPedSim is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with JuPedSim. If not, see <http://www.gnu.org/licenses/>.
+ **/
+#include "EventFileParser.h"
+
+#include "general/Logger.h"
+#include "general/Macros.h"
+#include "tinyxml.h"
+
+std::vector<Event> EventFileParser::ParseEvents(const fs::path & eventFile)
+{
+    LOG_INFO("Parsing event file");
+    TiXmlDocument docEvent(eventFile.string());
+    if(!docEvent.LoadFile()) {
+        LOG_ERROR("Cannot parse event file: {}", docEvent.ErrorDesc());
+        return std::vector<Event>();
+    }
+
+    TiXmlElement * xRootNode = docEvent.RootElement();
+    if(!xRootNode) {
+        LOG_ERROR("Event file root element missing");
+        return std::vector<Event>();
+    }
+
+    if(xRootNode->ValueStr() != "JPScore") {
+        LOG_ERROR("Event file root element should be 'JPScore'");
+        return std::vector<Event>();
+    }
+
+    TiXmlNode * xEvents = xRootNode->FirstChild("events");
+    if(!xEvents) {
+        LOG_ERROR("No events found");
+        return std::vector<Event>();
+    }
+
+    std::vector<Event> events;
+    for(TiXmlElement * e = xEvents->FirstChildElement("event"); e;
+        e                = e->NextSiblingElement("event")) {
+        // Read id and check for correct value
+        int id;
+        if(const char * attribute = e->Attribute("id"); attribute) {
+            if(int value = xmltoi(attribute, -1);
+               value > -1 && attribute == std::to_string(value)) {
+                id = value;
+            } else {
+                LOG_ERROR("event: id is set but no integer");
+                continue;
+            }
+        } else {
+            LOG_ERROR("event: id required");
+            continue;
+        }
+
+        // Read time of events
+        double time;
+        if(const char * attribute = e->Attribute("time"); attribute) {
+            if(double value = xmltof(attribute, std::numeric_limits<double>::min()); value >= 0.) {
+                time = value;
+            } else {
+                LOG_ERROR("event {:d}: time not set properly", id);
+                continue;
+            }
+        } else {
+            LOG_ERROR("event {:d}: time required", id);
+            continue;
+        }
+
+        // Read state
+        std::string state;
+        if(const char * attribute = e->Attribute("state"); attribute) {
+            std::string in = xmltoa(attribute, "");
+            if(!in.empty()) {
+                state = in;
+            } else {
+                LOG_ERROR("event {:d}: state not set properly", id);
+                continue;
+            }
+        } else {
+            LOG_ERROR("event {:d}: state required", id);
+            continue;
+        }
+
+        events.emplace_back(id, time, state);
+    }
+    LOG_INFO("Events have been initialized");
+    return events;
+}
+
+std::vector<Event> EventFileParser::ParseSchedule(const fs::path & scheduleFile)
+{
+    LOG_INFO("Parsing schedule file");
+    TiXmlDocument docSchedule(scheduleFile.string());
+    if(!docSchedule.LoadFile()) {
+        LOG_ERROR("Cannot parse schedule file: {}", docSchedule.ErrorDesc());
+        return std::vector<Event>();
+    }
+
+    TiXmlElement * xRootNode = docSchedule.RootElement();
+    if(!xRootNode) {
+        LOG_ERROR("Schedule file root element missing");
+        return std::vector<Event>();
+    }
+
+    if(xRootNode->ValueStr() != "JPScore") {
+        LOG_ERROR("Schedule file root element is not 'JPScore'");
+        return std::vector<Event>();
+    }
+
+    // Read groups
+    TiXmlNode * xGroups = xRootNode->FirstChild("groups");
+    if(!xGroups) {
+        LOG_ERROR("No groups found in schedule file");
+        return std::vector<Event>();
+    }
+
+    std::map<int, int> groupMaxAgents;
+    std::map<int, std::vector<int>> groupDoor;
+    std::vector<Event> events;
+
+    for(TiXmlElement * e = xGroups->FirstChildElement("group"); e;
+        e                = e->NextSiblingElement("group")) {
+        // Read id and check for correct value
+        int id;
+        if(const char * attribute = e->Attribute("id"); attribute) {
+            if(int value = xmltoi(attribute, -1);
+               value > -1 && attribute == std::to_string(value)) {
+                id = value;
+            } else {
+                LOG_ERROR("schedule group: id is set but no integer");
+                continue;
+            }
+        } else {
+            LOG_ERROR("schedule group: id required");
+            continue;
+        }
+
+        std::vector<int> member;
+        for(TiXmlElement * xmember = e->FirstChildElement("member"); xmember;
+            xmember                = xmember->NextSiblingElement("member")) {
+            int tId = std::stoi(xmember->Attribute("t_id"));
+            member.push_back(tId);
+        }
+        groupDoor[id] = member;
+    }
+
+    // Read times
+    TiXmlNode * xTimes = xRootNode->FirstChild("times");
+    if(!xTimes) {
+        LOG_ERROR("No times found");
+        return std::vector<Event>();
+    }
+
+    for(TiXmlElement * e = xTimes->FirstChildElement("time"); e;
+        e                = e->NextSiblingElement("time")) {
+        // Read id and check for correct value
+        int id;
+        if(const char * attribute = e->Attribute("group_id"); attribute) {
+            if(int value = xmltoi(attribute, -1);
+               value > -1 && attribute == std::to_string(value)) {
+                id = value;
+            } else {
+                LOG_ERROR("schedule times: group_id is set but no integer");
+                continue;
+            }
+        } else {
+            LOG_ERROR("schedule times: group_id required");
+            continue;
+        }
+
+        int closingTime;
+        if(const char * attribute = e->Attribute("closing_time"); attribute) {
+            if(int value = xmltoi(attribute, -1); value > 0 && attribute == std::to_string(value)) {
+                closingTime = value;
+            } else {
+                LOG_ERROR("schedule times {:d}: closing_time is not set properly", id);
+                continue;
+            }
+        } else {
+            LOG_ERROR("schedule times {:d}: closing_time required", id);
+            continue;
+        }
+
+        bool resetDoor = false;
+        if(const char * attribute = e->Attribute("reset"); attribute) {
+            std::string in = xmltoa(attribute, "");
+            if(!in.empty()) {
+                std::string resetString = in;
+                std::transform(
+                    resetString.begin(), resetString.end(), resetString.begin(), ::tolower);
+                resetDoor = (resetString == "true");
+            } else {
+                LOG_ERROR("schedule times {:d}: reset has no proper input, set to false", id);
+            }
+        }
+
+        std::vector<double> timeOpen;
+        std::vector<double> timeClose;
+        std::vector<double> timeReset;
+
+        for(TiXmlElement * time = e->FirstChildElement("t"); time;
+            time                = time->NextSiblingElement("t")) {
+            double openingTime = xmltof(time->Attribute("t"), -1.);
+            if (openingTime < 0){
+                LOG_ERROR("schedule times {:d}: t has no proper input", id);
+                continue;
+            }
+            if(resetDoor) {
+                timeReset.push_back(openingTime);
+            } else {
+                timeOpen.push_back(openingTime);
+            }
+
+            timeClose.push_back(openingTime + closingTime);
+        }
+
+        for(auto door : groupDoor[id]) {
+            for(auto open : timeOpen) {
+                Event event(door, open, "open");
+                events.push_back(event);
+            }
+
+            for(auto close : timeClose) {
+                Event event(door, close, "temp_close");
+                events.push_back(event);
+            }
+
+            for(auto reset : timeReset) {
+                Event event(door, reset, "reset");
+                events.push_back(event);
+            }
+        }
+    }
+    return events;
+}
+
+std::map<int, int> EventFileParser::ParseMaxAgents(const fs::path & scheduleFile)
+{
+    LOG_INFO("Parsing schedule file for max agents");
+    TiXmlDocument docSchedule(scheduleFile.string());
+    if(!docSchedule.LoadFile()) {
+        LOG_ERROR("Cannot parse schedule file: {}", docSchedule.ErrorDesc());
+        return std::map<int, int>();
+    }
+
+    TiXmlElement * xRootNode = docSchedule.RootElement();
+    if(!xRootNode) {
+        LOG_ERROR("Schedule file root element missing");
+        return std::map<int, int>();
+    }
+
+    if(xRootNode->ValueStr() != "JPScore") {
+        LOG_ERROR("Schedule file root element is not 'JPScore'");
+        return std::map<int, int>();
+    }
+
+    // Read groups
+    TiXmlNode * xGroups = xRootNode->FirstChild("groups");
+    if(!xGroups) {
+        LOG_ERROR("No groups found in schedule file");
+        return std::map<int, int>();
+    }
+
+    std::map<int, int> doorMaxAgents;
+
+    for(TiXmlElement * e = xGroups->FirstChildElement("group"); e;
+        e                = e->NextSiblingElement("group")) {
+        int maxAgents = std::numeric_limits<int>::min();
+        if(const char * attribute = e->Attribute("max_agents"); attribute) {
+            if(int value = xmltoi(attribute, -1); value > 0 && attribute == std::to_string(value)) {
+                maxAgents = value;
+            } else {
+                LOG_ERROR("schedule group: max_agents is set but no integer");
+                continue;
+            }
+        } else {
+            // if no max_agents set, or not set correctly continue
+            continue;
+        }
+
+        for(TiXmlElement * xmember = e->FirstChildElement("member"); xmember;
+            xmember                = xmember->NextSiblingElement("member")) {
+            int transID = std::numeric_limits<int>::min();
+            if(const char * attribute = e->Attribute("t"); attribute) {
+                if(int value = xmltoi(attribute, -1);
+                   value >= 0 && attribute == std::to_string(value)) {
+                    transID = value;
+                } else {
+                    LOG_ERROR("schedule times: trans_id not set properly");
+                    continue;
+                }
+            } else {
+                LOG_ERROR("schedule times: trans_id required");
+                continue;
+            }
+
+            doorMaxAgents[transID] = maxAgents;
+        }
+    }
+
+    return doorMaxAgents;
+}

--- a/libcore/src/IO/EventFileParser.cpp
+++ b/libcore/src/IO/EventFileParser.cpp
@@ -216,7 +216,7 @@ std::vector<Event> EventFileParser::ParseSchedule(const fs::path & scheduleFile)
         for(TiXmlElement * time = e->FirstChildElement("t"); time;
             time                = time->NextSiblingElement("t")) {
             double openingTime = xmltof(time->Attribute("t"), -1.);
-            if (openingTime < 0){
+            if(openingTime < 0) {
                 LOG_ERROR("schedule times {:d}: t has no proper input", id);
                 continue;
             }

--- a/libcore/src/IO/EventFileParser.h
+++ b/libcore/src/IO/EventFileParser.h
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2020 Forschungszentrum Jülich GmbH. All rights reserved.
+ *
+ * \section License
+ * This file is part of JuPedSim.
+ *
+ * JuPedSim is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * JuPedSim is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with JuPedSim. If not, see <http://www.gnu.org/licenses/>.
+ **/
+#pragma once
+
+#include "events/Event.h"
+#include "general/Filesystem.h"
+
+#include <map>
+#include <vector>
+
+class EventFileParser
+{
+public:
+    static std::vector<Event> ParseEvents(const fs::path & eventFile);
+    static std::vector<Event> ParseSchedule(const fs::path & scheduleFile);
+    static std::map<int, int> ParseMaxAgents(const fs::path & scheduleFile);
+};

--- a/libcore/src/IO/EventFileParser.h
+++ b/libcore/src/IO/EventFileParser.h
@@ -25,27 +25,26 @@
 #include <map>
 #include <vector>
 
-class EventFileParser
+namespace EventFileParser
 {
-public:
-    /**
-     * Reads all events from a specfic files and returns them in a vector.
-     * @param eventFile File containing the events
-     * @return All events which could be parsed from \p eventFile
-     */
-    static std::vector<Event> ParseEvents(const fs::path & eventFile);
+/**
+ * Reads all events from a specfic files and returns them in a vector.
+ * @param eventFile File containing the events
+ * @return All events which could be parsed from \p eventFile
+ */
+std::vector<Event> ParseEvents(const fs::path & eventFile);
 
-    /**
-     * Reads the events from a specific schedule file and returns them in a vector.
-     * @param scheduleFile File containing the schedule
-     * @return All events which could be parsed from \p scheduleFile
-     */
-    static std::vector<Event> ParseSchedule(const fs::path & scheduleFile);
+/**
+ * Reads the events from a specific schedule file and returns them in a vector.
+ * @param scheduleFile File containing the schedule
+ * @return All events which could be parsed from \p scheduleFile
+ */
+std::vector<Event> ParseSchedule(const fs::path & scheduleFile);
 
-    /**
-     * Reads the max agents defintions from the schedule file and returns them as a map of transition ID to maxAgents.
-     * @param scheduleFile File containing the schedule
-     * @return Map of max agents defintion which could be parsed from \p scheduleFile (ID to maxAgents)
-     */
-    static std::map<int, int> ParseMaxAgents(const fs::path & scheduleFile);
-};
+/**
+ * Reads the max agents defintions from the schedule file and returns them as a map of transition ID to maxAgents.
+ * @param scheduleFile File containing the schedule
+ * @return Map of max agents defintion which could be parsed from \p scheduleFile (ID to maxAgents)
+ */
+std::map<int, int> ParseMaxAgents(const fs::path & scheduleFile);
+}; // namespace EventFileParser

--- a/libcore/src/IO/EventFileParser.h
+++ b/libcore/src/IO/EventFileParser.h
@@ -28,7 +28,24 @@
 class EventFileParser
 {
 public:
+    /**
+     * Reads all events from a specfic files and returns them in a vector.
+     * @param eventFile File containing the events
+     * @return All events which could be parsed from \p eventFile
+     */
     static std::vector<Event> ParseEvents(const fs::path & eventFile);
+
+    /**
+     * Reads the events from a specific schedule file and returns them in a vector.
+     * @param scheduleFile File containing the schedule
+     * @return All events which could be parsed from \p scheduleFile
+     */
     static std::vector<Event> ParseSchedule(const fs::path & scheduleFile);
+
+    /**
+     * Reads the max agents defintions from the schedule file and returns them as a map of transition ID to maxAgents.
+     * @param scheduleFile File containing the schedule
+     * @return Map of max agents defintion which could be parsed from \p scheduleFile (ID to maxAgents)
+     */
     static std::map<int, int> ParseMaxAgents(const fs::path & scheduleFile);
 };

--- a/libcore/src/IO/IniFileParser.cpp
+++ b/libcore/src/IO/IniFileParser.cpp
@@ -165,14 +165,6 @@ void IniFileParser::Parse(const fs::path & iniFile)
 
 bool IniFileParser::ParseHeader(TiXmlNode * xHeader)
 {
-    LOG_INFO("JuPedSim - JPScore");
-    LOG_INFO("Current date: {} {}", __DATE__, __TIME__);
-    LOG_INFO("Version     : {}", JPSCORE_VERSION);
-    LOG_INFO("Commit hash : {}", GIT_COMMIT_HASH);
-    LOG_INFO("Commit date : {}", GIT_COMMIT_DATE);
-    LOG_INFO("Branch      : {}", GIT_BRANCH);
-
-
     //seed
     if(xHeader->FirstChild("seed")) {
         TiXmlNode * seedNode = xHeader->FirstChild("seed")->FirstChild();
@@ -427,6 +419,38 @@ bool IniFileParser::ParseHeader(TiXmlNode * xHeader)
                 }
             }
         }
+    }
+
+    //event file
+    if(xHeader->FirstChild("events_file") && xHeader->FirstChild("events_file")->FirstChild()) {
+        const fs::path eventFile = xHeader->FirstChild("events_file")->FirstChild()->Value();
+        if(!eventFile.empty() && fs::exists(eventFile)) {
+            _config->SetEventFile(_config->GetProjectRootDir() / eventFile);
+            LOG_INFO("Events are read from: <{}>", _config->GetEventFile().string());
+        } else {
+            LOG_WARNING(
+                "Event file is empty or the file does not exists. No events are used in the "
+                "simulation: <{}>",
+                eventFile.string());
+        }
+    } else {
+        LOG_INFO("No event file given.");
+    }
+
+    //schedule file
+    if(xHeader->FirstChild("schedule_file") && xHeader->FirstChild("schedule_file")->FirstChild()) {
+        const fs::path scheduleFile = xHeader->FirstChild("schedule_file")->FirstChild()->Value();
+        if(!scheduleFile.empty() && fs::exists(scheduleFile)) {
+            _config->SetScheduleFile(_config->GetProjectRootDir() / scheduleFile);
+            LOG_INFO("Schedule is read from: <{}>", _config->GetScheduleFile().string());
+        } else {
+            LOG_WARNING(
+                "Schedule file is empty or the file does not exists. No schedule is used in the "
+                "simulation: <{}>",
+                scheduleFile.string());
+        }
+    } else {
+        LOG_INFO("No schedule file given.");
     }
 
     return true;

--- a/libcore/src/Simulation.cpp
+++ b/libcore/src/Simulation.cpp
@@ -192,12 +192,12 @@ bool Simulation::InitArgs()
     }
     if(!_config->GetScheduleFile().empty()) {
         _em->AddEvents(EventFileParser::ParseSchedule(_config->GetScheduleFile()));
-    }
 
-    // Read and set max door usage from schedule file
-    auto groupMaxAgents = EventFileParser::ParseMaxAgents(_config->GetScheduleFile());
-    for(auto const [transID, maxAgents] : groupMaxAgents) {
-        _building->GetTransition(transID)->SetMaxDoorUsage(maxAgents);
+        // Read and set max door usage from schedule file
+        auto groupMaxAgents = EventFileParser::ParseMaxAgents(_config->GetScheduleFile());
+        for(auto const [transID, maxAgents] : groupMaxAgents) {
+            _building->GetTransition(transID)->SetMaxDoorUsage(maxAgents);
+        }
     }
 
     _goalManager.SetBuilding(_building.get());

--- a/libcore/src/Simulation.cpp
+++ b/libcore/src/Simulation.cpp
@@ -187,7 +187,7 @@ bool Simulation::InitArgs()
         return false;
     }
 
-    _em = new EventManager(_config, _building.get(), _config->GetSeed());
+    _em = new EventManager(_config, _building.get());
     if(!_em->ReadEventsXml()) {
         LOG_WARNING("Could not initialize events handling");
     }
@@ -472,7 +472,8 @@ double Simulation::RunBody(double maxSimTime)
             _operationalModel->ComputeNextTimeStep(t, _deltaT, _building.get(), _periodic);
 
             //update the events
-            _em->ProcessEvent();
+            bool eventProcessed = _em->ProcessEvent();
+            _building->GetRoutingEngine()->setNeedUpdate(eventProcessed);
 
             //here we could place router-tasks (calc new maps) that can use multiple cores AND we have 't'
             //update quickestRouter

--- a/libcore/src/Simulation.cpp
+++ b/libcore/src/Simulation.cpp
@@ -189,10 +189,10 @@ bool Simulation::InitArgs()
     }
 
     _em = new EventManager(_building.get());
-    if (!_config->GetEventFile().empty()) {
+    if(!_config->GetEventFile().empty()) {
         _em->AddEvents(EventFileParser::ParseEvents(_config->GetEventFile()));
     }
-    if (!_config->GetScheduleFile().empty()) {
+    if(!_config->GetScheduleFile().empty()) {
         _em->AddEvents(EventFileParser::ParseSchedule(_config->GetScheduleFile()));
     }
 

--- a/libcore/src/Simulation.cpp
+++ b/libcore/src/Simulation.cpp
@@ -71,8 +71,6 @@ Simulation::Simulation(Configuration * args) : _config(args)
 
 Simulation::~Simulation()
 {
-    delete _em;
-
     if(_iod) {
         _iod.reset();
     }
@@ -188,7 +186,7 @@ bool Simulation::InitArgs()
         return false;
     }
 
-    _em = new EventManager(_building.get());
+    _em = std::make_unique<EventManager>(_building.get());
     if(!_config->GetEventFile().empty()) {
         _em->AddEvents(EventFileParser::ParseEvents(_config->GetEventFile()));
     }

--- a/libcore/src/Simulation.h
+++ b/libcore/src/Simulation.h
@@ -63,7 +63,7 @@ private:
     std::shared_ptr<RoutingEngine> _routingEngine;
     /// writing the trajectories to file
     std::unique_ptr<Trajectories> _iod;
-    EventManager * _em;
+    std::unique_ptr<EventManager> _em;
     AgentsSourcesManager _agentSrcManager;
     int _periodic;
     int _maxSimTime;

--- a/libcore/src/events/Event.cpp
+++ b/libcore/src/events/Event.cpp
@@ -9,15 +9,13 @@
 
 #include <algorithm>
 
-Event::Event(int id, double time, const std::string & type, const std::string & state)
+Event::Event(int id, double time, const std::string & state)
 {
     _id     = id;
     _time   = time;
-    _type   = type;
     _action = StringToEventAction(state);
 }
 
-Event::~Event() {}
 
 int Event::GetId() const
 {
@@ -34,12 +32,7 @@ double Event::GetTime() const
     return _time;
 }
 
-const std::string & Event::GetType() const
-{
-    return _type;
-}
-
-const std::string Event::GetDescription() const
+std::string Event::GetDescription() const
 {
     char tmp[1024];
     std::string state;

--- a/libcore/src/events/Event.h
+++ b/libcore/src/events/Event.h
@@ -19,46 +19,55 @@ public:
       * Constructor
       * @param id
       * @param time
-      * @param type
       * @param state
       */
-    Event(int id, double time, const std::string & type, const std::string & state);
+    Event(int id, double time, const std::string & state);
 
     /**
       * Destructor
       */
-    virtual ~Event();
+    ~Event() = default;
 
     /**
       * @return the id of the event
       */
-    int GetId() const;
+    [[nodiscard]] int GetId() const;
 
     /**
       * @return the type of the event
       */
-    const EventAction & GetAction() const;
+    [[nodiscard]] const EventAction & GetAction() const;
 
     /**
       * @return the time at which the event was recorded
       */
-    double GetTime() const;
+    [[nodiscard]] double GetTime() const;
 
     /**
-      * @return the type of the event (room, door)
+      * @return a description of the event
       */
-    const std::string & GetType() const;
-
-    /**
-      * return a description of the event
-      */
-    const std::string GetDescription() const;
+    [[nodiscard]] std::string GetDescription() const;
 
 private:
+    /**
+     * Time when the event should be executed.
+     */
     double _time;
+
+    /**
+     * ID of transition which is effected by event.
+     */
     int _id;
-    std::string _type;
+
+    /**
+     * Action which should be performed.
+     */
     EventAction _action;
 
-    EventAction StringToEventAction(const std::string &);
+    /**
+     * Helper function to get the Action from the input.
+     * @param input Input string
+     * @return Action which is identified by \p input
+     */
+    static EventAction StringToEventAction(const std::string & input);
 };

--- a/libcore/src/events/EventManager.cpp
+++ b/libcore/src/events/EventManager.cpp
@@ -28,86 +28,19 @@
 
 #include "Event.h"
 #include "general/Logger.h"
-#include "geometry/SubRoom.h"
-#include "mpi/LCGrid.h"
-#include "pedestrian/Knowledge.h"
+#include "geometry/Building.h"
 #include "pedestrian/Pedestrian.h"
 
 #include <cmath>
-#include <map>
-#include <string>
-#include <tinyxml.h>
 
-EventManager::EventManager(Configuration * config, Building * _b)
+EventManager::EventManager(Building * _b)
 {
-    _config   = config;
     _building = _b;
 }
 
-bool EventManager::ReadEventsXml()
+void EventManager::AddEvents(std::vector<Event> events)
 {
-    LOG_INFO("Looking for pre-defined events in other files");
-    //get the geometry filename from the project file
-    TiXmlDocument doc(_config->GetProjectFile().string());
-    if(!doc.LoadFile()) {
-        LOG_ERROR("Cannot parse project file: {}", doc.ErrorDesc());
-        return false;
-    }
-
-    TiXmlElement * xMainNode = doc.RootElement();
-
-    fs::path eventfile{};
-    if(xMainNode->FirstChild("events_file")) {
-        eventfile = _config->GetProjectRootDir() /
-                    xMainNode->FirstChild("events_file")->FirstChild()->Value();
-        LOG_INFO("events<{}>", eventfile.string());
-    } else if(
-        xMainNode->FirstChild("header") &&
-        xMainNode->FirstChild("header")->FirstChild("events_file")) {
-        eventfile =
-            _config->GetProjectRootDir() /
-            xMainNode->FirstChild("header")->FirstChild("events_file")->FirstChild()->Value();
-        LOG_INFO("events<{}>", eventfile.string());
-    } else {
-        LOG_INFO("No events found");
-        return true;
-    }
-
-    LOG_INFO("Parsing event file");
-    TiXmlDocument docEvent(eventfile.string());
-    if(!docEvent.LoadFile()) {
-        LOG_ERROR("Cannot parse event file: {}", docEvent.ErrorDesc());
-        return false;
-    }
-
-    TiXmlElement * xRootNode = docEvent.RootElement();
-    if(!xRootNode) {
-        LOG_ERROR("Event file root element missing");
-        return false;
-    }
-
-    if(xRootNode->ValueStr() != "JPScore") {
-        LOG_ERROR("Event file root element should be 'JPScore'");
-        return false;
-    }
-
-    TiXmlNode * xEvents = xRootNode->FirstChild("events");
-    if(!xEvents) {
-        LOG_ERROR("No events found");
-        return false;
-    }
-
-    for(TiXmlElement * e = xEvents->FirstChildElement("event"); e;
-        e                = e->NextSiblingElement("event")) {
-        int id      = std::stoi(e->Attribute("id"));
-        double zeit = std::stoi(e->Attribute("time"));
-        std::string state(e->Attribute("state"));
-        std::string type(e->Attribute("type"));
-        _events.emplace_back(id, zeit, type, state);
-    }
-    LOG_INFO("Events have been initialized");
-
-    return true;
+    _events.insert(_events.end(), events.begin(), events.end());
 }
 
 void EventManager::ListEvents()
@@ -175,145 +108,4 @@ void EventManager::ResetDoor(int id)
     Transition * t = _building->GetTransition(id);
     t->ResetDoorUsage();
     LOG_INFO("Resetting door usage {}", id);
-}
-
-bool EventManager::ReadSchedule()
-{
-    LOG_INFO("Reading schedule");
-
-    //get the geometry filename from the project file
-    TiXmlDocument doc(_config->GetProjectFile().string());
-    if(!doc.LoadFile()) {
-        LOG_ERROR("Cannot parse project file: {}", doc.ErrorDesc());
-        return false;
-    }
-
-    TiXmlElement * xMainNode = doc.RootElement();
-
-    fs::path scheduleFile = "";
-    if(xMainNode->FirstChild("schedule_file")) {
-        scheduleFile = _config->GetProjectRootDir() /
-                       xMainNode->FirstChild("schedule_file")->FirstChild()->Value();
-        LOG_INFO("events<{}>", scheduleFile.string());
-    } else if(
-        xMainNode->FirstChild("header") &&
-        xMainNode->FirstChild("header")->FirstChild("schedule_file")) {
-        scheduleFile =
-            _config->GetProjectRootDir() /
-            xMainNode->FirstChild("header")->FirstChild("schedule_file")->FirstChild()->Value();
-        LOG_INFO("events<{}>", scheduleFile.string());
-    } else {
-        LOG_INFO("No events found");
-        return true;
-    }
-
-    LOG_INFO("Parsing schedule file");
-    TiXmlDocument docSchedule(scheduleFile.string());
-    if(!docSchedule.LoadFile()) {
-        LOG_ERROR("Cannot parse schedule file: {}", docSchedule.ErrorDesc());
-        return false;
-    }
-
-    TiXmlElement * xRootNode = docSchedule.RootElement();
-    if(!xRootNode) {
-        LOG_ERROR("Schedule file root element missing");
-        return false;
-    }
-
-    if(xRootNode->ValueStr() != "JPScore") {
-        LOG_ERROR("Schedule file root element is not 'JPScore'");
-        return false;
-    }
-
-    // Read groups
-    TiXmlNode * xGroups = xRootNode->FirstChild("groups");
-    if(!xGroups) {
-        LOG_ERROR("No groups found in schedule file");
-        return false;
-    }
-
-    std::map<int, int> groupMaxAgents;
-    std::map<int, std::vector<int>> groupDoor;
-
-    for(TiXmlElement * e = xGroups->FirstChildElement("group"); e;
-        e                = e->NextSiblingElement("group")) {
-        int id = std::stoi(e->Attribute("id"));
-
-        int max_agents = std::numeric_limits<int>::min();
-        if(e->Attribute("max_agents")) {
-            max_agents = std::stoi(e->Attribute("max_agents"));
-        }
-
-        std::vector<int> member;
-        for(TiXmlElement * xmember = e->FirstChildElement("member"); xmember;
-            xmember                = xmember->NextSiblingElement("member")) {
-            int tId = std::stoi(xmember->Attribute("t_id"));
-            member.push_back(tId);
-        }
-        groupDoor[id]      = member;
-        groupMaxAgents[id] = max_agents;
-    }
-
-    //Set max agents
-    for(auto const [groupID, maxAgents] : groupMaxAgents) {
-        if(maxAgents > 0) {
-            for(int transID : groupDoor.at(groupID)) {
-                _building->GetTransition(transID)->SetMaxDoorUsage(maxAgents);
-            }
-        }
-    }
-
-    // Read times
-    TiXmlNode * xTimes = xRootNode->FirstChild("times");
-    if(!xTimes) {
-        LOG_ERROR("No times found");
-        return false;
-    }
-
-    for(TiXmlElement * e = xTimes->FirstChildElement("time"); e;
-        e                = e->NextSiblingElement("time")) {
-        int id           = std::stoi(e->Attribute("group_id"));
-        int closing_time = std::stoi(e->Attribute("closing_time"));
-
-        std::string resetString;
-        if(e->Attribute("reset")) {
-            resetString = e->Attribute("reset");
-            std::transform(resetString.begin(), resetString.end(), resetString.begin(), ::tolower);
-        }
-        bool resetDoor = (resetString == "true");
-
-        std::vector<int> timeOpen;
-        std::vector<int> timeClose;
-        std::vector<int> timeReset;
-
-        for(TiXmlElement * time = e->FirstChildElement("t"); time;
-            time                = time->NextSiblingElement("t")) {
-            int t = std::stoi(time->Attribute("t"));
-            if(resetDoor) {
-                timeReset.push_back(t);
-            } else {
-                timeOpen.push_back(t);
-            }
-            timeClose.push_back(t + closing_time);
-        }
-
-        for(auto door : groupDoor[id]) {
-            for(auto open : timeOpen) {
-                Event event(door, open, "door", "open");
-                _events.push_back(event);
-            }
-
-            for(auto close : timeClose) {
-                Event event(door, close, "door", "temp_close");
-                _events.push_back(event);
-            }
-
-            for(auto reset : timeReset) {
-                Event event(door, reset, "door", "reset");
-                _events.push_back(event);
-            }
-        }
-    }
-    LOG_INFO("Schedule initialized");
-    return true;
 }

--- a/libcore/src/events/EventManager.cpp
+++ b/libcore/src/events/EventManager.cpp
@@ -32,47 +32,16 @@
 #include "mpi/LCGrid.h"
 #include "pedestrian/Knowledge.h"
 #include "pedestrian/Pedestrian.h"
-#include "routing/ff_router/ffRouter.h"
-#include "routing/global_shortest/GlobalRouter.h"
-#include "routing/quickest/QuickestPathRouter.h"
-#include "routing/smoke_router/SmokeRouter.h"
 
-#include <cstdlib>
-#include <fstream>
-#include <iostream>
-#include <math.h>
+#include <cmath>
+#include <map>
 #include <string>
 #include <tinyxml.h>
-#include <vector>
 
-using std::cout;
-using std::endl;
-using std::map;
-
-EventManager::EventManager(Configuration * config, Building * _b, unsigned int seed)
+EventManager::EventManager(Configuration * config, Building * _b)
 {
-    _config          = config;
-    _building        = _b;
-    _eventCounter    = 0;
-    _dynamic         = false;
-    _lastUpdateTime  = 0;
-    _updateFrequency = 1; //seconds
-    _updateRadius    = 2; //meters
-
-    //generate random number between 0 and 1 uniformly distributed
-    _rdDistribution = std::uniform_real_distribution<double>(0, 1);
-    _rdGenerator    = std::mt19937(seed);
-    _file           = nullptr;
-    //save the first graph
-    CreateRoutingEngine(_b, true);
-}
-
-EventManager::~EventManager()
-{
-    if(_file)
-        fclose(_file);
-
-    _eventEngineStorage.clear();
+    _config   = config;
+    _building = _b;
 }
 
 bool EventManager::ReadEventsXml()
@@ -86,23 +55,6 @@ bool EventManager::ReadEventsXml()
     }
 
     TiXmlElement * xMainNode = doc.RootElement();
-
-    if(xMainNode->FirstChild("event_realtime")) {
-        auto realtimefile = _config->GetProjectRootDir() /
-                            xMainNode->FirstChild("event_realtime")->FirstChild()->Value();
-        _file = fopen(realtimefile.string().c_str(), "r");
-        if(!_file) {
-            LOG_INFO(
-                "Realtime file missing: {} Realtime interaction with the "
-                "simulation not possible",
-                realtimefile.string());
-        } else {
-            LOG_INFO("Monitoring {} for new events", realtimefile.string());
-            _dynamic = true;
-        }
-    } else {
-        LOG_INFO("No realtime events found");
-    }
 
     fs::path eventfile{};
     if(xMainNode->FirstChild("events_file")) {
@@ -144,16 +96,14 @@ bool EventManager::ReadEventsXml()
         LOG_ERROR("No events found");
         return false;
     }
-    _updateFrequency = xmltoi(xEvents->ToElement()->Attribute("update_frequency"), 1);
-    _updateRadius    = xmltoi(xEvents->ToElement()->Attribute("update_radius"), 2);
 
     for(TiXmlElement * e = xEvents->FirstChildElement("event"); e;
         e                = e->NextSiblingElement("event")) {
-        int id      = atoi(e->Attribute("id"));
-        double zeit = atoi(e->Attribute("time"));
+        int id      = std::stoi(e->Attribute("id"));
+        double zeit = std::stoi(e->Attribute("time"));
         std::string state(e->Attribute("state"));
         std::string type(e->Attribute("type"));
-        _events.push_back(Event(id, zeit, type, state));
+        _events.emplace_back(id, zeit, type, state);
     }
     LOG_INFO("Events have been initialized");
 
@@ -167,270 +117,14 @@ void EventManager::ListEvents()
     }
 }
 
-void EventManager::ReadEventsTxt(double time)
+bool EventManager::ProcessEvent()
 {
-    rewind(_file);
-    char cstring[256];
-    int lines = 0;
-    do {
-        if(fgets(cstring, 30, _file) == nullptr) {
-            return;
-        }
-        if(cstring[0] != '#') { // skip comments
-            lines++;
-            if(lines > _eventCounter) {
-                LOG_INFO("Event: after {:.2f}", time);
-                GetEvent(cstring);
-                _eventCounter++;
-            }
-        }
-    } while(feof(_file) == 0);
-}
-
-bool EventManager::CollectNewKnowledge(Building * _b)
-{
-    //#pragma omp parallel for
-    for(auto && ped : _b->GetAllPedestrians()) {
-        for(auto && door : _b->GetAllTransitions()) {
-            if(door.second->DistTo(ped->GetPos()) < 0.5) //distance to door to register its state
-            {
-                //actualize the information about the newly closed door
-                if(door.second->IsOpen() == false) {
-                    //1.0 because the information is sure
-                    ped->AddKnownClosedDoor(
-                        door.first,
-                        Pedestrian::GetGlobalTime(),
-                        !door.second->IsOpen(),
-                        _updateFrequency,
-                        1.0);
-                    UpdateRoute(ped);
-                }
-            }
-        }
-    }
-    return true;
-}
-
-bool EventManager::DisseminateKnowledge(Building * _b)
-{
-    for(auto && ped : _b->GetAllPedestrians()) {
-        //update the latency for new and old information
-        for(auto && info : ped->GetKnownledge()) {
-            info.second.DecreaseLatency(_updateFrequency);
-        }
-    }
-
-    for(auto && ped1 : _b->GetAllPedestrians()) {
-        std::vector<Pedestrian *> neighbourhood;
-        _b->GetGrid()->GetNeighbourhood(ped1, neighbourhood);
-        for(auto && ped2 : neighbourhood) {
-            if((ped1->GetPos() - ped2->GetPos()).Norm() < _updateRadius) {
-                //maybe same room and subroom ?
-                std::vector<SubRoom *> empty;
-                if(_b->IsVisible(ped1->GetPos(), ped2->GetPos(), empty)) {
-                    MergeKnowledge(ped1, ped2);
-                }
-            }
-        }
-    }
-
-    return true;
-}
-
-bool EventManager::UpdateRoute(Pedestrian * ped)
-{
-    //create the key as std::string.
-    //map are sorted by default
-    std::string key = ped->GetKnowledgeAsString();
-    //get the router engine corresponding to the actual configuration
-    bool status = true;
-
-    if(_eventEngineStorage.count(key) > 0) {
-        RoutingEngine * engine = _eventEngineStorage[key];
-        //retrieve the old strategy
-        RoutingStrategy strategy = ped->GetRouter()->GetStrategy();
-        //retrieve the new router
-        Router * rout = engine->GetRouter(strategy);
-        //only update if it is a new router
-        if(ped->GetRouter() != rout) {
-            //check for validity
-            ped->SetRouter(rout);
-            //clear all previous routes
-            ped->ClearMentalMap();
-        }
-        if(!rout)
-            status = false;
-    } else {
-        status = false;
-    }
-    return status;
-}
-
-bool EventManager::SynchronizeKnowledge(Pedestrian * p1, Pedestrian * p2)
-{
-    auto const & old_info1 = p1->GetKnownledge();
-    auto const & old_info2 = p2->GetKnownledge();
-    map<int, Knowledge> merge_info;
-
-    //collect the most recent knowledge
-    for(auto && info1 : old_info1) {
-        merge_info[info1.first] = info1.second;
-    }
-
-    for(auto && info2 : old_info2) {
-        //update infos according to a newest time
-        if(merge_info.count(info2.first) > 0) {
-            if(info2.second.GetTime() > merge_info[info2.first].GetTime()) {
-                merge_info[info2.first] = info2.second;
-            }
-        } else //the info was not present, just add
-        {
-            merge_info[info2.first] = info2.second;
-        }
-    }
-
-    //synchronize the knowledge
-    p1->ClearKnowledge();
-    p2->ClearKnowledge();
-    for(auto && info : merge_info) {
-        p1->AddKnownClosedDoor(
-            info.first,
-            info.second.GetTime(),
-            info.second.GetState(),
-            info.second.GetQuality(),
-            _updateFrequency);
-        p2->AddKnownClosedDoor(
-            info.first,
-            info.second.GetTime(),
-            info.second.GetState(),
-            info.second.GetQuality(),
-            _updateFrequency);
-    }
-    return true;
-}
-
-bool EventManager::MergeKnowledgeUsingProbability(Pedestrian * p1, Pedestrian * p2)
-{
-    auto const & old_info1 = p1->GetKnownledge();
-    auto const & old_info2 = p2->GetKnownledge();
-
-    map<int, Knowledge> merge_info;
-    //collect the most recent knowledge
-    //only the knowledge that has been accepted
-    for(auto && info1 : old_info1) {
-        merge_info[info1.first] = info1.second;
-    }
-
-    for(auto && info2 : old_info2) {
-        //update infos according to a newest time
-        if(merge_info.count(info2.first) > 0) {
-            if(info2.second.GetTime() > merge_info[info2.first].GetTime())
-            // and the quality
-            // only if I never refused that information
-            {
-                merge_info[info2.first] = info2.second;
-            }
-        } else //the info was not present, just add
-        {
-            merge_info[info2.first] = info2.second;
-        }
-    }
-
-    //synchronize the knowledge
-    //accept the information with a certain probability
-    if(_rdDistribution(_rdGenerator) < (1 - p1->GetRiskTolerance())) {
-        p2->ClearKnowledge();
-        for(auto && info : merge_info) {
-            p2->AddKnownClosedDoor(
-                info.first, info.second.GetTime(), info.second.GetState(), _updateFrequency, 1.0);
-        }
-        return true;
-    } else {
-        cout << "refusing the information:" << p2->GetID() << endl;
-        return false;
-    }
-}
-
-bool EventManager::MergeKnowledge(Pedestrian * p1, Pedestrian * p2)
-{
-    auto const & old_info1 = p1->GetKnownledge();
-    auto & old_info2       = p2->GetKnownledge();
-    bool status            = true;
-    //accept the new information
-    if(_rdDistribution(_rdGenerator) < (1 - p1->GetRiskTolerance())) {
-        for(const auto & info1 : old_info1) {
-            // Is the latency ok ?
-            if(!info1.second.CanBeForwarded())
-                continue;
-
-            //do I already have that information ?
-            if(old_info2.count(info1.first) > 0) {
-                //only accept if it is newer
-                if(info1.second.GetTime() > old_info2[info1.first].GetTime()) {
-                    //maybe I already refused that information earlier. Keep refusing
-                    if(old_info2[info1.first].HasBeenRefused() == false) {
-                        old_info2[info1.first] = info1.second;
-                        //alter the quality of the info
-                        old_info2[info1.first].SetQuality(0.5);
-                        old_info2[info1.first].SetLatency(_updateFrequency);
-                    }
-                }
-            } else {
-                //new piece of information
-                old_info2[info1.first] = info1.second;
-                //alter the quality of the info
-                old_info2[info1.first].SetQuality(0.5);
-                old_info2[info1.first].SetLatency(_updateFrequency);
-            }
-        }
-        status = true;
-    }
-    //refuse the new information
-    else {
-        for(const auto & info1 : old_info1) {
-            if(old_info2.count(info1.first) > 0) {
-                old_info2[info1.first].Refuse(true);
-                old_info2[info1.first].SetLatency(_updateFrequency);
-            } else { //refuse the information and set a bad quality
-                old_info2[info1.first] = info1.second;
-                //alter the quality of the info
-                old_info2[info1.first].SetQuality(0.0);
-                old_info2[info1.first].Refuse(true);
-                old_info2[info1.first].SetLatency(_updateFrequency);
-            }
-            //es gibt mindestens eine info zum ablehnen
-            status = false;
-        }
-    }
-    return status;
-}
-
-void EventManager::ProcessEvent()
-{
-    if(_events.empty()) {
-        return;
-    }
-
-    int current_time = Pedestrian::GetGlobalTime();
-
-    //update knowledge about closed doors
-    CollectNewKnowledge(_building);
-
-    if((current_time != _lastUpdateTime) && ((current_time % _updateFrequency) == 0)) {
-        //share the information between the pedestrians
-        DisseminateKnowledge(_building);
-        //actualize based on the new knowledge
-        _lastUpdateTime = current_time;
-    }
-
-    //update the building state
-    // the time is needed as double
-    double current_time_d = Pedestrian::GetGlobalTime();
+    bool eventProcessed = false;
 
     for(const auto & event : _events) {
-        if(fabs(event.GetTime() - current_time_d) < J_EPS_EVENT) {
+        if(fabs(event.GetTime() - Pedestrian::GetGlobalTime()) < J_EPS_EVENT) {
             //Event with current time stamp detected
-            LOG_INFO("Event: after {:.2f} sec", current_time_d);
+            LOG_INFO("Event: after {:.2f} sec", Pedestrian::GetGlobalTime());
             switch(event.GetAction()) {
                 case EventAction::OPEN:
                     OpenDoor(event.GetId());
@@ -449,245 +143,44 @@ void EventManager::ProcessEvent()
                                 "temp_close. Default: do nothing");
                     break;
             }
-            _building->GetRoutingEngine()->setNeedUpdate(true);
+            eventProcessed = true;
         }
     }
-
-    if(_dynamic)
-        ReadEventsTxt(current_time);
+    return eventProcessed;
 }
 
-//close the door if it was open and relaunch the routing procedure
 void EventManager::CloseDoor(int id)
 {
     Transition * t = _building->GetTransition(id);
-
     t->Close(true);
     LOG_INFO("Closing door {}", id);
-    //Create and save a graph corresponding to the actual state of the building.
-    if(CreateRoutingEngine(_building) == false) {
-        LOG_ERROR("Cannot create a routing engine with new event");
-    }
 }
 
 void EventManager::TempCloseDoor(int id)
 {
     Transition * t = _building->GetTransition(id);
-
     t->TempClose(true);
     LOG_INFO("Closing door {}", id);
-    //Create and save a graph corresponding to the actual state of the building.
-    if(CreateRoutingEngine(_building) == false) {
-        LOG_ERROR("Cannot create a routing engine with new event");
-    }
 }
 
-//open the door if it was open and relaunch the routing procedure
 void EventManager::OpenDoor(int id)
 {
     Transition * t = _building->GetTransition(id);
     t->Open(true);
     LOG_INFO("Opening door {}", id);
-    //Create and save a graph corresponding to the actual state of the building.
-    if(CreateRoutingEngine(_building) == false) {
-        LOG_ERROR("Cannot create a routing engine with new event");
-    }
 }
 
-//resets the door if it was open and relaunch the routing procedure
 void EventManager::ResetDoor(int id)
 {
     Transition * t = _building->GetTransition(id);
     t->ResetDoorUsage();
     LOG_INFO("Resetting door usage {}", id);
-    if(CreateRoutingEngine(_building) == false) {
-        LOG_ERROR("Cannot create a routing engine with new event");
-    }
-}
-
-void EventManager::GetEvent(char * c)
-{
-    int split         = 0;
-    std::string type  = "";
-    std::string id    = "";
-    std::string state = "";
-    for(int i = 0; i < 20; i++) {
-        if(!c[i]) {
-            break;
-        } else if(c[i] == ' ') {
-            split++;
-        } else if(c[i] == '\n') {
-        } else {
-            if(split == 0) {
-                type += c[i];
-            } else if(split == 1) {
-                id += c[i];
-            } else if(split == 2) {
-                state += c[i];
-            }
-        }
-    }
-    if(state.compare("close") == 0) {
-        CloseDoor(atoi(id.c_str()));
-    } else {
-        OpenDoor(atoi(id.c_str()));
-    }
-}
-
-bool EventManager::CreateRoutingEngine(Building * _b, int first_engine)
-{
-    std::vector<int> closed_doors;
-    closed_doors.clear();
-
-    for(auto && t : _b->GetAllTransitions()) {
-        if(!t.second->IsClose())
-            closed_doors.push_back(t.second->GetID());
-    }
-    std::sort(closed_doors.begin(), closed_doors.end());
-
-    //create the key as string.
-    std::string key = "";
-    for(int door : closed_doors) {
-        if(key.empty())
-            key.append(std::to_string(door));
-        else
-            key.append(":" + std::to_string(door));
-    }
-
-    //the first (default) engine was created in the simulation
-    // collect the defined routers
-    if(first_engine) {
-        RoutingEngine * engine   = _b->GetRoutingEngine();
-        _eventEngineStorage[key] = engine;
-
-        for(auto && rout : engine->GetAvailableRouters()) {
-            _availableRouters.push_back(rout->GetStrategy());
-        }
-        LOG_WARNING("Adding new routing engine with key {}", key);
-
-
-        return true;
-    }
-
-    // the engine was not created
-    // create a new one with the actual configuration
-    if(_eventEngineStorage.count(key) == 0) {
-        //populate the engine with the routers defined in the ini file
-        //and initialize
-        RoutingEngine * engine = new RoutingEngine();
-        for(auto && rout : _availableRouters) {
-            engine->AddRouter(CreateRouter(rout));
-        }
-
-        if(engine->Init(_b) == false)
-            return false;
-
-        //save the configuration
-        _eventEngineStorage[key] = engine;
-        LOG_WARNING("Adding new routing engine with key {}", key);
-    } else {
-        LOG_WARNING("Routing engine with key {} already exists", key);
-    }
-
-    return true;
-}
-
-Router * EventManager::CreateRouter(const RoutingStrategy & strategy)
-{
-    Router * rout = nullptr;
-
-    switch(strategy) {
-        case ROUTING_LOCAL_SHORTEST:
-            rout = new GlobalRouter(ROUTING_LOCAL_SHORTEST, ROUTING_LOCAL_SHORTEST);
-            break;
-
-        case ROUTING_GLOBAL_SHORTEST:
-            rout = new GlobalRouter(ROUTING_GLOBAL_SHORTEST, ROUTING_GLOBAL_SHORTEST);
-            break;
-
-        case ROUTING_QUICKEST:
-            rout = new QuickestPathRouter(ROUTING_QUICKEST, ROUTING_QUICKEST);
-            break;
-
-        case ROUTING_SMOKE:
-            rout = new SmokeRouter(ROUTING_SMOKE, ROUTING_SMOKE);
-            break;
-
-        case ROUTING_FF_GLOBAL_SHORTEST:
-            rout = new FFRouter(
-                ROUTING_FF_GLOBAL_SHORTEST,
-                ROUTING_FF_GLOBAL_SHORTEST,
-                _config->get_has_specific_goals(),
-                _config);
-            break;
-
-        case ROUTING_FF_QUICKEST:
-            rout = new FFRouter(
-                ROUTING_FF_QUICKEST,
-                ROUTING_FF_QUICKEST,
-                _config->get_has_specific_goals(),
-                _config);
-            break;
-
-        default:
-            LOG_ERROR("Unknown value for routing strategy: {}", strategy);
-            exit(EXIT_FAILURE);
-            break;
-    }
-    return rout;
-}
-
-void EventManager::CreateSomeEngines()
-{
-    LOG_INFO("Populating routers");
-    std::map<int, bool> doors_states;
-
-    for(auto && t : _building->GetAllTransitions()) {
-        LOG_INFO("ID: {} IsOpen: {}", t.second->GetID(), t.second->IsOpen());
-    }
-
-    //save the doors states
-    for(auto && t : _building->GetAllTransitions()) {
-        doors_states[t.second->GetID()] = t.second->IsOpen();
-    }
-
-    //open all doors
-    for(auto && t : _building->GetAllTransitions()) {
-        t.second->Open();
-    }
-
-    //close the doors one by one and create engines
-    for(auto && t1 : _building->GetAllTransitions()) {
-        for(auto && t2 : _building->GetAllTransitions()) {
-            t2.second->Open();
-        }
-        t1.second->Close();
-
-        //create the engine;
-        CreateRoutingEngine(_building, false);
-    }
-
-
-    //restore the door states
-    for(auto && t : _building->GetAllTransitions()) {
-        if(doors_states[t.second->GetID()]) {
-            t.second->Open();
-        } else {
-            t.second->Close();
-        }
-    }
-    LOG_INFO("Done populating routers");
-
-    cout << endl << endl;
-    for(auto && t : _building->GetAllTransitions()) {
-        LOG_INFO("ID: {} IsOpen: {}", t.second->GetID(), t.second->IsOpen());
-    }
-    exit(0);
 }
 
 bool EventManager::ReadSchedule()
 {
     LOG_INFO("Reading schedule");
+
     //get the geometry filename from the project file
     TiXmlDocument doc(_config->GetProjectFile().string());
     if(!doc.LoadFile()) {
@@ -740,20 +233,21 @@ bool EventManager::ReadSchedule()
     }
 
     std::map<int, int> groupMaxAgents;
+    std::map<int, std::vector<int>> groupDoor;
 
     for(TiXmlElement * e = xGroups->FirstChildElement("group"); e;
         e                = e->NextSiblingElement("group")) {
-        int id = atoi(e->Attribute("id"));
+        int id = std::stoi(e->Attribute("id"));
 
         int max_agents = std::numeric_limits<int>::min();
         if(e->Attribute("max_agents")) {
-            max_agents = atoi(e->Attribute("max_agents"));
+            max_agents = std::stoi(e->Attribute("max_agents"));
         }
 
         std::vector<int> member;
         for(TiXmlElement * xmember = e->FirstChildElement("member"); xmember;
             xmember                = xmember->NextSiblingElement("member")) {
-            int tId = atoi(xmember->Attribute("t_id"));
+            int tId = std::stoi(xmember->Attribute("t_id"));
             member.push_back(tId);
         }
         groupDoor[id]      = member;
@@ -778,8 +272,8 @@ bool EventManager::ReadSchedule()
 
     for(TiXmlElement * e = xTimes->FirstChildElement("time"); e;
         e                = e->NextSiblingElement("time")) {
-        int id           = atoi(e->Attribute("group_id"));
-        int closing_time = atoi(e->Attribute("closing_time"));
+        int id           = std::stoi(e->Attribute("group_id"));
+        int closing_time = std::stoi(e->Attribute("closing_time"));
 
         std::string resetString;
         if(e->Attribute("reset")) {
@@ -794,7 +288,7 @@ bool EventManager::ReadSchedule()
 
         for(TiXmlElement * time = e->FirstChildElement("t"); time;
             time                = time->NextSiblingElement("t")) {
-            int t = atoi(time->Attribute("t"));
+            int t = std::stoi(time->Attribute("t"));
             if(resetDoor) {
                 timeReset.push_back(t);
             } else {

--- a/libcore/src/events/EventManager.h
+++ b/libcore/src/events/EventManager.h
@@ -21,152 +21,92 @@
  * along with JuPedSim. If not, see <http://www.gnu.org/licenses/>.
  *
  * \section Description
- *
- *
+ * The EventManager is responsible for handling events related to the door in the simulations.
  **/
 #pragma once
 
 #include "Event.h"
-#include "general/Configuration.h"
-#include "general/Filesystem.h"
-#include "general/Macros.h"
 
-#include <random>
 #include <string>
 #include <vector>
 
 class Building;
-class Pedestrian;
-class Router;
-class RoutingEngine;
-class OutputHandler;
+class Configuration;
 
 class EventManager
 {
 public:
     /**
-      * Constructor
+      * Constructor.
       */
-    EventManager(Configuration * config, Building * _b, unsigned int seed);
+    EventManager(Configuration * config, Building * _b);
 
     /**
-      * destructor
+      * Default deconstructor.
       */
-    ~EventManager();
+    ~EventManager() = default;
 
     /**
       * Read and parse the events
-      * @return false if an error occured
+      * @return false if an error occurred
       */
     bool ReadEventsXml();
 
     /**
-      * Print the parsed events
+      * Print the parsed events.
       */
     void ListEvents();
-
-    /**
-      * Read and parse events from a text file
-      * @param time
-      */
-    void ReadEventsTxt(double time);
 
     /**
       * Reads the schedule file
       */
     bool ReadSchedule();
 
-    //process the event using the current time stamp
-    //from the pedestrian class
-    void ProcessEvent();
-    //Eventhandling
+    /**
+     * Process the event using the current time stamp from the pedestrian class.
+     *
+     * @return Any event was processed.
+     */
+    bool ProcessEvent();
+
+private:
+    /**
+     * Closes the transition identified by \p id.
+     * @param id ID of the transition to close.
+     */
     void CloseDoor(int id);
+
+    /**
+     * Temp closes the transition identified by \p id.
+     * @param id ID of the transition to temp close.
+     */
     void TempCloseDoor(int id);
+
+    /**
+     * Opens the transition identified by \p id.
+     * @param id ID of the transition to close.
+     */
     void OpenDoor(int id);
+
+    /**
+     * Resets the door usage of transition identified by \p id.
+     * @param id ID of the transition to close.
+     */
     void ResetDoor(int id);
-    void GetEvent(char * c);
-
 
 private:
     /**
-      * collect the close doors and generate a new graph
-      * @param _building
-      */
-    bool CreateRoutingEngine(Building * _b, int first_engine = false);
-
-    /**
-      * Create a router corresponding to the given strategy
-      * @param strategy
-      * @return a router/NULL for invalid strategies
-      */
-    Router * CreateRouter(const RoutingStrategy & strategy);
-
-    /**
-      * Update the knowledge about closed doors.
-      * Each pedestrian who is xx metres from a closed door,
-      * will save that information
-      * @param _b, the building object
-      */
-    bool DisseminateKnowledge(Building * _b);
-
-    /**
-      * Gather knowledge about the state of the doors.
-      * Which is going to be disseminated afterwards.
-      * @param _b
-      * @return
-      */
-    bool CollectNewKnowledge(Building * _b);
-
-    /**
-      * Synchronize the knowledge of the two pedestrians.
-      * The information with the newest timestamp
-      * is always accepted with a probability of one.
-      * @param p1, first pedestrian
-      * @param p2, second pedestrian
-      * @return true if the information could be synchronized
-      */
-    bool SynchronizeKnowledge(Pedestrian * p1, Pedestrian * p2);
-
-    /**
-      * Merge the knowledge of the two pedestrians. Ped1 is informing ped2 who depending
-      * on his risk awareness probability could accept of refuse the new information.
-      * @param p1, the informant with the new information
-      * @param p2, the pedestrian receiving the information
-      * @return true in the case p2 accepted the new information
-      */
-    bool MergeKnowledge(Pedestrian * p1, Pedestrian * p2);
-
-    bool MergeKnowledgeUsingProbability(Pedestrian * p1, Pedestrian * p2);
-
-
-    /**
-      * Update the pedestrian route based on the new information
-      * @param p1
-      * @return
-      */
-    bool UpdateRoute(Pedestrian * p1);
-
-    void CreateSomeEngines();
-
-private:
+     * Configuration of simulation.
+     */
     Configuration * _config;
-    std::vector<Event> _events;
-    Building * _building;
-    FILE * _file;
-    bool _dynamic;
-    int _eventCounter;
-    long int _lastUpdateTime;
-    //information propagation time in seconds
-    int _updateFrequency;
-    //information propagation range in meters
-    int _updateRadius;
-    //save the router corresponding to the actual state of the building
-    std::map<std::string, RoutingEngine *> _eventEngineStorage;
-    //save the available routers defined in the simulation
-    std::vector<RoutingStrategy> _availableRouters;
 
-    // random number generator
-    std::mt19937 _rdGenerator;
-    std::uniform_real_distribution<double> _rdDistribution;
-    std::map<int, std::vector<int>> groupDoor;
+    /**
+     * List of all events processed by the EventManager.
+     */
+    std::vector<Event> _events;
+
+    /**
+     * Geometry the events will be processed on.
+     */
+    Building * _building;
 };

--- a/libcore/src/events/EventManager.h
+++ b/libcore/src/events/EventManager.h
@@ -31,7 +31,6 @@
 #include <vector>
 
 class Building;
-class Configuration;
 
 class EventManager
 {
@@ -39,7 +38,7 @@ public:
     /**
       * Constructor.
       */
-    EventManager(Configuration * config, Building * _b);
+    explicit EventManager(Building * _b);
 
     /**
       * Default deconstructor.
@@ -47,20 +46,16 @@ public:
     ~EventManager() = default;
 
     /**
-      * Read and parse the events
-      * @return false if an error occurred
-      */
-    bool ReadEventsXml();
+     * Adds the events from \p events to the EventManager. This should be done before the simulation
+     * starts.
+     * @param events List of events, which should be used in the simulation
+     */
+    void AddEvents(std::vector<Event> events);
 
     /**
       * Print the parsed events.
       */
     void ListEvents();
-
-    /**
-      * Reads the schedule file
-      */
-    bool ReadSchedule();
 
     /**
      * Process the event using the current time stamp from the pedestrian class.
@@ -95,11 +90,6 @@ private:
     void ResetDoor(int id);
 
 private:
-    /**
-     * Configuration of simulation.
-     */
-    Configuration * _config;
-
     /**
      * List of all events processed by the EventManager.
      */


### PR DESCRIPTION
With this PR the functionality of the EventManager reduced. It now only can process the Event (e.g., open, close, temp_close, reset transitions). The reading of the event and schedule file was moved to a new EventFileParser, where additional checks during parsing were added.
Also the knowledge spreading is removed completely from the EventManager as it was broken at the moment. It may added back, with a specific KnowledgeManager later. This leads to the removal of the following input options in the event file: `update_frequency`, `update_radius`, and `agents_color_by_knowledge`, `caption`.
The field `type` from the events is also removed as it is always set to `door`. 