### PR TITLE
Adds Private keyword for linking unittests

### DIFF
--- a/libcore/CMakeLists.txt
+++ b/libcore/CMakeLists.txt
@@ -260,7 +260,10 @@ if (BUILD_CPPUNIT_TEST)
             test/catch2/geometry/CorrectGeometryTest.cpp
             )
 
-    target_link_libraries(unittests Catch2::Catch2 core)
+    target_link_libraries(unittests PRIVATE
+        Catch2::Catch2
+        core
+    )
 
     target_compile_options(unittests PRIVATE
         ${COMMON_COMPILE_OPTIONS}


### PR DESCRIPTION
Cmake requires to have target_link_library either all plain or all
with keyword (Private, Public, Interface). Since code coverage is
linked using PRIVATE keyword we need to add the keyword when linking
unittests.