### PR TITLE
Added prefix path flag in build documentation

### DIFF
--- a/docs/pages/jupedsim/jupedsim_install_on_linux.md
+++ b/docs/pages/jupedsim/jupedsim_install_on_linux.md
@@ -45,18 +45,20 @@ Alternatively you can generate a make based build with:
 ```bash
 mkdir build
 cd build
-cmake -DCMAKE_BUILD_TYPE=Debug <path-to-cmakelists>
+cmake -DCMAKE_BUILD_TYPE=Debug <path-to-cmakelists> -DCMAKE_PREFIX_PATH=$(pwd)/deps
 make -j$(nproc)
 ```
 
 {% include note.html content="If you do not want to use OpenMP you have to pass `-DUSE_OPENMP=OFF` to cmake on generation." %}
 ```bash
-cmake -DCMAKE_BUILD_TYPE=Debug -DUSE_OPENMP=OFF <path-to-cmakelists>
+cmake -DCMAKE_BUILD_TYPE=Debug -DUSE_OPENMP=OFF <path-to-cmakelists> -DCMAKE_PREFIX_PATH=$(pwd)/deps
 ```
 
 ## CMake configuration flags
 
 The following configuration flags are available:
+
+- CMAKE_PREFIX_PATH must always be set to directory `deps` to consider dependencies. See [CMake documentation](https://cmake.org/cmake/help/latest/variable/CMAKE_PREFIX_PATH.html) for detailed information.
 
 - USE_OPENMP defaults to ON (Disabled on Windows)
 Build `jpscore` with OpenMP support, generation will fail if OpenMP cannot be

--- a/docs/pages/jupedsim/jupedsim_install_on_linux.md
+++ b/docs/pages/jupedsim/jupedsim_install_on_linux.md
@@ -58,7 +58,7 @@ cmake -DCMAKE_BUILD_TYPE=Debug -DUSE_OPENMP=OFF <path-to-cmakelists> -DCMAKE_PRE
 
 The following configuration flags are available:
 
-- CMAKE_PREFIX_PATH must always be set to directory `deps` to consider dependencies. See [CMake documentation](https://cmake.org/cmake/help/latest/variable/CMAKE_PREFIX_PATH.html) for detailed information.
+- CMAKE_PREFIX_PATH must always be set to directory `deps`, where the dependencies are installed. See [CMake documentation](https://cmake.org/cmake/help/latest/variable/CMAKE_PREFIX_PATH.html) for detailed information.
 
 - USE_OPENMP defaults to ON (Disabled on Windows)
 Build `jpscore` with OpenMP support, generation will fail if OpenMP cannot be


### PR DESCRIPTION
Added CMAKE_PREFIX_PATH when executing cmake to consider dependencies correctly.
Description of this flag was added below.

Fixes #724 