### PR TITLE
Remove unneeded inifile option solver

### DIFF
--- a/demos/01_corridor/corridor_ini.xml
+++ b/demos/01_corridor/corridor_ini.xml
@@ -37,7 +37,6 @@ xsi:noNamespaceSchemaLocation="../../xsd/jps_ini_core.xsd">
  <operational_models>
     <model operational_model_id="1" description="gcfm">
       <model_parameters>
-        <solver>euler</solver>
         <stepsize>0.01</stepsize>
          <exit_crossing_strategy>2</exit_crossing_strategy>
         <linkedcells enabled="true" cell_size="2.2" />

--- a/demos/02_bottleneck/bottleneck_ini.xml
+++ b/demos/02_bottleneck/bottleneck_ini.xml
@@ -51,7 +51,6 @@ xsi:noNamespaceSchemaLocation="http://134.94.2.137/jps_ini_core.xsd">
          <operational_models>
                 <model operational_model_id="1" description="gcfm">
                   <model_parameters>
-                        <solver>euler</solver>
                         <stepsize>0.01</stepsize>
                         <exit_crossing_strategy>2</exit_crossing_strategy>
                         <linkedcells enabled="true" cell_size="2.2" />

--- a/demos/02_bottleneck/bottleneck_ini.xml
+++ b/demos/02_bottleneck/bottleneck_ini.xml
@@ -78,7 +78,6 @@ xsi:noNamespaceSchemaLocation="http://134.94.2.137/jps_ini_core.xsd">
 
      <model operational_model_id="3" description="Tordeux2015">
       <model_parameters>
-        <solver>euler</solver>
         <stepsize>0.01</stepsize>
         <exit_crossing_strategy>3</exit_crossing_strategy>
         <linkedcells enabled="true" cell_size="2.2" />

--- a/demos/03_corner/corner_ini.xml
+++ b/demos/03_corner/corner_ini.xml
@@ -52,7 +52,6 @@ xsi:noNamespaceSchemaLocation="../../xsd/jps_ini_core.xsd">
  <operational_models>
     <model operational_model_id="1" description="gcfm">
       <model_parameters>
-        <solver>euler</solver>
         <stepsize>0.01</stepsize>
         <exit_crossing_strategy>2</exit_crossing_strategy>
         <linkedcells enabled="true" cell_size="2.2" />

--- a/demos/04_stairs/stairs_ini.xml
+++ b/demos/04_stairs/stairs_ini.xml
@@ -55,7 +55,6 @@ xsi:noNamespaceSchemaLocation="../../xsd/jps_ini_core.xsd">
  <operational_models>
     <model operational_model_id="1" description="gcfm">
       <model_parameters>
-        <solver>euler</solver>
         <stepsize>0.01</stepsize>
         <exit_crossing_strategy>8</exit_crossing_strategy>
         <linkedcells enabled="true" cell_size="2.2" />

--- a/demos/05_events/events_ini.xml
+++ b/demos/05_events/events_ini.xml
@@ -74,7 +74,6 @@ xsi:noNamespaceSchemaLocation="http://xsd.jupedsim.org/0.6/jps_ini_core.xsd">
 <operational_models>
     <model operational_model_id="1" description="gcfm">
       <model_parameters>
-        <solver>euler</solver>
         <stepsize>0.001</stepsize>
         <exit_crossing_strategy>2</exit_crossing_strategy>
         <linkedcells enabled="true" cell_size="2.2" />

--- a/demos/06_floorfield/floorfield_ini.xml
+++ b/demos/06_floorfield/floorfield_ini.xml
@@ -64,7 +64,6 @@
  <operational_models>
     <model operational_model_id="1" description="gcfm">
       <model_parameters>
-        <solver>euler</solver>
         <stepsize>0.01</stepsize>
         <exit_crossing_strategy>3</exit_crossing_strategy>
         <linkedcells enabled="true" cell_size="2.2" />

--- a/demos/06_floorfield/floorfield_ini.xml
+++ b/demos/06_floorfield/floorfield_ini.xml
@@ -90,7 +90,6 @@
 
     <model operational_model_id="3" description="Tordeux2015">
           <model_parameters>
-            <solver>euler</solver>
             <stepsize>0.1</stepsize>
     <periodic>0</periodic>
             <exit_crossing_strategy>8</exit_crossing_strategy>

--- a/demos/07_big_room/big_room_ini.xml
+++ b/demos/07_big_room/big_room_ini.xml
@@ -70,7 +70,6 @@ xsi:noNamespaceSchemaLocation="../../xsd/jps_ini_core.xsd">
 
     <model operational_model_id="3" description="Tordeux2015">
         <model_parameters>
-            <solver>euler</solver>
             <stepsize>0.05</stepsize>
             <exit_crossing_strategy>3</exit_crossing_strategy>
             <linkedcells enabled="true" cell_size="2" />

--- a/demos/07_big_room/big_room_ini.xml
+++ b/demos/07_big_room/big_room_ini.xml
@@ -44,7 +44,6 @@ xsi:noNamespaceSchemaLocation="../../xsd/jps_ini_core.xsd">
 <operational_models>
     <model operational_model_id="1" description="gcfm">
         <model_parameters>
-            <solver>euler</solver>
             <stepsize>0.01</stepsize>
             <exit_crossing_strategy>2</exit_crossing_strategy>
             <linkedcells enabled="true" cell_size="2.2" />

--- a/demos/08_sources/source_ini.xml
+++ b/demos/08_sources/source_ini.xml
@@ -100,7 +100,6 @@
   <operational_models>
      <model operational_model_id="3" description="Tordeux2015">
       <model_parameters>
-        <solver>euler</solver>
         <stepsize>0.01</stepsize>
         <exit_crossing_strategy>2</exit_crossing_strategy>
         <linkedcells enabled="true" cell_size="2.2" />

--- a/demos/09_area/wa_triangle_ini.xml
+++ b/demos/09_area/wa_triangle_ini.xml
@@ -120,7 +120,6 @@
         </model>
         <model operational_model_id="3" description="Tordeux2015">
             <model_parameters>
-                <solver>euler</solver>
                 <stepsize>0.01</stepsize>
                 <exit_crossing_strategy>8</exit_crossing_strategy>
                 <!--<exit_crossing_strategy>8</exit_crossing_strategy>-->

--- a/demos/09_area/wa_triangle_ini.xml
+++ b/demos/09_area/wa_triangle_ini.xml
@@ -95,7 +95,6 @@
     <operational_models>
         <model operational_model_id="1" description="gcfm">
             <model_parameters>
-                <solver>euler</solver>
                 <stepsize>0.01</stepsize>
                 <exit_crossing_strategy>9</exit_crossing_strategy>
                 <linkedcells enabled="true" cell_size="2.2"/>

--- a/demos/10_schedule/schedule_ini.xml
+++ b/demos/10_schedule/schedule_ini.xml
@@ -139,7 +139,6 @@
 
         <model operational_model_id="3" description="Tordeux2015">
             <model_parameters>
