### PR TITLE
Move copy input files to start of simulation

### DIFF
--- a/libcore/src/Simulation.cpp
+++ b/libcore/src/Simulation.cpp
@@ -409,6 +409,10 @@ void Simulation::PrintStatistics(double simTime)
 
 void Simulation::RunHeader(long nPed)
 {
+    // Copy input files used for simulation to output folder for reproducibility
+    CopyInputFilesToOutPath();
+    UpdateOutputFiles();
+
     // writing the header
     if(nPed == -1)
         nPed = _nPeds;
@@ -847,10 +851,6 @@ bool Simulation::correctGeometry(
 
 void Simulation::RunFooter()
 {
-    // Copy input files used for simulation to output folder for reproducibility
-    CopyInputFilesToOutPath();
-    UpdateOutputFiles();
-
     _iod->WriteFooter();
 }
 


### PR DESCRIPTION
Move the copy of all input files to start of simulation. Otherwise it can happen that the simulation breaks at some point and the results directory is not set properly or worse set with wrong files.