### PR TITLE
Automatically set jpscore executable for systemtest

### DIFF
--- a/systemtest/CMakeLists.txt
+++ b/systemtest/CMakeLists.txt
@@ -1,3 +1,6 @@
+# get used jpscore executable
+set(jpscore_exe $<TARGET_FILE:jpscore>)
+
 add_subdirectory(test_geometry)
 add_subdirectory(juelich_tests)
 add_subdirectory(rimea_tests)

--- a/systemtest/JPSRunTest.py
+++ b/systemtest/JPSRunTest.py
@@ -27,17 +27,18 @@ def getScriptPath():
 
 class JPSRunTestDriver(object):
 
-    def __init__(self, testnumber, argv0, testdir, utestdir="..", jpsreportdir=""):
+    def __init__(self, testnumber, argv0, testdir, utestdir="..", jpsreportdir="", jpscore=""):
         self.SUCCESS = 0
         self.FAILURE = 1
         # check if testnumber is digit
         assert isinstance(testnumber, float) or isinstance(testnumber, int), "argument <testnumber> is not digit"
         # only allow path and strings as path directory name
         assert isinstance(argv0, str), "argument <testdir> is not string"
-        assert path.exists(testdir), "%s does not exist"%testdir
-        assert path.exists(utestdir), "%s does not exist"%utestdir
+        assert path.exists(testdir), "%s does not exist" % testdir
+        assert path.exists(utestdir), "%s does not exist" % utestdir
         assert isinstance(argv0, str), "argument <argv0> is not string"
-        assert path.exists(argv0), "%s is does not exist"%argv0
+        assert path.exists(argv0), "%s is does not exist" % argv0
+        assert jpscore, "no jpscore executable given"
         self.testno = testnumber
 
         # touch file if not already there
@@ -46,6 +47,7 @@ class JPSRunTestDriver(object):
         self.HOME = path.expanduser("~")
         self.DIR = testdir
         self.jpsreportdir = jpsreportdir