-                <solver>euler</solver>
                 <stepsize>0.01</stepsize>
                 <exit_crossing_strategy>8</exit_crossing_strategy>
                 <linkedcells enabled="true" cell_size="2.2"/>

--- a/demos/10_schedule/schedule_ini.xml
+++ b/demos/10_schedule/schedule_ini.xml
@@ -113,7 +113,6 @@
     <operational_models>
         <model operational_model_id="1" description="gcfm">
             <model_parameters>
-                <solver>euler</solver>
                 <stepsize>0.01</stepsize>
                 <exit_crossing_strategy>3</exit_crossing_strategy>
                 <linkedcells enabled="true" cell_size="2.2"/>

--- a/docs/pages/jpscore/jpscore_operativ.md
+++ b/docs/pages/jpscore/jpscore_operativ.md
@@ -23,8 +23,6 @@ sections:
     or other pedestrian properties like desired speed, reaction time etc.
 
 ## Model parameters (in general)
-- `<solver>euler</solver>`
-     - The solver for the ODE. Only *Euler*. No other options.
 - `<stepsize>0.001</stepsize>`:
      - The time step for the solver. This should be choosed with care. For force-based model it is recommended to take a value between $$ 10^{-2} $$ and $$10^{-3}$$ s.
        For first-order models, a value of 0.05 s should be OK.

--- a/docs/pages/jpscore/jpscore_operativ.md
+++ b/docs/pages/jpscore/jpscore_operativ.md
@@ -6,7 +6,7 @@ sidebar: jupedsim_sidebar
 folder: jpscore
 permalink: jpscore_operativ.html
 summary: Several operational models are implemented in jpscore. An operational model defines how pedestrians interact with each other and with their environment.
-last_updated: Dec 31, 2019
+last_updated: Mar 10, 2020
 ---
 
 ## Introduction
