### PR TITLE
Method I, remove unused parameter

### DIFF
--- a/jpsreport/Analysis.cpp
+++ b/jpsreport/Analysis.cpp
@@ -177,7 +177,6 @@ void Analysis::InitArgs(ArgumentParser * args)
         }
         _StartFramesMethodI = args->GetStartFramesMethodI();
         _StopFramesMethodI  = args->GetStopFramesMethodI();
-        _IndividualFDFlags  = args->GetIndividualFDFlags();
         _geoPolyMethodI     = ReadGeometry(args->GetGeometryFilename(), _areaForMethod_I);
     }
 
@@ -453,7 +452,6 @@ int Analysis::RunAnalysis(const fs::path & filename, const fs::path & path)
             Method_I method_I;
             method_I.SetStartFrame(_StartFramesMethodI[i]);
             method_I.SetStopFrame(_StopFramesMethodI[i]);
-            method_I.SetCalculateIndividualFD(_IndividualFDFlags[i]);
             method_I.SetGeometryPolygon(_geoPolyMethodI[_areaForMethod_I[i]->_id]);
             method_I.SetGeometryFileName(_geometryFileName);
             method_I.SetGeometryBoundaries(_lowVertexX, _lowVertexY, _highVertexX, _highVertexY);

--- a/jpsreport/general/ArgumentParser.cpp
+++ b/jpsreport/general/ArgumentParser.cpp
@@ -794,18 +794,8 @@ bool ArgumentParser::ParseIniFile(const string & inifile)
                 } else {
                     _stop_frames_MethodI.push_back(-1);
                 }
-
-                if(xMeasurementArea->Attribute("get_individual_FD")) {
-                    if(string(xMeasurementArea->Attribute("get_individual_FD")) == "true") {
-                        _individual_FD_flags.push_back(true);
-                        Log->Write("INFO: \tIndividual FD will be output");
-                    } else {
-                        _individual_FD_flags.push_back(false);
-                    }
-                } else {
-                    _individual_FD_flags.push_back(false);
-                }
             }
+
             if(xMethod_I->FirstChildElement("one_dimensional")) {
                 if(string(xMethod_I->FirstChildElement("one_dimensional")->Attribute("enabled")) ==
                    "true") {

--- a/jpsreport/methods/Method_I.cpp
+++ b/jpsreport/methods/Method_I.cpp
@@ -54,7 +54,6 @@ Method_I::Method_I()
     _cutRadius             = -1;
     _circleEdges           = -1;
     _fIndividualFD         = nullptr;
-    _calcIndividualFD      = true;
     _areaForMethod_I       = nullptr;
     _isOneDimensional      = false;
     _startFrame            = -1;
@@ -102,11 +101,10 @@ bool Method_I::Process(
         }
     }
 
-    if(_calcIndividualFD) {
-        if(!OpenFileIndividualFD()) {
-            return_value = false;
-        }
+    if(!OpenFileIndividualFD()) {
+        return_value = false;
     }
+
     Log->Write("------------------------ Analyzing with Method I -----------------------------");
 
     for(auto ite : _peds_t) {
@@ -168,18 +166,16 @@ bool Method_I::Process(
             }
 
             if(!polygons.empty()) {
-                if(_calcIndividualFD) {
-                    if(!_isOneDimensional) {
-                        // GetIndividualFD(polygons,VInFrame, IdInFrame,  str_frid); // TODO polygons_id
-                        GetIndividualFD(
-                            polygons,
-                            VInFrame,
-                            IdInFrame,
-                            str_frid,
-                            XInFrame,
-                            YInFrame,
-                            ZInFrame); //
-                    }
+                if(!_isOneDimensional) {
+                    // GetIndividualFD(polygons,VInFrame, IdInFrame,  str_frid); // TODO polygons_id
+                    GetIndividualFD(
+                        polygons,
+                        VInFrame,
+                        IdInFrame,
+                        str_frid,
+                        XInFrame,
+                        YInFrame,
+                        ZInFrame); //
                 }
             } else {
                 for(int i = 0; i < (int) IdInFrame.size(); i++) {
@@ -193,9 +189,9 @@ bool Method_I::Process(
             }
         }
     } //peds
-    if(_calcIndividualFD) {
-        fclose(_fIndividualFD);
-    }
+
+    fclose(_fIndividualFD);
+
     return return_value;
 }
 
@@ -290,11 +286,6 @@ void Method_I::GetIndividualFD(
             polygon_str.c_str());
         temp++;
     }
-}
-
-void Method_I::SetCalculateIndividualFD(bool /*individualFD*/)
-{
-    _calcIndividualFD = true;
 }
 
 void Method_I::SetStartFrame(int startFrame)
@@ -420,18 +411,17 @@ void Method_I::CalcVoronoiResults1D(
             right_boundary);
         VoronoiDensity += ratio;
         VoronoiVelocity += (VInFrame[i] * voronoi_distance[i] * ratio * CMtoM);
-        if(_calcIndividualFD) {
-            double headway           = (XRightNeighbor[i] - XInFrame[i]) * CMtoM;
-            double individualDensity = 2.0 / ((XRightNeighbor[i] - XLeftNeighbor[i]) * CMtoM);
-            fprintf(
-                _fIndividualFD,
-                "%s\t%d\t%.3f\t%.3f\t%.3f\n",
-                frid.c_str(),
-                IdInFrame[i],
-                individualDensity,
-                VInFrame[i],
-                headway);
-        }
+
+        double headway           = (XRightNeighbor[i] - XInFrame[i]) * CMtoM;
+        double individualDensity = 2.0 / ((XRightNeighbor[i] - XLeftNeighbor[i]) * CMtoM);
+        fprintf(
+            _fIndividualFD,
+            "%s\t%d\t%.3f\t%.3f\t%.3f\n",
+            frid.c_str(),
+            IdInFrame[i],
+            individualDensity,
+            VInFrame[i],
+            headway);
     }
     VoronoiDensity /= ((right_boundary - left_boundary) * CMtoM);
     VoronoiVelocity /= ((right_boundary - left_boundary) * CMtoM);


### PR DESCRIPTION
Unused parameters for indicating whether individual FD values should be calculated or not were removed. (since they should be always true)

Parameter is not read in when parsing arguments anymore. ini-file for using Method I should be change accordingly.
Besides, the handling of several measurement areas in Method I does not make sense because values are calculated for the whole geometry.

Fixes #634 