+        self.jpscore = jpscore
         # Where to find the measured data from the simulations. We will use Voronoi diagrams
         # if self.testno == 101: # fix for 1dfd, since jpsreport can not be used in 1D
         self.simDataDir = os.path.join(self.DIR,
@@ -67,11 +69,11 @@ class JPSRunTestDriver(object):
     def run_test(self, testfunction, fd=0, *args): #fd==1: make fundamental diagram
         assert hasattr(testfunction, '__call__'), "run_test: testfunction has no __call__ function"
         self.__configure()
-        jpscore = os.path.join(self.trunk, "build", "bin", "jpscore")
-        jpscore_exe = self.__find_executable(jpscore)
+        assert path.exists(self.jpscore), "executable {} does not exists".format(self.jpscore)
+
         results = []
         for inifile in self.inifiles:
-            res = self.__execute_test(jpscore_exe, inifile, testfunction, *args)
+            res = self.__execute_test(self.jpscore, inifile, testfunction, *args)
             results.append(res)
 
         if fd:

--- a/systemtest/door_tests/CMakeLists.txt
+++ b/systemtest/door_tests/CMakeLists.txt
@@ -3,7 +3,7 @@ foreach (file ${test_py_files})
     get_filename_component(test ${file} NAME_WE)
     add_test(
             NAME ${test}
-            COMMAND ${PYTHON_EXECUTABLE} ${file}
+            COMMAND ${PYTHON_EXECUTABLE} ${file} ${jpscore_exe}
     )
     set_tests_properties(
             ${test}

--- a/systemtest/door_tests/test_flow_regulation/01_door_flow_regulation.py
+++ b/systemtest/door_tests/test_flow_regulation/01_door_flow_regulation.py
@@ -181,7 +181,7 @@ def runtest(inifile, trajfile):
 
 
 if __name__ == "__main__":
-    test = JPSRunTestDriver(2, argv0=argv[0], testdir=path[0], utestdir=utestdir)
+    test = JPSRunTestDriver(2, argv0=argv[0], testdir=path[0], utestdir=utestdir, jpscore=argv[1])
     test.run_test(testfunction=runtest)
     logging.info("%s exits with SUCCESS" % (argv[0]))
     exit(SUCCESS)

--- a/systemtest/juelich_tests/CMakeLists.txt
+++ b/systemtest/juelich_tests/CMakeLists.txt
@@ -1,27 +1,27 @@
-add_test(NAME juelich_test-1 COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/systemtest/juelich_tests/test_1/runtest_juelich_1.py)
-add_test(NAME juelich_test-2 COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/systemtest/juelich_tests/test_2/runtest_juelich_2.py)
-add_test(NAME juelich_test-3 COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/systemtest/juelich_tests/test_3/runtest_juelich_3.py)
-add_test(NAME juelich_test-4 COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/systemtest/juelich_tests/test_4/runtest_juelich_4.py)
-add_test(NAME juelich_test-5 COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/systemtest/juelich_tests/test_5/runtest_juelich_5.py)
-add_test(NAME juelich_test-6 COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/systemtest/juelich_tests/test_6/runtest_juelich_6.py)
-add_test(NAME juelich_test-9 COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/systemtest/juelich_tests/test_9/runtest_juelich_9.py)
-add_test(NAME juelich_test-11 COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/systemtest/juelich_tests/test_11/runtest_juelich_11.py)
-add_test(NAME juelich_test-12 COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/systemtest/juelich_tests/test_12/runtest_juelich_12.py)
-add_test(NAME juelich_test-15 COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/systemtest/juelich_tests/test_15/runtest_juelich_15.py)
+add_test(NAME juelich_test-1 COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/systemtest/juelich_tests/test_1/runtest_juelich_1.py ${jpscore_exe})
+add_test(NAME juelich_test-2 COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/systemtest/juelich_tests/test_2/runtest_juelich_2.py ${jpscore_exe})
+add_test(NAME juelich_test-3 COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/systemtest/juelich_tests/test_3/runtest_juelich_3.py ${jpscore_exe})
+add_test(NAME juelich_test-4 COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/systemtest/juelich_tests/test_4/runtest_juelich_4.py ${jpscore_exe})
+add_test(NAME juelich_test-5 COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/systemtest/juelich_tests/test_5/runtest_juelich_5.py ${jpscore_exe})
+add_test(NAME juelich_test-6 COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/systemtest/juelich_tests/test_6/runtest_juelich_6.py ${jpscore_exe})
+add_test(NAME juelich_test-9 COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/systemtest/juelich_tests/test_9/runtest_juelich_9.py ${jpscore_exe})
+add_test(NAME juelich_test-11 COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/systemtest/juelich_tests/test_11/runtest_juelich_11.py ${jpscore_exe})
+add_test(NAME juelich_test-12 COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/systemtest/juelich_tests/test_12/runtest_juelich_12.py ${jpscore_exe})
+add_test(NAME juelich_test-15 COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/systemtest/juelich_tests/test_15/runtest_juelich_15.py ${jpscore_exe})
 set_tests_properties(
-    juelich_test-1
-    juelich_test-2
-    juelich_test-3
-    juelich_test-4
-    juelich_test-5
-    juelich_test-6
-    juelich_test-9
-    juelich_test-11
-    juelich_test-12
-    juelich_test-15
-    PROPERTIES LABELS "CI:FAST")
+        juelich_test-1
+        juelich_test-2
+        juelich_test-3
+        juelich_test-4
+        juelich_test-5
+        juelich_test-6
+        juelich_test-9
+        juelich_test-11
+        juelich_test-12
+        juelich_test-15
+        PROPERTIES LABELS "CI:FAST")
 
 
-add_test(NAME juelich_test-8 COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/systemtest/juelich_tests/test_8/runtest_juelich_8.py)
-add_test(NAME juelich_test-10 COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/systemtest/juelich_tests/test_10/runtest_juelich_10.py)
-add_test(NAME juelich_test-14 COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/systemtest/juelich_tests/test_14/runtest_juelich_14.py)
+add_test(NAME juelich_test-8 COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/systemtest/juelich_tests/test_8/runtest_juelich_8.py ${jpscore_exe})
+add_test(NAME juelich_test-10 COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/systemtest/juelich_tests/test_10/runtest_juelich_10.py ${jpscore_exe})
+add_test(NAME juelich_test-14 COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/systemtest/juelich_tests/test_14/runtest_juelich_14.py ${jpscore_exe})

--- a/systemtest/juelich_tests/test_1/runtest_juelich_1.py
+++ b/systemtest/juelich_tests/test_1/runtest_juelich_1.py
@@ -26,7 +26,7 @@ def runtest1(inifile, trajfile):
 
 
 if __name__ == "__main__":
-    test = JPSRunTestDriver(1, argv0=argv[0], testdir=sys.path[0], utestdir=utestdir)
+    test = JPSRunTestDriver(1, argv0=argv[0], testdir=sys.path[0], utestdir=utestdir, jpscore=argv[1])
     test.run_test(testfunction=runtest1)
     logging.info("%s exits with SUCCESS" % (argv[0]))
     exit(SUCCESS)

--- a/systemtest/juelich_tests/test_12/runtest_juelich_12.py
+++ b/systemtest/juelich_tests/test_12/runtest_juelich_12.py
@@ -23,7 +23,7 @@ def runtest12(inifile, trajfile):
         logging.info("dy2 = %f (tolerance=%f)", dy2, tolerance)
 
 if __name__ == "__main__":
-    test = JPSRunTestDriver(12, argv0=argv[0], testdir=sys.path[0], utestdir=utestdir)
+    test = JPSRunTestDriver(12, argv0=argv[0], testdir=sys.path[0], utestdir=utestdir, jpscore=argv[1])
     test.run_test(testfunction=runtest12)
     logging.info("%s exits with SUCCESS" % (argv[0]))
     exit(SUCCESS)

--- a/systemtest/juelich_tests/test_14/runtest_juelich_14.py
+++ b/systemtest/juelich_tests/test_14/runtest_juelich_14.py
@@ -51,8 +51,8 @@ def runtest14(inifile, trajfile):
 
 if __name__ == "__main__":
     PX = []  #p-value for x
-    PY = []  #p-value for y
-    test = JPSRunTestDriver(14, argv0=argv[0], testdir=sys.path[0], utestdir=utestdir)
+    PY = []  # p-value for y
+    test = JPSRunTestDriver(14, argv0=argv[0], testdir=sys.path[0], utestdir=utestdir, jpscore=argv[1])
     results = test.run_test(testfunction=runtest14)
     results = np.array(results)
     PX = results[:, 0]

--- a/systemtest/juelich_tests/test_15/runtest_juelich_15.py
+++ b/systemtest/juelich_tests/test_15/runtest_juelich_15.py
@@ -56,7 +56,7 @@ def runtest15(inifile, trajfile):
         
 
 if __name__ == "__main__":
-    test = JPSRunTestDriver(15, argv0=argv[0], testdir=sys.path[0], utestdir=utestdir)
+    test = JPSRunTestDriver(15, argv0=argv[0], testdir=sys.path[0], utestdir=utestdir, jpscore=argv[1])
     test.run_test(runtest15)
     logging.info("%s exits with SUCCESS"%(argv[0]))
     exit(SUCCESS)

--- a/systemtest/juelich_tests/test_2/runtest_juelich_2.py
+++ b/systemtest/juelich_tests/test_2/runtest_juelich_2.py
@@ -33,7 +33,8 @@ def runtest2(inifile, trajfile):
 
 
 if __name__ == "__main__":
-    test = JPSRunTestDriver(2, argv0=argv[0], testdir=sys.path[0], utestdir=utestdir)
+    logging.error("{}".format(argv))
+    test = JPSRunTestDriver(2, argv0=argv[0], testdir=sys.path[0], utestdir=utestdir, jpscore=argv[1])
     test.run_test(testfunction=runtest2)
     logging.info("%s exits with SUCCESS" % (argv[0]))
     exit(SUCCESS)

--- a/systemtest/juelich_tests/test_3/runtest_juelich_3.py
+++ b/systemtest/juelich_tests/test_3/runtest_juelich_3.py
@@ -26,7 +26,7 @@ def runtest3(inifile, trajfile):
 
 
 if __name__ == "__main__":
-    test = JPSRunTestDriver(3, argv0=argv[0], testdir=sys.path[0], utestdir=utestdir)
+    test = JPSRunTestDriver(3, argv0=argv[0], testdir=sys.path[0], utestdir=utestdir, jpscore=argv[1])
     test.run_test(testfunction=runtest3)
     logging.info("%s exits with SUCCESS" % (argv[0]))
     exit(SUCCESS)

--- a/systemtest/juelich_tests/test_4/runtest_juelich_4.py
+++ b/systemtest/juelich_tests/test_4/runtest_juelich_4.py
@@ -35,7 +35,7 @@ def runtest4(inifile, trajfile):
 
 
 if __name__ == "__main__":
-    test = JPSRunTestDriver(4, argv0=argv[0], testdir=sys.path[0], utestdir=utestdir)
+    test = JPSRunTestDriver(4, argv0=argv[0], testdir=sys.path[0], utestdir=utestdir, jpscore=argv[1])
     test.run_test(testfunction=runtest4)
     logging.info("%s exits with SUCCESS" % (argv[0]))
     exit(SUCCESS)

--- a/systemtest/juelich_tests/test_5/runtest_juelich_5.py
+++ b/systemtest/juelich_tests/test_5/runtest_juelich_5.py
@@ -40,7 +40,7 @@ def runtest5(inifile, trajfile):
 
 
 if __name__ == "__main__":
-    test = JPSRunTestDriver(5, argv0=argv[0], testdir=sys.path[0], utestdir=utestdir)
+    test = JPSRunTestDriver(5, argv0=argv[0], testdir=sys.path[0], utestdir=utestdir, jpscore=argv[1])
     test.run_test(testfunction=runtest5)
     logging.info("%s exits with SUCCESS" % (argv[0]))
     exit(SUCCESS)

--- a/systemtest/juelich_tests/test_6/runtest_juelich_6.py
+++ b/systemtest/juelich_tests/test_6/runtest_juelich_6.py
@@ -23,7 +23,7 @@ def runtest6(inifile, trajfile):
 
 
 if __name__ == "__main__":
-    test = JPSRunTestDriver(6, argv0=argv[0], testdir=sys.path[0], utestdir=utestdir)
+    test = JPSRunTestDriver(6, argv0=argv[0], testdir=sys.path[0], utestdir=utestdir, jpscore=argv[1])
     test.run_test(testfunction=runtest6)
     logging.info("%s exits with SUCCESS" % (argv[0]))
     exit(SUCCESS)

--- a/systemtest/juelich_tests/test_8/runtest_juelich_8.py
+++ b/systemtest/juelich_tests/test_8/runtest_juelich_8.py
@@ -27,7 +27,7 @@ def runtest8(inifile, trajfile):
 
 
 if __name__ == "__main__":
-    test = JPSRunTestDriver(8, argv0=argv[0], testdir=sys.path[0], utestdir=utestdir)
+    test = JPSRunTestDriver(8, argv0=argv[0], testdir=sys.path[0], utestdir=utestdir, jpscore=argv[1])
     test.run_test(testfunction=runtest8)
     logging.info("%s exits with SUCCESS" % (argv[0]))
     exit(SUCCESS)

--- a/systemtest/juelich_tests/test_9/runtest_juelich_9.py
+++ b/systemtest/juelich_tests/test_9/runtest_juelich_9.py
@@ -64,7 +64,7 @@ def run_test_9(inifile, trajfile):
 if __name__ == "__main__":
     test = JPSRunTestDriver(9, argv0=argv[0],
                             testdir=sys.path[0],
-                            utestdir=utestdir)
+                            utestdir=utestdir, jpscore=argv[1])
 
     results = test.run_test(testfunction=run_test_9)
     eval_results(results)