@@ -160,7 +160,6 @@ In summary the relevant section for this model could look like:
 ```xml
  <model operational_model_id="3" description="Tordeux2015">
     <model_parameters>
-        <solver>euler</solver>
         <stepsize>0.05</stepsize>
         <exit_crossing_strategy>3</exit_crossing_strategy>
         <linkedcells enabled="true" cell_size="2"/>

--- a/jpsreport/demos/corridor/ini_corridor_jpscore.xml
+++ b/jpsreport/demos/corridor/ini_corridor_jpscore.xml
@@ -32,7 +32,6 @@ xsi:noNamespaceSchemaLocation="../../xsd/jps_ini_core.xsd">
  <operational_models>
     <model operational_model_id="1" description="gcfm">
       <model_parameters>
-        <solver>euler</solver>
         <stepsize>0.01</stepsize>
          <exit_crossing_strategy>4</exit_crossing_strategy>
         <linkedcells enabled="true" cell_size="2.2" />

--- a/libcore/src/IO/IniFileParser.cpp
+++ b/libcore/src/IO/IniFileParser.cpp
@@ -443,10 +443,6 @@ bool IniFileParser::ParseGCFMModel(TiXmlElement * xGCFM, TiXmlElement * xMainNod
         return false;
     }
 
-    //solver
-    if(!ParseNodeToSolver(*xModelPara))
-        return false;
-
     //stepsize
     if(!ParseStepSize(*xModelPara))
         return false;
@@ -542,10 +538,6 @@ bool IniFileParser::ParseVelocityModel(TiXmlElement * xVelocity, TiXmlElement * 
         LOG_ERROR("\t <max_sim_time> </max_sim_time>\n");
         return false;
     }
-
-    //solver
-    if(!ParseNodeToSolver(*xModelPara))
-        return false;
 
     //stepsize
     if(!ParseStepSize(*xModelPara))
@@ -1001,26 +993,6 @@ bool IniFileParser::ParsePeriodic(TiXmlNode & Node)
         _config->SetIsPeriodic(0);
     }
     return true; //default is periodic=0. If not specified than is OK
-}
-
-bool IniFileParser::ParseNodeToSolver(const TiXmlNode & solverNode)
-{
-    if(solverNode.FirstChild("solver")) {
-        std::string solver = solverNode.FirstChild("solver")->FirstChild()->Value();
-        if(solver == "euler") {
-            _config->SetSolver(1);
-        } else if(solver == "verlet")
-            _config->SetSolver(2);
-        else if(solver == "leapfrog")
-            _config->SetSolver(3);
-        else {
-            LOG_ERROR("Wrong value [{}] for solver type", solver);
-            return false;
-        }
-        LOG_ERROR("pSolver <{}>", _config->GetSolver());
-        return true;
-    }
-    return false;
 }
 
 bool IniFileParser::ParseStrategyNodeToObject(const TiXmlNode & strategyNode)

--- a/libcore/src/IO/IniFileParser.h
+++ b/libcore/src/IO/IniFileParser.h
@@ -61,8 +61,6 @@ private:
 
     bool ParsePeriodic(TiXmlNode & Node);
 
-    bool ParseNodeToSolver(const TiXmlNode & solverNode);
-
     bool ParseStrategyNodeToObject(const TiXmlNode & strategyNode);
 
     bool ParseFfOpts(const TiXmlNode & strategyNode);

--- a/libcore/src/general/Configuration.h
+++ b/libcore/src/general/Configuration.h
@@ -44,7 +44,6 @@ public:
     {
         _walkingSpeed     = nullptr;
         _ToxicityAnalysis = nullptr;
-        _solver           = 1;
         _routingEngine    = std::shared_ptr<RoutingEngine>(new RoutingEngine());
         _maxOpenMPThreads = 1;
         _seed             = 0;
@@ -112,10 +111,6 @@ public:
 
     std::shared_ptr<ToxicityAnalysis> GetToxicityAnalysis() { return _ToxicityAnalysis; };
     void SetToxicityAnalysis(std::shared_ptr<ToxicityAnalysis> & t) { _ToxicityAnalysis = t; };
-
-    int GetSolver() const { return _solver; };
-
-    void SetSolver(int solver) { _solver = solver; };
 
     std::shared_ptr<RoutingEngine> GetRoutingEngine() const { return _routingEngine; };
 
@@ -383,7 +378,6 @@ public:
 private:
     std::shared_ptr<WalkingSpeed> _walkingSpeed;
     std::shared_ptr<ToxicityAnalysis> _ToxicityAnalysis;
-    int _solver;
     std::shared_ptr<RoutingEngine> _routingEngine;
     int _maxOpenMPThreads;
     unsigned int _seed;

--- a/systemtest/Validation/1test_1D/master_ini.xml
+++ b/systemtest/Validation/1test_1D/master_ini.xml
@@ -57,7 +57,6 @@
   <operational_models>
     <model operational_model_id="3" description="Tordeux2015">
       <model_parameters>
-        <solver>euler</solver>
         <periodic>1</periodic>
         <stepsize>0.01</stepsize>
         <exit_crossing_strategy>3</exit_crossing_strategy>

--- a/systemtest/Validation/2test_2D/master_ini.xml
+++ b/systemtest/Validation/2test_2D/master_ini.xml
@@ -57,7 +57,6 @@
   <operational_models>
     <model operational_model_id="3" description="Tordeux2015">
       <model_parameters>
-        <solver>euler</solver>
         <periodic>1</periodic>
         <stepsize>0.01</stepsize>
         <exit_crossing_strategy>3</exit_crossing_strategy>

--- a/systemtest/Validation/3test_UO/master_ini.xml
+++ b/systemtest/Validation/3test_UO/master_ini.xml
@@ -65,7 +65,6 @@
   <operational_models>
     <model operational_model_id="1" description="gcfm">
       <model_parameters>
-        <solver>euler</solver>
         <stepsize>0.001</stepsize>
         <exit_crossing_strategy>4</exit_crossing_strategy>
         <linkedcells enabled="true" cell_size="2.2" />
@@ -93,7 +92,6 @@
   <operational_models>
     <model operational_model_id="3" description="Tordeux2015">
       <model_parameters>
-        <solver>euler</solver>
         <stepsize>0.01</stepsize>
         <exit_crossing_strategy>2</exit_crossing_strategy>
         <linkedcells enabled="true" cell_size="2.3" />

--- a/systemtest/Validation/4test_EO/master_ini.xml
+++ b/systemtest/Validation/4test_EO/master_ini.xml
@@ -57,7 +57,6 @@
   <operational_models>
     <model operational_model_id="3" description="Tordeux2015">
       <model_parameters>
-        <solver>euler</solver>
         <stepsize>0.1</stepsize>
 		<periodic>0</periodic>
         <exit_crossing_strategy>4</exit_crossing_strategy>

--- a/systemtest/Validation/6test_KO/master_ini.xml
+++ b/systemtest/Validation/6test_KO/master_ini.xml
@@ -58,7 +58,6 @@
   <operational_models>
     <model operational_model_id="3" description="Tordeux2015">
       <model_parameters>
-        <solver>euler</solver>
         <stepsize>0.05</stepsize>
 	<periodic>0</periodic>
         <exit_crossing_strategy>3</exit_crossing_strategy>

--- a/systemtest/Validation/test_13/master_ini.xml
+++ b/systemtest/Validation/test_13/master_ini.xml
@@ -56,7 +56,6 @@
   <operational_models >
       <model operational_model_id="3" description="Tordeux2015">
       <model_parameters>
-        <solver>euler</solver>
         <stepsize>0.05</stepsize>
         <exit_crossing_strategy>3</exit_crossing_strategy>
         <linkedcells enabled="true" cell_size="2.2" />
@@ -76,7 +75,6 @@
 
     <model operational_model_id="1" description="gcfm">
       <model_parameters>
-        <solver>euler</solver>
         <stepsize>0.001</stepsize>
         <exit_crossing_strategy>2</exit_crossing_strategy>
         <linkedcells enabled="true" cell_size="2.2" />

--- a/systemtest/develop_tests/doors/master_ini.xml
+++ b/systemtest/develop_tests/doors/master_ini.xml
@@ -39,7 +39,6 @@ xsi:noNamespaceSchemaLocation="../../xsd/jps_ini_core.xsd">
 <operational_models>
     <model operational_model_id="3" description="Tordeux2015">
         <model_parameters>
-            <solver>euler</solver>
             <stepsize>0.01</stepsize>
             <exit_crossing_strategy>8</exit_crossing_strategy>
             <linkedcells enabled="true" cell_size="2.2" />

--- a/systemtest/door_tests/test_flow_regulation/master_ini.xml
+++ b/systemtest/door_tests/test_flow_regulation/master_ini.xml
@@ -32,7 +32,6 @@
     <operational_models>
         <model operational_model_id="3" description="Tordeux2015">
             <model_parameters>
-                <solver>euler</solver>
                 <stepsize>0.01</stepsize>
                 <exit_crossing_strategy>8</exit_crossing_strategy>
                 <!--<exit_crossing_strategy>8</exit_crossing_strategy>-->

--- a/systemtest/jpsreport_tests/method_A/test02/jpscore_ini.xml
+++ b/systemtest/jpsreport_tests/method_A/test02/jpscore_ini.xml
@@ -27,7 +27,6 @@
     <operational_models>
         <model operational_model_id="1" description="gcfm">
             <model_parameters>
-                <solver>euler</solver>
                 <stepsize>0.01</stepsize>
                 <exit_crossing_strategy>2</exit_crossing_strategy>
                 <linkedcells enabled="true" cell_size="2.2" />

--- a/systemtest/jpsreport_tests/method_A/test03/jpscore_ini.xml
+++ b/systemtest/jpsreport_tests/method_A/test03/jpscore_ini.xml
@@ -29,7 +29,6 @@
     <operational_models>
         <model operational_model_id="1" description="gcfm">
             <model_parameters>
-                <solver>euler</solver>
                 <stepsize>0.01</stepsize>
                 <exit_crossing_strategy>2</exit_crossing_strategy>
                 <linkedcells enabled="true" cell_size="2.2" />

--- a/systemtest/jpsreport_tests/method_A/test04/jpscore_ini.xml
+++ b/systemtest/jpsreport_tests/method_A/test04/jpscore_ini.xml
@@ -33,7 +33,6 @@
     <operational_models>
         <model operational_model_id="1" description="gcfm">
             <model_parameters>
-                <solver>euler</solver>
                 <stepsize>0.01</stepsize>
                 <exit_crossing_strategy>2</exit_crossing_strategy>
                 <linkedcells enabled="true" cell_size="2.2" />

--- a/systemtest/jpsreport_tests/method_A/test05/jpscore_ini.xml
+++ b/systemtest/jpsreport_tests/method_A/test05/jpscore_ini.xml
@@ -33,7 +33,6 @@
     <operational_models>
         <model operational_model_id="1" description="gcfm">
             <model_parameters>
-                <solver>euler</solver>
                 <stepsize>0.01</stepsize>
                 <exit_crossing_strategy>2</exit_crossing_strategy>
                 <linkedcells enabled="true" cell_size="2.2" />

--- a/systemtest/juelich_tests/test_1/master_ini.xml
+++ b/systemtest/juelich_tests/test_1/master_ini.xml
@@ -55,7 +55,6 @@
   <operational_models>
     <model operational_model_id="3" description="Tordeux2015">
       <model_parameters>
-        <solver>euler</solver>
         <stepsize>0.001</stepsize>
         <exit_crossing_strategy>3</exit_crossing_strategy>
         <linkedcells enabled="true" cell_size="2.2" />
@@ -75,7 +74,6 @@
 
     <model operational_model_id="1" description="gcfm">
       <model_parameters>
-        <solver>euler</solver>
         <stepsize>0.05</stepsize>
         <exit_crossing_strategy>range(1,5)</exit_crossing_strategy>
         <linkedcells enabled="true" cell_size="2.2" />

--- a/systemtest/juelich_tests/test_11/master_ini_a.xml
+++ b/systemtest/juelich_tests/test_11/master_ini_a.xml
@@ -63,7 +63,6 @@
   <operational_models >
     <model operational_model_id="3" description="Tordeux2015">
       <model_parameters>
-        <solver>euler</solver>
         <stepsize>0.05</stepsize>
         <exit_crossing_strategy>3</exit_crossing_strategy>
         <linkedcells enabled="true" cell_size="2.2" />
@@ -83,7 +82,6 @@
 
     <model operational_model_id="1" description="gcfm">
       <model_parameters>
-        <solver>euler</solver>
         <stepsize>0.001</stepsize>
         <exit_crossing_strategy>range(1,6)</exit_crossing_strategy>
         <linkedcells enabled="true" cell_size="2.8" />

--- a/systemtest/juelich_tests/test_11/master_ini_b.xml
+++ b/systemtest/juelich_tests/test_11/master_ini_b.xml
@@ -63,7 +63,6 @@
   <operational_models >
     <model operational_model_id="3" description="Tordeux2015">
       <model_parameters>
-        <solver>euler</solver>
         <stepsize>0.05</stepsize>
         <exit_crossing_strategy>3</exit_crossing_strategy>
         <linkedcells enabled="true" cell_size="2.2" />
@@ -83,7 +82,6 @@
 
     <model operational_model_id="1" description="gcfm">
       <model_parameters>
-        <solver>euler</solver>
         <stepsize>0.001</stepsize>
         <exit_crossing_strategy>range(1,6)</exit_crossing_strategy>
         <linkedcells enabled="true" cell_size="2.8" />

--- a/systemtest/juelich_tests/test_12/master_ini.xml
+++ b/systemtest/juelich_tests/test_12/master_ini.xml
@@ -58,7 +58,6 @@
   <operational_models >
     <model operational_model_id="3" description="Tordeux2015">
       <model_parameters>
-        <solver>euler</solver>
         <stepsize>0.05</stepsize>
         <exit_crossing_strategy>3</exit_crossing_strategy>
         <linkedcells enabled="true" cell_size="2.2" />
@@ -87,7 +86,6 @@
 
     <model operational_model_id="1" description="gcfm">
       <model_parameters>
-        <solver>euler</solver>
         <stepsize>0.001</stepsize>
         <exit_crossing_strategy>3</exit_crossing_strategy>
         <linkedcells enabled="true" cell_size="3" />

--- a/systemtest/juelich_tests/test_14/master_ini.xml
+++ b/systemtest/juelich_tests/test_14/master_ini.xml
@@ -55,7 +55,6 @@
   <operational_models >
         <model operational_model_id="3" description="Tordeux2015">
       <model_parameters>
-        <solver>euler</solver>
         <stepsize>0.05</stepsize>
         <exit_crossing_strategy>3</exit_crossing_strategy>
         <linkedcells enabled="true" cell_size="2.2" />
@@ -75,7 +74,6 @@
 
   <model operational_model_id="1" description="gcfm">
     <model_parameters>
-      <solver>euler</solver>
       <stepsize>2</stepsize>
       <exit_crossing_strategy>1</exit_crossing_strategy>
       <linkedcells enabled="true" cell_size="2.2" />

--- a/systemtest/juelich_tests/test_2/master_ini.xml
+++ b/systemtest/juelich_tests/test_2/master_ini.xml
@@ -58,7 +58,6 @@
   <operational_models >
     <model operational_model_id="3" description="Tordeux2015">
       <model_parameters>
-        <solver>euler</solver>
         <stepsize>0.05</stepsize>
         <exit_crossing_strategy>3</exit_crossing_strategy>
         <linkedcells enabled="true" cell_size="2.2" />
@@ -78,7 +77,6 @@
 
     <model operational_model_id="1" description="gcfm">
       <model_parameters>
-        <solver>euler</solver>
         <stepsize>0.05</stepsize>
         <exit_crossing_strategy>3</exit_crossing_strategy>
         <linkedcells enabled="true" cell_size="2.2" />

--- a/systemtest/juelich_tests/test_3/master_ini.xml
+++ b/systemtest/juelich_tests/test_3/master_ini.xml
@@ -57,7 +57,6 @@
   <operational_models >
         <model operational_model_id="3" description="Tordeux2015">
       <model_parameters>
-        <solver>euler</solver>
         <stepsize>0.05</stepsize>
         <exit_crossing_strategy>[1, 2, 3, 4, 6, 8, 9]</exit_crossing_strategy> <!-- 7 is experimental -->
         <linkedcells enabled="true" cell_size="2.2" />
@@ -77,7 +76,6 @@
 
     <model operational_model_id="1" description="gcfm">
       <model_parameters>
-        <solver>euler</solver>
         <stepsize>0.001</stepsize>
         <exit_crossing_strategy>3</exit_crossing_strategy>
         <linkedcells enabled="true" cell_size="2.2" />

--- a/systemtest/juelich_tests/test_4/master_ini.xml
+++ b/systemtest/juelich_tests/test_4/master_ini.xml
@@ -54,7 +54,6 @@
   <operational_models >
     <model operational_model_id="3" description="Tordeux2015">
       <model_parameters>
-        <solver>euler</solver>
         <stepsize>0.05</stepsize>
         <exit_crossing_strategy>3</exit_crossing_strategy>
         <linkedcells enabled="true" cell_size="2.2" />
@@ -94,7 +93,6 @@
 
     <model operational_model_id="1" description="gcfm">
       <model_parameters>
-        <solver>euler</solver>
         <stepsize>0.001</stepsize>
         <exit_crossing_strategy>1</exit_crossing_strategy>
         <linkedcells enabled="true" cell_size="2.2" />

--- a/systemtest/juelich_tests/test_5/master_ini.xml
+++ b/systemtest/juelich_tests/test_5/master_ini.xml
@@ -53,7 +53,6 @@
   <operational_models >
     <model operational_model_id="3" description="Tordeux2015">
       <model_parameters>
-        <solver>euler</solver>
         <stepsize>0.05</stepsize>
         <exit_crossing_strategy>3</exit_crossing_strategy>
         <linkedcells enabled="true" cell_size="2.2" />
@@ -84,7 +83,6 @@
 
     <model operational_model_id="1" description="gcfm">
       <model_parameters>
-        <solver>euler</solver>
         <stepsize>0.001</stepsize>
         <exit_crossing_strategy>1</exit_crossing_strategy>
         <linkedcells enabled="true" cell_size="2.2" />

--- a/systemtest/juelich_tests/test_6/master_ini.xml
+++ b/systemtest/juelich_tests/test_6/master_ini.xml
@@ -52,7 +52,6 @@
   <operational_models >
     <model operational_model_id="3" description="Tordeux2015">
       <model_parameters>
-        <solver>euler</solver>
         <stepsize>0.001</stepsize>
         <exit_crossing_strategy>3</exit_crossing_strategy>
         <linkedcells enabled="true" cell_size="2.2" />
@@ -72,7 +71,6 @@
 
     <model operational_model_id="1" description="gcfm">
       <model_parameters>
-        <solver>euler</solver>
         <stepsize>0.001</stepsize>
         <exit_crossing_strategy>range(1,6)</exit_crossing_strategy>
         <linkedcells enabled="true" cell_size="2.2" />

--- a/systemtest/juelich_tests/test_8/master_ini.xml
+++ b/systemtest/juelich_tests/test_8/master_ini.xml
@@ -53,7 +53,6 @@
   <operational_models >
     <model operational_model_id="3" description="Tordeux2015">
       <model_parameters>
-        <solver>euler</solver>
         <stepsize>0.05</stepsize>
         <exit_crossing_strategy>3</exit_crossing_strategy>
         <linkedcells enabled="true" cell_size="2.2" />
@@ -73,7 +72,6 @@
 
     <model operational_model_id="1" description="gcfm">
       <model_parameters>
-        <solver>euler</solver>
         <stepsize>0.001</stepsize>
         <exit_crossing_strategy>range(1,5)</exit_crossing_strategy>
         <linkedcells enabled="true" cell_size="2.2" />

--- a/systemtest/juelich_tests/test_9/master_ini.xml
+++ b/systemtest/juelich_tests/test_9/master_ini.xml
@@ -56,7 +56,6 @@
   <operational_models>
     <model operational_model_id="3" description="Tordeux2015">
       <model_parameters>
-        <solver>euler</solver>
         <stepsize>0.05</stepsize>
         <exit_crossing_strategy>3</exit_crossing_strategy>
         <linkedcells enabled="true" cell_size="2.2" />
@@ -76,7 +75,6 @@
 
     <model operational_model_id="1" description="gcfm">
       <model_parameters>
-        <solver>euler</solver>
         <stepsize>0.001</stepsize>
         <exit_crossing_strategy>4</exit_crossing_strategy>
         <linkedcells enabled="true" cell_size="2.2" />

--- a/systemtest/rimea_tests/test_1/master_ini.xml
+++ b/systemtest/rimea_tests/test_1/master_ini.xml
@@ -29,7 +29,6 @@
 	<operational_models>
 		<model operational_model_id="1" description="gcfm">
 			<model_parameters>
-				<solver>euler</solver>
 				<stepsize>0.01</stepsize>
 				<exit_crossing_strategy>4</exit_crossing_strategy>
 				<linkedcells enabled="true" cell_size="2.2" />

--- a/systemtest/rimea_tests/test_10/master_ini.xml
+++ b/systemtest/rimea_tests/test_10/master_ini.xml
@@ -61,7 +61,6 @@
 	<operational_models>
 		<model operational_model_id="1" description="gcfm">
 			<model_parameters>
-				<solver>euler</solver>
 				<stepsize>0.01</stepsize>
 				<exit_crossing_strategy>4</exit_crossing_strategy>
 				<linkedcells enabled="true" cell_size="2.2" />

--- a/systemtest/rimea_tests/test_11/master_ini.xml
+++ b/systemtest/rimea_tests/test_11/master_ini.xml
@@ -24,7 +24,6 @@
 	<operational_models>
 		<model operational_model_id="1" description="gcfm">
 			<model_parameters>
-				<solver>euler</solver>
 				<stepsize>0.01</stepsize>
 				<exit_crossing_strategy>4</exit_crossing_strategy>
 				<linkedcells enabled="true" cell_size="2.2" />
@@ -51,7 +50,6 @@
 
 		<model operational_model_id="3" description="Tordeux2015">
     		<model_parameters>
-        		<solver>euler</solver>
         		<stepsize>0.05</stepsize>
         		<exit_crossing_strategy>3</exit_crossing_strategy>
         		<linkedcells enabled="true" cell_size="2"/>

--- a/systemtest/rimea_tests/test_12/master_ini.xml
+++ b/systemtest/rimea_tests/test_12/master_ini.xml
@@ -36,7 +36,6 @@
   <operational_models>
     <model operational_model_id="1" description="gcfm">
         <model_parameters>
-            <solver>euler</solver>
             <stepsize>0.001</stepsize>
             <exit_crossing_strategy>4</exit_crossing_strategy>
             <linkedcells enabled="true" cell_size="2.2" />

--- a/systemtest/rimea_tests/test_13/master_ini.xml
+++ b/systemtest/rimea_tests/test_13/master_ini.xml
@@ -27,7 +27,6 @@
   <operational_models>
     <model operational_model_id="1" description="gcfm">
       <model_parameters>
-        <solver>euler</solver>
         <stepsize>0.01</stepsize>
         <exit_crossing_strategy>4</exit_crossing_strategy>
         <linkedcells enabled="true" cell_size="2.2" />
@@ -54,7 +53,6 @@
     </model>
 	<model operational_model_id="3" description="Tordeux2015">
     	<model_parameters>
-        	<solver>euler</solver>
         	<stepsize>0.05</stepsize>
         	<exit_crossing_strategy>3</exit_crossing_strategy>
         	<linkedcells enabled="true" cell_size="2"/>

--- a/systemtest/rimea_tests/test_14/master_ini.xml
+++ b/systemtest/rimea_tests/test_14/master_ini.xml
@@ -31,7 +31,6 @@
 	<operational_models>
 		<model operational_model_id="1" description="gcfm">
 			<model_parameters>
-				<solver>euler</solver>
 				<stepsize>0.01</stepsize>
 				<exit_crossing_strategy>4</exit_crossing_strategy>
 				<linkedcells enabled="true" cell_size="2.2" />

--- a/systemtest/rimea_tests/test_15/master_ini.xml
+++ b/systemtest/rimea_tests/test_15/master_ini.xml
@@ -30,7 +30,6 @@
 	<operational_models>
 		<model operational_model_id="1" description="gcfm">
 			<model_parameters>
-				<solver>euler</solver>
 				<stepsize>0.01</stepsize>
 				<exit_crossing_strategy>4</exit_crossing_strategy>
 				<linkedcells enabled="true" cell_size="2.2" />
@@ -56,7 +55,6 @@
 		</model>
 		<model operational_model_id="3" description="Tordeux2015">
 			<model_parameters>
-				<solver>euler</solver>
 				<stepsize>0.05</stepsize>
 				<exit_crossing_strategy>3</exit_crossing_strategy>
 				<linkedcells enabled="true" cell_size="2"/>

--- a/systemtest/rimea_tests/test_2/master_ini.xml
+++ b/systemtest/rimea_tests/test_2/master_ini.xml
@@ -26,7 +26,6 @@
 	<operational_models>
 		<model operational_model_id="1" description="gcfm">
 			<model_parameters>
-				<solver>euler</solver>
 				<stepsize>0.01</stepsize>
 				<exit_crossing_strategy>4</exit_crossing_strategy>
 				<linkedcells enabled="true" cell_size="2.2" />
@@ -55,7 +54,6 @@
 
 		<model operational_model_id="3" description="Tordeux2015">
     		<model_parameters>
-        		<solver>euler</solver>
         		<stepsize>0.05</stepsize>
         		<exit_crossing_strategy>3</exit_crossing_strategy>
         		<linkedcells enabled="true" cell_size="2"/>

--- a/systemtest/rimea_tests/test_3/master_ini.xml
+++ b/systemtest/rimea_tests/test_3/master_ini.xml
@@ -26,7 +26,6 @@
 	<operational_models>
 		<model operational_model_id="1" description="gcfm">
 			<model_parameters>
-				<solver>euler</solver>
 				<stepsize>0.01</stepsize>
 				<exit_crossing_strategy>4</exit_crossing_strategy>
 				<linkedcells enabled="true" cell_size="2.2" />
@@ -55,7 +54,6 @@
 
 		 <model operational_model_id="3" description="Tordeux2015">
 			<model_parameters>
-				<solver>euler</solver>
 				<stepsize>0.05</stepsize>
 				<exit_crossing_strategy>3</exit_crossing_strategy>
 				<linkedcells enabled="true" cell_size="2"/>

--- a/systemtest/rimea_tests/test_4/master_ini.xml
+++ b/systemtest/rimea_tests/test_4/master_ini.xml
@@ -41,7 +41,6 @@
 	<operational_models>
 		<model operational_model_id="3" description="Tordeux2015">
 			<model_parameters>
-				<solver>euler</solver>
 				<periodic>1</periodic>
 				<stepsize>0.01</stepsize>
 				<exit_crossing_strategy>3</exit_crossing_strategy>
@@ -71,7 +70,6 @@
 
 		<model operational_model_id="1" description="gcfm">
 			<model_parameters>
-				<solver>euler</solver>
 				<stepsize>0.01</stepsize>
 				<exit_crossing_strategy>4</exit_crossing_strategy>
 				<linkedcells enabled="true" cell_size="2.2" />

--- a/systemtest/rimea_tests/test_5/master_ini.xml
+++ b/systemtest/rimea_tests/test_5/master_ini.xml
@@ -35,7 +35,6 @@
 	<operational_models>
 		<model operational_model_id="1" description="gcfm">
 			<model_parameters>
-				<solver>euler</solver>
 				<stepsize>0.01</stepsize>
 				<exit_crossing_strategy>4</exit_crossing_strategy>
 				<linkedcells enabled="true" cell_size="2.2" />
@@ -64,7 +63,6 @@
 
 		 <model operational_model_id="3" description="Tordeux2015">
 			<model_parameters>
-				<solver>euler</solver>
 				<stepsize>0.05</stepsize>
 				<exit_crossing_strategy>3</exit_crossing_strategy>
 				<linkedcells enabled="true" cell_size="2"/>

--- a/systemtest/rimea_tests/test_6/master_ini.xml
+++ b/systemtest/rimea_tests/test_6/master_ini.xml
@@ -37,7 +37,6 @@
 	<operational_models>
 		<model operational_model_id="1" description="gcfm">
 			<model_parameters>
-				<solver>euler</solver>
 				<stepsize>0.01</stepsize>
 				<exit_crossing_strategy>4</exit_crossing_strategy>
 				<linkedcells enabled="true" cell_size="2.2" />
@@ -64,7 +63,6 @@
 
 		<model operational_model_id="3" description="Tordeux2015">
     		<model_parameters>
-        		<solver>euler</solver>
         		<stepsize>0.05</stepsize>
         		<exit_crossing_strategy>3</exit_crossing_strategy>
         		<linkedcells enabled="true" cell_size="2"/>

--- a/systemtest/rimea_tests/test_7/master_ini.xml
+++ b/systemtest/rimea_tests/test_7/master_ini.xml
@@ -29,7 +29,6 @@
 	<operational_models>
 		<model operational_model_id="1" description="gcfm">
 			<model_parameters>
-				<solver>euler</solver>
 				<stepsize>0.009615</stepsize>
 				<exit_crossing_strategy>4</exit_crossing_strategy>
 				<linkedcells enabled="true" cell_size="2.2" />

--- a/systemtest/rimea_tests/test_8/master_ini.xml
+++ b/systemtest/rimea_tests/test_8/master_ini.xml
@@ -151,7 +151,6 @@
 	<operational_models>
 		<model operational_model_id="1" description="gcfm">
 			<model_parameters>
-				<solver>euler</solver>
 				<stepsize>0.01</stepsize>
 				<exit_crossing_strategy>4</exit_crossing_strategy>
 				<linkedcells enabled="true" cell_size="2.2" />
@@ -178,7 +177,6 @@
 
 		<model operational_model_id="3" description="Tordeux2015">
 			<model_parameters>
-				<solver>euler</solver>
 				<stepsize>0.05</stepsize>
 				<exit_crossing_strategy>3</exit_crossing_strategy>
 				<linkedcells enabled="true" cell_size="2"/>

--- a/systemtest/rimea_tests/test_9/master_ini.xml
+++ b/systemtest/rimea_tests/test_9/master_ini.xml
@@ -33,7 +33,6 @@
 	<operational_models>
 		<model operational_model_id="1" description="gcfm">
 			<model_parameters>
-				<solver>euler</solver>
 				<stepsize>0.01</stepsize>
 				<exit_crossing_strategy>4</exit_crossing_strategy>
 				<linkedcells enabled="true" cell_size="2.2" />
@@ -61,7 +60,6 @@
 
 		<model operational_model_id="3" description="Tordeux2015">
 			<model_parameters>
-				<solver>euler</solver>
 				<stepsize>0.01</stepsize>
 				<exit_crossing_strategy>3</exit_crossing_strategy>
 				<linkedcells enabled="true" cell_size="2.2"/>

--- a/systemtest/router_tests/test_router_1/master_ini.xml
+++ b/systemtest/router_tests/test_router_1/master_ini.xml
@@ -38,7 +38,6 @@
   <operational_models >
     <model operational_model_id="3" description="Tordeux2015">
       <model_parameters>
-        <solver>euler</solver>
         <stepsize>0.05</stepsize>
         <exit_crossing_strategy>3</exit_crossing_strategy>
         <linkedcells enabled="true" cell_size="2.2" />

--- a/systemtest/router_tests/test_router_10/master_ini.xml
+++ b/systemtest/router_tests/test_router_10/master_ini.xml
@@ -47,7 +47,6 @@
     <operational_models>
         <model operational_model_id="3" description="Tordeux2015">
             <model_parameters>
-                <solver>euler</solver>
                 <stepsize>0.01</stepsize>
                 <exit_crossing_strategy>9</exit_crossing_strategy>
                 <linkedcells enabled="true" cell_size="2.2"/>

--- a/systemtest/router_tests/test_router_2/master_ini.xml
+++ b/systemtest/router_tests/test_router_2/master_ini.xml
@@ -37,7 +37,6 @@
   <operational_models >
     <model operational_model_id="3" description="Tordeux2015">
       <model_parameters>
-        <solver>euler</solver>
         <stepsize>0.05</stepsize>
         <exit_crossing_strategy>3</exit_crossing_strategy>
         <linkedcells enabled="true" cell_size="2.2" />

--- a/systemtest/router_tests/test_router_3/master_ini.xml
+++ b/systemtest/router_tests/test_router_3/master_ini.xml
@@ -37,7 +37,6 @@
   <operational_models >
     <model operational_model_id="3" description="Tordeux2015">
       <model_parameters>
-        <solver>euler</solver>
         <stepsize>0.05</stepsize>
         <exit_crossing_strategy>3</exit_crossing_strategy>
         <linkedcells enabled="true" cell_size="2.2" />

--- a/systemtest/router_tests/test_router_4/master_ini.xml
+++ b/systemtest/router_tests/test_router_4/master_ini.xml
@@ -43,7 +43,6 @@
           
           <model description="Tordeux2015" operational_model_id="3">
                <model_parameters>
-                    <solver>euler</solver>
                     <stepsize>0.1</stepsize>
                     <periodic>0</periodic>
                     <exit_crossing_strategy>8</exit_crossing_strategy>

--- a/systemtest/router_tests/test_router_5/master_ini.xml
+++ b/systemtest/router_tests/test_router_5/master_ini.xml
@@ -54,7 +54,6 @@ xsi:noNamespaceSchemaLocation="http://134.94.2.137/jps_ini_core.xsd">
     <operational_models>
         <model operational_model_id = "3" description = "Tordeux2015">
             <model_parameters>
-                <solver>euler</solver>
                 <stepsize>0.01</stepsize>
                 <exit_crossing_strategy>3</exit_crossing_strategy>
                 <linkedcells enabled = "true" cell_size = "2.2" />

--- a/systemtest/router_tests/test_router_6/master_ini.xml
+++ b/systemtest/router_tests/test_router_6/master_ini.xml
@@ -55,7 +55,6 @@ xsi:noNamespaceSchemaLocation="http://134.94.2.137/jps_ini_core.xsd">
     <operational_models>
         <model operational_model_id = "3" description = "Tordeux2015">
             <model_parameters>
-                <solver>euler</solver>
                 <stepsize>0.01</stepsize>
                 <exit_crossing_strategy>3</exit_crossing_strategy>
                 <linkedcells enabled = "true" cell_size = "2.2" />

--- a/systemtest/router_tests/test_router_7/master_ini.xml
+++ b/systemtest/router_tests/test_router_7/master_ini.xml
@@ -43,7 +43,6 @@
           
           <model description="Tordeux2015" operational_model_id="3">
             <model_parameters>
-              <solver>euler</solver>
               <stepsize>0.05</stepsize>
               <periodic>0</periodic>
               <exit_crossing_strategy>8</exit_crossing_strategy>

--- a/systemtest/router_tests/test_router_8/master_ini.xml
+++ b/systemtest/router_tests/test_router_8/master_ini.xml
@@ -46,7 +46,6 @@
           
           <model description="Tordeux2015" operational_model_id="3">
             <model_parameters>
-              <solver>euler</solver>
               <stepsize>0.05</stepsize>
               <periodic>0</periodic>
               <exit_crossing_strategy>8</exit_crossing_strategy>

--- a/systemtest/router_tests/test_router_9/master_ini.xml
+++ b/systemtest/router_tests/test_router_9/master_ini.xml
@@ -22,7 +22,6 @@
           
           <model description="Tordeux2015" operational_model_id="3">
             <model_parameters>
-              <solver>euler</solver>
               <stepsize>0.05</stepsize>
               <periodic>0</periodic>
               <exit_crossing_strategy>8</exit_crossing_strategy>

--- a/systemtest/source_tests/test_source_bounding_box/master_ini.xml
+++ b/systemtest/source_tests/test_source_bounding_box/master_ini.xml
@@ -48,7 +48,6 @@
   <operational_models>
      <model operational_model_id="3" description="Tordeux2015">
       <model_parameters>
-        <solver>euler</solver>
         <stepsize>0.01</stepsize>
         <exit_crossing_strategy>2</exit_crossing_strategy>
         <linkedcells enabled="true" cell_size="2.2" />

--- a/systemtest/source_tests/test_source_frequency/master_ini.xml
+++ b/systemtest/source_tests/test_source_frequency/master_ini.xml
@@ -48,7 +48,6 @@
   <operational_models>
      <model operational_model_id="3" description="Tordeux2015">
       <model_parameters>
-        <solver>euler</solver>
         <stepsize>0.01</stepsize>
         <exit_crossing_strategy>2</exit_crossing_strategy>
         <linkedcells enabled="true" cell_size="2.2" />

--- a/systemtest/source_tests/test_source_start_position/master_ini.xml
+++ b/systemtest/source_tests/test_source_start_position/master_ini.xml
@@ -47,7 +47,6 @@
   <operational_models>
      <model operational_model_id="3" description="Tordeux2015">
       <model_parameters>
-        <solver>euler</solver>
         <stepsize>0.01</stepsize>
         <exit_crossing_strategy>2</exit_crossing_strategy>
         <linkedcells enabled="true" cell_size="2.2" />

--- a/systemtest/source_tests/test_source_starting_time/master_ini.xml
+++ b/systemtest/source_tests/test_source_starting_time/master_ini.xml
@@ -48,7 +48,6 @@
   <operational_models>
      <model operational_model_id="3" description="Tordeux2015">
       <model_parameters>
-        <solver>euler</solver>
         <stepsize>0.01</stepsize>
         <exit_crossing_strategy>2</exit_crossing_strategy>
         <linkedcells enabled="true" cell_size="2.2" />

--- a/systemtest/source_tests/test_source_time_limits/master_ini.xml
+++ b/systemtest/source_tests/test_source_time_limits/master_ini.xml
@@ -48,7 +48,6 @@
   <operational_models>
      <model operational_model_id="3" description="Tordeux2015">
       <model_parameters>
-        <solver>euler</solver>
         <stepsize>0.01</stepsize>
         <exit_crossing_strategy>2</exit_crossing_strategy>
         <linkedcells enabled="true" cell_size="2.2" />

--- a/systemtest/template_test/master_ini.xml
+++ b/systemtest/template_test/master_ini.xml
@@ -55,7 +55,6 @@
 <operational_models >
     <model operational_model_id="1" description="gcfm">
       <model_parameters>
-        <solver>euler</solver>
         <stepsize>0.001</stepsize>
         <exit_crossing_strategy>range(1,6)</exit_crossing_strategy>
         <linkedcells enabled="true" cell_size="2.2" />

--- a/systemtest/test_geometry/clean_geometry/inifile1.xml
+++ b/systemtest/test_geometry/clean_geometry/inifile1.xml
@@ -37,7 +37,6 @@ xsi:noNamespaceSchemaLocation="../../xsd/jps_ini_core.xsd">
  <operational_models>
     <model operational_model_id="1" description="gcfm">
       <model_parameters>
-        <solver>euler</solver>
         <stepsize>0.01</stepsize>
          <exit_crossing_strategy>4</exit_crossing_strategy>
         <linkedcells enabled="true" cell_size="2.2" />

--- a/systemtest/test_geometry/clean_geometry/inifile10.xml
+++ b/systemtest/test_geometry/clean_geometry/inifile10.xml
@@ -31,7 +31,6 @@ xsi:noNamespaceSchemaLocation="../../xsd/jps_ini_core.xsd">
 
     <model operational_model_id="3" description="Tordeux2015">
         <model_parameters>
-            <solver>euler</solver>
             <stepsize>0.05</stepsize>
             <exit_crossing_strategy>8</exit_crossing_strategy>
             <linkedcells enabled="true" cell_size="2"/>

--- a/systemtest/test_geometry/clean_geometry/inifile2.xml
+++ b/systemtest/test_geometry/clean_geometry/inifile2.xml
@@ -39,7 +39,6 @@ xsi:noNamespaceSchemaLocation="../../xsd/jps_ini_core.xsd">
  <operational_models>
     <model operational_model_id="1" description="gcfm">
       <model_parameters>
-        <solver>euler</solver>
         <stepsize>0.01</stepsize>
          <exit_crossing_strategy>4</exit_crossing_strategy>
         <linkedcells enabled="true" cell_size="2.2" />

--- a/systemtest/test_geometry/clean_geometry/inifile3.xml
+++ b/systemtest/test_geometry/clean_geometry/inifile3.xml
@@ -37,7 +37,6 @@ xsi:noNamespaceSchemaLocation="../../xsd/jps_ini_core.xsd">
  <operational_models>
     <model operational_model_id="1" description="gcfm">
       <model_parameters>
-        <solver>euler</solver>
         <stepsize>0.01</stepsize>
          <exit_crossing_strategy>4</exit_crossing_strategy>
         <linkedcells enabled="true" cell_size="2.2" />

--- a/systemtest/test_geometry/clean_geometry/inifile4.xml
+++ b/systemtest/test_geometry/clean_geometry/inifile4.xml
@@ -36,7 +36,6 @@ xsi:noNamespaceSchemaLocation="../../xsd/jps_ini_core.xsd">
  <operational_models>
     <model operational_model_id="1" description="gcfm">
       <model_parameters>
-        <solver>euler</solver>
         <stepsize>0.01</stepsize>
          <exit_crossing_strategy>4</exit_crossing_strategy>
         <linkedcells enabled="true" cell_size="2.2" />

--- a/systemtest/test_geometry/clean_geometry/inifile5.xml
+++ b/systemtest/test_geometry/clean_geometry/inifile5.xml
@@ -41,7 +41,6 @@ xsi:noNamespaceSchemaLocation="../../xsd/jps_ini_core.xsd">
  <operational_models>
     <model operational_model_id="1" description="gcfm">
       <model_parameters>
-        <solver>euler</solver>
         <stepsize>0.01</stepsize>
          <exit_crossing_strategy>4</exit_crossing_strategy>
         <linkedcells enabled="true" cell_size="2.2" />

--- a/systemtest/test_geometry/clean_geometry/inifile6.xml
+++ b/systemtest/test_geometry/clean_geometry/inifile6.xml
@@ -52,7 +52,6 @@ xsi:noNamespaceSchemaLocation="../../xsd/jps_ini_core.xsd">
 
     <model operational_model_id="3" description="Tordeux2015">
         <model_parameters>
-            <solver>euler</solver>
             <stepsize>0.05</stepsize>
             <exit_crossing_strategy>8</exit_crossing_strategy>
             <linkedcells enabled="true" cell_size="2"/>

--- a/systemtest/test_geometry/clean_geometry/inifile7.xml
+++ b/systemtest/test_geometry/clean_geometry/inifile7.xml
@@ -31,7 +31,6 @@ xsi:noNamespaceSchemaLocation="../../xsd/jps_ini_core.xsd">
 
     <model operational_model_id="3" description="Tordeux2015">
         <model_parameters>
-            <solver>euler</solver>
             <stepsize>0.05</stepsize>
             <exit_crossing_strategy>8</exit_crossing_strategy>
             <linkedcells enabled="true" cell_size="2"/>

--- a/systemtest/test_geometry/clean_geometry/inifile8.xml
+++ b/systemtest/test_geometry/clean_geometry/inifile8.xml
@@ -31,7 +31,6 @@ xsi:noNamespaceSchemaLocation="../../xsd/jps_ini_core.xsd">
 
     <model operational_model_id="3" description="Tordeux2015">
         <model_parameters>
-            <solver>euler</solver>
             <stepsize>0.05</stepsize>
             <exit_crossing_strategy>8</exit_crossing_strategy>
             <linkedcells enabled="true" cell_size="2"/>

--- a/systemtest/test_geometry/clean_geometry/inifile9-1.xml
+++ b/systemtest/test_geometry/clean_geometry/inifile9-1.xml
@@ -31,7 +31,6 @@ xsi:noNamespaceSchemaLocation="../../xsd/jps_ini_core.xsd">
 
     <model operational_model_id="3" description="Tordeux2015">
         <model_parameters>
-            <solver>euler</solver>
             <stepsize>0.05</stepsize>
             <exit_crossing_strategy>8</exit_crossing_strategy>
             <linkedcells enabled="true" cell_size="2"/>

--- a/systemtest/test_geometry/clean_geometry/inifile9-2.xml
+++ b/systemtest/test_geometry/clean_geometry/inifile9-2.xml
@@ -31,7 +31,6 @@ xsi:noNamespaceSchemaLocation="../../xsd/jps_ini_core.xsd">
 
     <model operational_model_id="3" description="Tordeux2015">
         <model_parameters>
-            <solver>euler</solver>
             <stepsize>0.05</stepsize>
             <exit_crossing_strategy>8</exit_crossing_strategy>
             <linkedcells enabled="true" cell_size="2"/>


### PR DESCRIPTION
As we only support Euler solver at the moment the option is always set to euler and hence not needed.
Additionally the parsing of solver always raised an error message although no error occurs.
- Removes solver option from parsing
- Removes solver from configuration
- Removes option from documentation
- Removes option from demo files