### PR TITLE
Update build documentation to mention CODE_COVERAGE

### DIFF
--- a/docs/pages/jupedsim/jupedsim_install_on_linux.md
+++ b/docs/pages/jupedsim/jupedsim_install_on_linux.md
@@ -6,7 +6,7 @@ summary: "JuPedSim does not offer any Linux binaries. A compilation of the code 
 sidebar: jupedsim_sidebar
 permalink: jupedsim_install_on_linux.html
 folder: jupedsim
-last_updated: Dec 31, 2019
+last_updated: Mar 02, 2020
 ---
 
 ## Get the code 
@@ -63,6 +63,10 @@ Build an additional target `jpscore_asan` with address and undefined behavior
 sanitizer enabled. Note there is an approx. 2x slowdown when using
 `jpscore_asan` over `jpscore`
 
+- CODE_COVERAGE defaults to OFF (Does not support Windows)
+Build unittests with code coverage. Following additional libraries are needed:
+    - gcc: `lcov`
+    - clang: `llvm-cov` and `llvm-profdata`
 
 {% include links.html %}
 


### PR DESCRIPTION
To get github readme and the website to the same level, added the cmake flag `CODE_COVERAGE` also to the build instructions on our website.