--- a/systemtest/rimea_tests/CMakeLists.txt
+++ b/systemtest/rimea_tests/CMakeLists.txt
@@ -3,7 +3,7 @@ foreach (file ${test_py_files})
     get_filename_component(test ${file} NAME_WE)
     string(REGEX MATCH "[0-9]+" test_number ${test})
     add_test(
-        NAME rimea_test-${test_number}
-        COMMAND ${PYTHON_EXECUTABLE} ${file}
-        )
+            NAME rimea_test-${test_number}
+            COMMAND ${PYTHON_EXECUTABLE} ${file} ${jpscore_exe}
+    )
 endforeach ()

--- a/systemtest/rimea_tests/test_1/runtest_rimea_1.py
+++ b/systemtest/rimea_tests/test_1/runtest_rimea_1.py
@@ -52,8 +52,8 @@ def run_rimea_test1(inifile, trajfile):
 
 
 if __name__ == "__main__":
-    start_time=time.time()
-    test = JPSRunTestDriver(1, argv0=argv[0], testdir=sys.path[0], utestdir=utestdir)
+    start_time = time.time()
+    test = JPSRunTestDriver(1, argv0=argv[0], testdir=sys.path[0], utestdir=utestdir, jpscore=argv[1])
     test.run_test(testfunction=run_rimea_test1)
     logging.info("%s exits with SUCCESS\nExecution time %.3f seconds." % (argv[0],time.time()-start_time))
     exit(SUCCESS)

