### PR TITLE
Add a systemtest based on pytest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -192,3 +192,7 @@ titlepage.tex
 
 __pycache__
 ipynb_checkpoints/
+
+# Ignore vscode workspace files
+*.code-workspace
+.vscode

--- a/jpscore/src/main.cpp
+++ b/jpscore/src/main.cpp
@@ -67,7 +67,6 @@ int main(int argc, char ** argv)
         iniFileParser.Parse(a.IniFilePath());
     } catch(const std::exception & e) {
         LOG_ERROR("Exception in IniFileParser::Parse thrown, what: {}", e.what());
-
         return EXIT_FAILURE;
     }
 

--- a/systemtest/jps/checker.py
+++ b/systemtest/jps/checker.py
@@ -1,0 +1,14 @@
+"""Functions to check jpscore log files for specific output."""
+
+
+def output_contains_line_exact(text, line):
+    """
+    Search for a specific line in the output.
+
+    @param text to search in. This is the output of jpscore usually.
+    @param line to search for.
+    """
+    for line in text.splitlines():
+        if line == line:
+            return True
+    return False

--- a/systemtest/jps/driver.py
+++ b/systemtest/jps/driver.py
@@ -1,0 +1,60 @@
+"""Support to run jpscore from python."""
+import os
+import subprocess
+
+
+class JpsCore:
+    """
+    JpsCore executable wrapper.
+
+    Use this class to run jpscore executable.
+    All possible comandline options are available as arguments.
+
+    Use the 'output' field to access the generated output.
+
+    Use the 'returncode' field to check if execution was successful,
+    this is a standart unix returncode.
+    """
+
+    LOG_LEVEL_DEBUG = "debug"
+    LOG_LEVEL_INFO = "info"
+    LOG_LEVEL_WARNING = "warning"
+    LOG_LEVEL_ERROR = "error"
+    LOG_LEVEL_OFF = "off"
+
+    def __init__(
+        self,
+        executable,
+        log_level=LOG_LEVEL_DEBUG,
+        input_file="ini.xml",
+        work_dir=None,
+    ):
+        """
+        Create a wrapper around the jpscore executable.
+
+        @param executable the path to the jpscore executable you want to test.
+        @param log_level to set, this reflects all available log levels from
+               the comand line.
+        @param input_file to pass to jpscore, if none is provided the
+               application is called without a path.
+        @param work_dir to be used for execution.
+        """
+        self.cmd = [executable, f"--log-level={log_level}", input_file]
+        self.output = None
+        self.returncode = None
+        self.work_dir = work_dir
+
+    def run(self):
+        """Execute jpscore with the configured parameters."""
+        with open(os.path.join(self.work_dir, "log.txt"), "a+") as logfile:
+            proc = subprocess.Popen(
+                self.cmd,
+                stderr=logfile,
+                stdout=subprocess.PIPE,
+                text=True,
+                cwd=self.work_dir,
+            )
+            proc.communicate()
+            logfile.seek(0)
+            self.output = logfile.read()
+            self.returncode = proc.returncode

--- a/systemtest/test_comandline_args.py
+++ b/systemtest/test_comandline_args.py
@@ -1,0 +1,39 @@
+"""Systemtests for jpscore."""
+import os
+
+import pytest
+
+from jps.checker import output_contains_line_exact
+from jps.driver import JpsCore
+
+
+@pytest.yield_fixture
+def fixture(tmpdir):
+    """Testfixture providing a temp directory and the path to jpscore."""
+    jpscore_path = os.getenv(key="JPSCORE", default="jpscore")
+    assert os.path.exists(
+        jpscore_path
+    ), f"Cannot find jpscore under {jpscore_path}"
+    yield (tmpdir, jpscore_path)
+
+
+def test_checks_file_argument_exists(fixture):
+    """
+    Checks jpscore error message about ini.xml.
+
+    This tests check that jpscore will report if the supplied path does
+    not point to a file.
+    """
+    temp_folder, executable_path = fixture
+    jps_core = JpsCore(
+        executable=executable_path,
+        input_file="I-DO-NOT-EXIST",
+        work_dir=str(temp_folder),
+    )
+    jps_core.run()
+    expected_message = "inifile: File does not exist: I-DO-NOT-EXIST"
+    assert jps_core.returncode != 0
+    has_expected_message = output_contains_line_exact(
+        jps_core.output, expected_message
+    )
+    assert has_expected_message


### PR DESCRIPTION
A new set of test helper functions / class have been added as python
module under 'systemtest/jps'. Please see the individual files for
details about their functionality.

The newly added systemtest can be found in
'systemtest/test_comandline_args.py', each 'test_*' function represents
a test case.

For now the tests are not hooked up to cmake and can be executed with:
'JPSCORE=<path to your jpscore binary> pytest -s -vv'

Note you will need pytest installed in your python environment.