--- a/systemtest/rimea_tests/test_10/runtest_rimea_10.py
+++ b/systemtest/rimea_tests/test_10/runtest_rimea_10.py
@@ -69,8 +69,8 @@ def run_rimea_test10(inifile, trajfile):
 
 
 if __name__ == "__main__":
-    start_time=time.time()
-    test = JPSRunTestDriver(10, argv0=argv[0], testdir=sys.path[0], utestdir=utestdir)
+    start_time = time.time()
+    test = JPSRunTestDriver(10, argv0=argv[0], testdir=sys.path[0], utestdir=utestdir, jpscore=argv[1])
     test.run_test(testfunction=run_rimea_test10)
     logging.info("%s exits with SUCCESS\nExecution time %.3f seconds." % (argv[0],time.time()-start_time))
     exit(SUCCESS)

--- a/systemtest/rimea_tests/test_11/runtest_rimea_11.py
+++ b/systemtest/rimea_tests/test_11/runtest_rimea_11.py
@@ -38,8 +38,8 @@ def run_rimea_test11(inifile, trajfile):
         logging.info("%d peds evacuated from exit <%s>", num_evacuated, f.split(".dat")[0].split("_id_")[1])
 
 if __name__ == "__main__":
-    start_time=time.time()
-    test = JPSRunTestDriver(11, argv0=argv[0], testdir=sys.path[0], utestdir=utestdir)
+    start_time = time.time()
+    test = JPSRunTestDriver(11, argv0=argv[0], testdir=sys.path[0], utestdir=utestdir, jpscore=argv[1])
     test.run_test(testfunction=run_rimea_test11)
     logging.info("%s exits with SUCCESS\nExecution time %.3f seconds." % (argv[0],time.time()-start_time))
     exit(SUCCESS)

--- a/systemtest/rimea_tests/test_12/runtest_rimea_12.py
+++ b/systemtest/rimea_tests/test_12/runtest_rimea_12.py
@@ -52,8 +52,8 @@ def run_rimea_test12(inifile, trajfile):
 
 
 if __name__ == "__main__":
-    start_time=time.time()
-    test = JPSRunTestDriver(12, argv0=argv[0], testdir=sys.path[0], utestdir=utestdir)
+    start_time = time.time()
+    test = JPSRunTestDriver(12, argv0=argv[0], testdir=sys.path[0], utestdir=utestdir, jpscore=argv[1])
     test.run_test(testfunction=run_rimea_test12)
     logging.info("%s exits with SUCCESS\nExecution time %.3f seconds." % (argv[0],time.time()-start_time))
     exit(SUCCESS)

--- a/systemtest/rimea_tests/test_13/runtest_rimea_13.py
+++ b/systemtest/rimea_tests/test_13/runtest_rimea_13.py
@@ -83,8 +83,8 @@ def run_rimea_test13(inifile, trajfile):
     return (J_corridor, J_stair)
 
 if __name__ == "__main__":
-    start_time=time.time()
-    test = JPSRunTestDriver(13, argv0=argv[0], testdir=sys.path[0], utestdir=utestdir)
+    start_time = time.time()
+    test = JPSRunTestDriver(13, argv0=argv[0], testdir=sys.path[0], utestdir=utestdir, jpscore=argv[1])
     results = test.run_test(testfunction=run_rimea_test13)
     eval_results(results)
     logging.info("%s exits with SUCCESS\nExecution time %.3f seconds." % (argv[0],time.time()-start_time))

--- a/systemtest/rimea_tests/test_14/runtest_rimea_14.py
+++ b/systemtest/rimea_tests/test_14/runtest_rimea_14.py
@@ -65,8 +65,8 @@ def run_rimea_test14(inifile, trajfile):
     logging.info("Return state ---> %s", state)
 
 if __name__ == "__main__":
-    start_time=time.time()
-    test = JPSRunTestDriver(14, argv0=argv[0], testdir=sys.path[0], utestdir=utestdir)
+    start_time = time.time()
+    test = JPSRunTestDriver(14, argv0=argv[0], testdir=sys.path[0], utestdir=utestdir, jpscore=argv[1])
     test.run_test(testfunction=run_rimea_test14)
     logging.info("%s exits with SUCCESS\nExecution time %.3f seconds." % (argv[0],time.time()-start_time))
     exit(SUCCESS)

--- a/systemtest/rimea_tests/test_15/runtest_rimea_15.py
+++ b/systemtest/rimea_tests/test_15/runtest_rimea_15.py
@@ -101,8 +101,8 @@ def create_dia (peds):
     return ('none')
 
 if __name__ == "__main__":
-    start_time=time.time()
-    test = JPSRunTestDriver(15, argv0=argv[0], testdir=sys.path[0], utestdir=utestdir)
+    start_time = time.time()
+    test = JPSRunTestDriver(15, argv0=argv[0], testdir=sys.path[0], utestdir=utestdir, jpscore=argv[1])
     test.run_test(testfunction=run_rimea_test15)
     logging.info("%s exits with SUCCESS\nExecution time %.3f seconds." % (argv[0],time.time()-start_time))
     exit(SUCCESS)

--- a/systemtest/rimea_tests/test_2/runtest_rimea_2.py
+++ b/systemtest/rimea_tests/test_2/runtest_rimea_2.py
@@ -56,8 +56,8 @@ def run_rimea_test2(inifile, trajfile):
         exit(FAILURE)
 
 if __name__ == "__main__":
-    start_time=time.time()
-    test = JPSRunTestDriver(2, argv0=argv[0], testdir=sys.path[0], utestdir=utestdir)
+    start_time = time.time()
+    test = JPSRunTestDriver(2, argv0=argv[0], testdir=sys.path[0], utestdir=utestdir, jpscore=argv[1])
     test.run_test(testfunction=run_rimea_test2)
     logging.info("%s exits with SUCCESS\nExecution time %.3f seconds." % (argv[0],time.time()-start_time))
     exit(SUCCESS)

--- a/systemtest/rimea_tests/test_3/runtest_rimea_3.py
+++ b/systemtest/rimea_tests/test_3/runtest_rimea_3.py
@@ -56,8 +56,8 @@ def run_rimea_test3(inifile, trajfile):
         exit(FAILURE)
 
 if __name__ == "__main__":
-    start_time=time.time()
-    test = JPSRunTestDriver(3, argv0=argv[0], testdir=sys.path[0], utestdir=utestdir)
+    start_time = time.time()
+    test = JPSRunTestDriver(3, argv0=argv[0], testdir=sys.path[0], utestdir=utestdir, jpscore=argv[1])
     test.run_test(testfunction=run_rimea_test3)
     logging.info("%s exits with SUCCESS\nExecution time %.3f seconds." % (argv[0],time.time()-start_time))
     exit(SUCCESS)

--- a/systemtest/rimea_tests/test_4/runtest_rimea_4.py
+++ b/systemtest/rimea_tests/test_4/runtest_rimea_4.py
@@ -221,8 +221,8 @@ def run_rimea_test4(inifile, trajfile):
         txt_file.close()
 
 if __name__ == "__main__":
-    start_time=time.time()
-    test = JPSRunTestDriver(4, argv0=argv[0], testdir=sys.path[0], utestdir=utestdir)
+    start_time = time.time()
+    test = JPSRunTestDriver(4, argv0=argv[0], testdir=sys.path[0], utestdir=utestdir, jpscore=argv[1])
     test.run_test(testfunction=run_rimea_test4)
     logging.info("%s exits with SUCCESS\nExecution time %.3f seconds." % (argv[0],time.time()-start_time))
     exit(SUCCESS)

--- a/systemtest/rimea_tests/test_5/runtest_rimea_5.py
+++ b/systemtest/rimea_tests/test_5/runtest_rimea_5.py
@@ -90,8 +90,8 @@ def run_rimea_test5(inifile, trajfile):
         exit(FAILURE)
 
 if __name__ == "__main__":
-    start_time=time.time()
-    test = JPSRunTestDriver(5, argv0=argv[0], testdir=sys.path[0], utestdir=utestdir)
+    start_time = time.time()
+    test = JPSRunTestDriver(5, argv0=argv[0], testdir=sys.path[0], utestdir=utestdir, jpscore=argv[1])
     test.run_test(testfunction=run_rimea_test5)
     logging.info("%s exits with SUCCESS\nExecution time %.3f seconds." % (argv[0],time.time()-start_time))
     exit(SUCCESS)

--- a/systemtest/rimea_tests/test_6/runtest_rimea_6.py
+++ b/systemtest/rimea_tests/test_6/runtest_rimea_6.py
@@ -49,8 +49,8 @@ def run_rimea_test6(inifile, trajfile):
         exit(FAILURE)
 
 if __name__ == "__main__":
-    start_time=time.time()
-    test = JPSRunTestDriver(6, argv0=argv[0], testdir=sys.path[0], utestdir=utestdir)
+    start_time = time.time()
+    test = JPSRunTestDriver(6, argv0=argv[0], testdir=sys.path[0], utestdir=utestdir, jpscore=argv[1])
     test.run_test(testfunction=run_rimea_test6)
     logging.info("%s exits with SUCCESS\nExecution time %.3f seconds." % (argv[0],time.time()-start_time))
     exit(SUCCESS)

--- a/systemtest/rimea_tests/test_7/runtest_rimea_7.py
+++ b/systemtest/rimea_tests/test_7/runtest_rimea_7.py
@@ -112,8 +112,8 @@ def run_rimea_test7(inifile, trajfile):
         exit(FAILURE)
 
 if __name__ == "__main__":
-    start_time=time.time()
-    test = JPSRunTestDriver(7, argv0=argv[0], testdir=sys.path[0], utestdir=utestdir)
+    start_time = time.time()
+    test = JPSRunTestDriver(7, argv0=argv[0], testdir=sys.path[0], utestdir=utestdir, jpscore=argv[1])
     test.run_test(testfunction=run_rimea_test7)
     logging.info("%s exits with SUCCESS\nExecution time %.3f seconds." % (argv[0],time.time()-start_time))
     exit(SUCCESS)

--- a/systemtest/rimea_tests/test_8/runtest_rimea_8.py
+++ b/systemtest/rimea_tests/test_8/runtest_rimea_8.py
@@ -83,8 +83,8 @@ def run_rimea_test8(inifile, trajfile):
         plt.savefig(figname)
 
 if __name__ == "__main__":
-    start_time=time.time()
-    test = JPSRunTestDriver(8, argv0=argv[0], testdir=sys.path[0], utestdir=utestdir)
+    start_time = time.time()
+    test = JPSRunTestDriver(8, argv0=argv[0], testdir=sys.path[0], utestdir=utestdir, jpscore=argv[1])
     test.run_test(testfunction=run_rimea_test8)
     logging.info("%s exits with SUCCESS\nExecution time %.3f seconds." % (argv[0],time.time()-start_time))
     exit(SUCCESS)

--- a/systemtest/rimea_tests/test_9/runtest_rimea_9.py
+++ b/systemtest/rimea_tests/test_9/runtest_rimea_9.py
@@ -66,8 +66,8 @@ def run_rimea_test9(inifile, trajfile):
         exit(FAILURE)
 
 if __name__ == "__main__":
-    start_time=time.time()
-    test = JPSRunTestDriver(9, argv0=argv[0], testdir=sys.path[0], utestdir=utestdir)
+    start_time = time.time()
+    test = JPSRunTestDriver(9, argv0=argv[0], testdir=sys.path[0], utestdir=utestdir, jpscore=argv[1])
     test.run_test(testfunction=run_rimea_test9)
     logging.info("%s exits with SUCCESS\nExecution time %.3f seconds." % (argv[0],time.time()-start_time))
     exit(SUCCESS)

--- a/systemtest/router_tests/CMakeLists.txt
+++ b/systemtest/router_tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_test(NAME router_test-10 COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/systemtest/router_tests/test_router_10/runtest_router_10.py)
+add_test(NAME router_test-10 COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/systemtest/router_tests/test_router_10/runtest_router_10.py ${jpscore_exe})
 
 set_tests_properties(
         router_test-10

--- a/systemtest/router_tests/test_router_1/runtest_router_1.py
+++ b/systemtest/router_tests/test_router_1/runtest_router_1.py
@@ -36,7 +36,7 @@ def runtest1(inifile, trajfile):
 
 
 if __name__ == "__main__":
-    test = JPSRunTestDriver(1, argv0=argv[0], testdir=sys.path[0], utestdir=utestdir)
+    test = JPSRunTestDriver(1, argv0=argv[0], testdir=sys.path[0], utestdir=utestdir, jpscore=argv[1])
     test.run_test(testfunction=runtest1)
     logging.info("%s exits with SUCCESS" % (argv[0]))
     exit(SUCCESS)

--- a/systemtest/router_tests/test_router_10/runtest_router_10.py
+++ b/systemtest/router_tests/test_router_10/runtest_router_10.py
@@ -40,7 +40,9 @@ def runtest10(inifile, trajfile):
 
 
 if __name__ == "__main__":
-    test = JPSRunTestDriver(10, argv0=argv[0], testdir=sys.path[0], utestdir=utestdir)
+    test = JPSRunTestDriver(10, argv0=argv[0], testdir=sys.path[0], utestdir=utestdir, jpscore=argv[1])
+
     test.run_test(testfunction=runtest10)
     logging.info("%s exits with SUCCESS." % (argv[0]))
+
     exit(SUCCESS)

--- a/systemtest/router_tests/test_router_2/runtest_router_2.py
+++ b/systemtest/router_tests/test_router_2/runtest_router_2.py
@@ -48,7 +48,7 @@ def runtest2(inifile, trajfile):
 
 
 if __name__ == "__main__":
-    test = JPSRunTestDriver(2, argv0=argv[0], testdir=sys.path[0], utestdir=utestdir)
+    test = JPSRunTestDriver(2, argv0=argv[0], testdir=sys.path[0], utestdir=utestdir, jpscore=argv[1])
     test.run_test(testfunction=runtest2)
     logging.info("%s exits with SUCCESS" % (argv[0]))
     exit(SUCCESS)

--- a/systemtest/router_tests/test_router_3/runtest_router_3.py
+++ b/systemtest/router_tests/test_router_3/runtest_router_3.py
@@ -39,7 +39,7 @@ def runtest3(inifile, trajfile):
 
 
 if __name__ == "__main__":
-    test = JPSRunTestDriver(3, argv0=argv[0], testdir=sys.path[0], utestdir=utestdir)
+    test = JPSRunTestDriver(3, argv0=argv[0], testdir=sys.path[0], utestdir=utestdir, jpscore=argv[1])
     test.run_test(testfunction=runtest3)
     logging.info("%s exits with SUCCESS" % (argv[0]))
     exit(SUCCESS)

--- a/systemtest/router_tests/test_router_4/runtest_router_4.py
+++ b/systemtest/router_tests/test_router_4/runtest_router_4.py
@@ -46,7 +46,7 @@ def runtest4(inifile, trajfile):
 
 
 if __name__ == "__main__":
-    test = JPSRunTestDriver(4, argv0=argv[0], testdir=sys.path[0], utestdir=utestdir)
+    test = JPSRunTestDriver(4, argv0=argv[0], testdir=sys.path[0], utestdir=utestdir, jpscore=argv[1])
     test.run_test(testfunction=runtest4)
     logging.info("%s exits with SUCCESS." % (argv[0]))
     exit(SUCCESS)

--- a/systemtest/router_tests/test_router_5/runtest_router_5.py
+++ b/systemtest/router_tests/test_router_5/runtest_router_5.py
@@ -56,7 +56,7 @@ def runtest5(inifile, trajfile):
 
 
 if __name__ == "__main__":
-    test = JPSRunTestDriver(5, argv0=argv[0], testdir=sys.path[0], utestdir=utestdir)
+    test = JPSRunTestDriver(5, argv0=argv[0], testdir=sys.path[0], utestdir=utestdir, jpscore=argv[1])
     test.run_test(testfunction=runtest5)
     logging.info("%s exits with SUCCESS." % (argv[0]))
     exit(SUCCESS)

--- a/systemtest/router_tests/test_router_6/runtest_router_6.py
+++ b/systemtest/router_tests/test_router_6/runtest_router_6.py
@@ -47,7 +47,7 @@ def runtest6(inifile, trajfile):
 
 
 if __name__ == "__main__":
-    test = JPSRunTestDriver(6, argv0=argv[0], testdir=sys.path[0], utestdir=utestdir)
+    test = JPSRunTestDriver(6, argv0=argv[0], testdir=sys.path[0], utestdir=utestdir, jpscore=argv[1])
     test.run_test(testfunction=runtest6)
     logging.info("%s exits with SUCCESS." % (argv[0]))
     exit(SUCCESS)

--- a/systemtest/router_tests/test_router_7/runtest_router_7.py
+++ b/systemtest/router_tests/test_router_7/runtest_router_7.py
@@ -56,7 +56,7 @@ def runtest7(inifile, trajfile):
 
 
 if __name__ == "__main__":
-    test = JPSRunTestDriver(7, argv0=argv[0], testdir=sys.path[0], utestdir=utestdir)
+    test = JPSRunTestDriver(7, argv0=argv[0], testdir=sys.path[0], utestdir=utestdir, jpscore=argv[1])
     test.run_test(testfunction=runtest7)
     logging.info("%s exits with SUCCESS." % (argv[0]))
     exit(SUCCESS)

--- a/systemtest/router_tests/test_router_8/runtest_router_8.py
+++ b/systemtest/router_tests/test_router_8/runtest_router_8.py
@@ -43,7 +43,7 @@ def runtest8(inifile, trajfile):
 
 
 if __name__ == "__main__":
-    test = JPSRunTestDriver(8, argv0=argv[0], testdir=sys.path[0], utestdir=utestdir)
+    test = JPSRunTestDriver(8, argv0=argv[0], testdir=sys.path[0], utestdir=utestdir, jpscore=argv[1])
     test.run_test(testfunction=runtest8)
     logging.info("%s exits with SUCCESS." % (argv[0]))
     exit(SUCCESS)

--- a/systemtest/router_tests/test_router_9/runtest_router_9.py
+++ b/systemtest/router_tests/test_router_9/runtest_router_9.py
@@ -42,7 +42,7 @@ def runtest9(inifile, trajfile):
 
 
 if __name__ == "__main__":
-    test = JPSRunTestDriver(9, argv0=argv[0], testdir=sys.path[0], utestdir=utestdir)
+    test = JPSRunTestDriver(9, argv0=argv[0], testdir=sys.path[0], utestdir=utestdir, jpscore=argv[1])
     test.run_test(testfunction=runtest9)
     logging.info("%s exits with SUCCESS." % (argv[0]))
     exit(SUCCESS)

--- a/systemtest/source_tests/CMakeLists.txt
+++ b/systemtest/source_tests/CMakeLists.txt
@@ -2,9 +2,9 @@ file(GLOB_RECURSE test_py_files "${CMAKE_SOURCE_DIR}/systemtest/source_tests/*/*
 foreach (file ${test_py_files})
     get_filename_component(test ${file} NAME_WE)
     add_test(
-        NAME ${test}
-        COMMAND ${PYTHON_EXECUTABLE} ${file}
-        )
+            NAME ${test}
+            COMMAND ${PYTHON_EXECUTABLE} ${file} ${jpscore_exe}
+    )
     set_tests_properties(
             ${test}
             PROPERTIES LABELS "CI:FAST")

--- a/systemtest/source_tests/test_source_bounding_box/02_source_bounding_box.py
+++ b/systemtest/source_tests/test_source_bounding_box/02_source_bounding_box.py
@@ -46,7 +46,7 @@ def runtest(inifile, trajfile):
             exit(FAILURE)
 
 if __name__ == "__main__":
-    test = JPSRunTestDriver(2, argv0=argv[0], testdir=path[0], utestdir=utestdir)
+    test = JPSRunTestDriver(2, argv0=argv[0], testdir=path[0], utestdir=utestdir, jpscore=argv[1])
     test.run_test(testfunction=runtest)
     logging.info("%s exits with SUCCESS" % (argv[0]))
     exit(SUCCESS)

--- a/systemtest/source_tests/test_source_frequency/05_source_frequency.py
+++ b/systemtest/source_tests/test_source_frequency/05_source_frequency.py
@@ -52,7 +52,7 @@ def runtest(inifile, trajfile):
             exit(FAILURE)
 
 if __name__ == "__main__":
-    test = JPSRunTestDriver(5, argv0=argv[0], testdir=path[0], utestdir=utestdir)
+    test = JPSRunTestDriver(5, argv0=argv[0], testdir=path[0], utestdir=utestdir, jpscore=argv[1])
     test.run_test(testfunction=runtest)
     logging.info("%s exits with SUCCESS" % (argv[0]))
     exit(SUCCESS)

--- a/systemtest/source_tests/test_source_start_position/01_source_start_position.py
+++ b/systemtest/source_tests/test_source_start_position/01_source_start_position.py
@@ -38,7 +38,7 @@ def runtest(inifile, trajfile):
             exit(FAILURE)
 
 if __name__ == "__main__":
-    test = JPSRunTestDriver(1, argv0=argv[0], testdir=path[0], utestdir=utestdir)
+    test = JPSRunTestDriver(1, argv0=argv[0], testdir=path[0], utestdir=utestdir, jpscore=argv[1])
     test.run_test(testfunction=runtest)
     logging.info("%s exits with SUCCESS" % (argv[0]))
     exit(SUCCESS)

--- a/systemtest/source_tests/test_source_starting_time/03_source_starting_time.py
+++ b/systemtest/source_tests/test_source_starting_time/03_source_starting_time.py
@@ -41,7 +41,7 @@ def runtest(inifile, trajfile):
             exit(FAILURE)
 
 if __name__ == "__main__":
-    test = JPSRunTestDriver(3, argv0=argv[0], testdir=path[0], utestdir=utestdir)
+    test = JPSRunTestDriver(3, argv0=argv[0], testdir=path[0], utestdir=utestdir, jpscore=argv[1])
     test.run_test(testfunction=runtest)
     logging.info("%s exits with SUCCESS" % (argv[0]))
     exit(SUCCESS)

--- a/systemtest/source_tests/test_source_time_limits/04_source_time_limits.py
+++ b/systemtest/source_tests/test_source_time_limits/04_source_time_limits.py
@@ -44,7 +44,7 @@ def runtest(inifile, trajfile):
             exit(FAILURE)
 
 if __name__ == "__main__":
-    test = JPSRunTestDriver(4, argv0=argv[0], testdir=path[0], utestdir=utestdir)
+    test = JPSRunTestDriver(4, argv0=argv[0], testdir=path[0], utestdir=utestdir, jpscore=argv[1])
     test.run_test(testfunction=runtest)
     logging.info("%s exits with SUCCESS" % (argv[0]))
     exit(SUCCESS)


### PR DESCRIPTION
Instead of using `build/bin/jpscore` a jpscore executable can be passed as argument to JPSRunTest. For the systemtests this executable is automatically set to the executable build with the build command.
See #461.