### PR TITLE
Bug fix: FF router with closed transitions

### DIFF
--- a/libcore/src/routing/ff_router/ffRouter.cpp
+++ b/libcore/src/routing/ff_router/ffRouter.cpp
@@ -362,8 +362,9 @@ int FFRouter::FindExit(Pedestrian * p)
     validFinalDoor.clear();
     if(goalID == -1) {
         for(auto & pairDoor : _ExitsByUID) {
-            //we add the all exits
-            if(!_building->GetTransitionByUID(pairDoor.first)->IsClose()) {
+            // we add all open/temp_close exits
+            if(_building->GetTransitionByUID(pairDoor.first)->IsOpen() ||
+               _building->GetTransitionByUID(pairDoor.first)->IsTempClose()) {
                 validFinalDoor.emplace_back(pairDoor.first); //UID
             }
         }
@@ -400,7 +401,7 @@ int FFRouter::FindExit(Pedestrian * p)
         for(auto & transI : _building->GetRoom(p->GetRoomID())
                                 ->GetSubRoom(p->GetSubRoomID())
                                 ->GetAllTransitions()) {
-            if(!transI->IsClose()) {
+            if(transI->IsOpen() || transI->IsTempClose()) {
                 DoorUIDsOfRoom.emplace_back(transI->GetUniqueID());
             }
         }

--- a/libcore/src/routing/ff_router/ffRouter.cpp
+++ b/libcore/src/routing/ff_router/ffRouter.cpp
@@ -362,8 +362,10 @@ int FFRouter::FindExit(Pedestrian * p)
     validFinalDoor.clear();
     if(goalID == -1) {
         for(auto & pairDoor : _ExitsByUID) {
-            //we add the all exits,
-            validFinalDoor.emplace_back(pairDoor.first); //UID
+            //we add the all exits
+            if(!_building->GetTransitionByUID(pairDoor.first)->IsClose()) {
+                validFinalDoor.emplace_back(pairDoor.first); //UID
+            }
         }
     } else { //only one specific goal, goalToLineUIDmap gets
         //populated in Init()
@@ -385,20 +387,26 @@ int FFRouter::FindExit(Pedestrian * p)
         }
         for(auto & subIPair : _building->GetRoom(p->GetRoomID())->GetAllSubRooms()) {
             for(auto & crossI : subIPair.second->GetAllCrossings()) {
-                DoorUIDsOfRoom.emplace_back(crossI->GetUniqueID());
+                if(!crossI->IsClose()) {
+                    DoorUIDsOfRoom.emplace_back(crossI->GetUniqueID());
+                }
             }
         }
     } else {
         //candidates of current subroom only
         for(auto & crossI :
             _building->GetRoom(p->GetRoomID())->GetSubRoom(p->GetSubRoomID())->GetAllCrossings()) {
-            DoorUIDsOfRoom.emplace_back(crossI->GetUniqueID());
+            if(!crossI->IsClose()) {
+                DoorUIDsOfRoom.emplace_back(crossI->GetUniqueID());
+            }
         }
 
         for(auto & transI : _building->GetRoom(p->GetRoomID())
                                 ->GetSubRoom(p->GetSubRoomID())
                                 ->GetAllTransitions()) {
-            DoorUIDsOfRoom.emplace_back(transI->GetUniqueID());
+            if(!transI->IsClose()) {
+                DoorUIDsOfRoom.emplace_back(transI->GetUniqueID());
+            }
         }
     }
 

--- a/libcore/src/routing/ff_router/ffRouter.cpp
+++ b/libcore/src/routing/ff_router/ffRouter.cpp
@@ -387,18 +387,14 @@ int FFRouter::FindExit(Pedestrian * p)
         }
         for(auto & subIPair : _building->GetRoom(p->GetRoomID())->GetAllSubRooms()) {
             for(auto & crossI : subIPair.second->GetAllCrossings()) {
-                if(!crossI->IsClose()) {
-                    DoorUIDsOfRoom.emplace_back(crossI->GetUniqueID());
-                }
+                DoorUIDsOfRoom.emplace_back(crossI->GetUniqueID());
             }
         }
     } else {
         //candidates of current subroom only
         for(auto & crossI :
             _building->GetRoom(p->GetRoomID())->GetSubRoom(p->GetSubRoomID())->GetAllCrossings()) {
-            if(!crossI->IsClose()) {
-                DoorUIDsOfRoom.emplace_back(crossI->GetUniqueID());
-            }
+            DoorUIDsOfRoom.emplace_back(crossI->GetUniqueID());
         }
 
         for(auto & transI : _building->GetRoom(p->GetRoomID())

--- a/systemtest/router_tests/CMakeLists.txt
+++ b/systemtest/router_tests/CMakeLists.txt
@@ -3,3 +3,9 @@ add_test(NAME router_test-10 COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/sy
 set_tests_properties(
         router_test-10
         PROPERTIES LABELS "CI:FAST")
+
+add_test(NAME router_test_corridor_close COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/systemtest/router_tests/test_corridor_close/runtest_corridor_close.py ${jpscore_exe})
+
+set_tests_properties(
+        router_test_corridor_close
+        PROPERTIES LABELS "CI:FAST")

--- a/systemtest/router_tests/test_corridor_close/geometry.xml
+++ b/systemtest/router_tests/test_corridor_close/geometry.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+
+<geometry version="0.8" caption="Projectname" unit="m">
+    <rooms>
+        <room id="0">
+            <subroom id="1" closed="0" class="subroom" A_x="0" B_y="0" C_z="0">
+                <polygon caption="wall">
+                    <vertex px="-20.0" py="-5.0"/>
+                    <vertex px="10.0" py="-5.0"/>
+                </polygon>
+                <polygon caption="wall">
+                    <vertex px="-20.0" py="5.0"/>
+                    <vertex px="10.0" py="5.0"/>
+                </polygon>
+            </subroom>
+        </room>
+    </rooms>
+    <transitions>
+        <transition id="0" caption="No_Name" type="emergency" room1_id="0" subroom1_id="1" room2_id="-1"
+                    subroom2_id="-1">
+            <vertex px="-20.0" py="-5.0"/>
+            <vertex px="-20.0" py="5.0"/>
+        </transition>
+        <transition id="1" caption="No_Name" type="emergency" room1_id="0" subroom1_id="1" room2_id="-1"
+                    subroom2_id="-1">
+            <vertex px="10.0" py="-5.0"/>
+            <vertex px="10.0" py="5.0"/>
+        </transition>
+    </transitions>
+</geometry>
+

--- a/systemtest/router_tests/test_corridor_close/master_ini.xml
+++ b/systemtest/router_tests/test_corridor_close/master_ini.xml
@@ -9,7 +9,7 @@
         <!-- geometry file -->
         <geometry>../geometry.xml</geometry>
         <!-- traectories file and format -->
-        <trajectories format="xml-plain" embed_mesh="false" fps="10">
+        <trajectories format="xml-plain" embed_mesh="false" fps="20">
             <file location="Traj_test_7.xml"/>
         </trajectories>
     </header>

--- a/systemtest/router_tests/test_corridor_close/master_ini.xml
+++ b/systemtest/router_tests/test_corridor_close/master_ini.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<JuPedSim project="JPS-Project" version="0.8" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <header>
+        <seed>1</seed>
+        <max_sim_time>90</max_sim_time>
+        <num_threads>8</num_threads>
+
+        <!-- geometry file -->
+        <geometry>../geometry.xml</geometry>
+        <!-- traectories file and format -->
+        <trajectories format="xml-plain" embed_mesh="false" fps="10">
+            <file location="Traj_test_7.xml"/>
+        </trajectories>
+    </header>
+
+    <!-- traffic information: e.g closed doors or smoked rooms -->
+    <traffic_constraints>
+        <!-- doors states are: close or open -->
+        <doors>
+            <door trans_id="0" caption="" state="close"/>
+        </doors>
+    </traffic_constraints>
+
+    <!--persons information and distribution -->
+    <agents operational_model_id="3">
+        <agents_distribution>
+            <group group_id="0" agent_parameter_id="0" room_id="0" subroom_id="1" number="1" goal_id="-1" x_min="-19"
+                   x_max="-17" router_id="[1,2,3,4,5]"/>
+        </agents_distribution>
+    </agents>
+
+    <operational_models>
+        <model operational_model_id="3" description="Tordeux2015">
+            <model_parameters>
+                <stepsize>0.05</stepsize>
+                <exit_crossing_strategy>3</exit_crossing_strategy>
+                <linkedcells enabled="true" cell_size="2.2"/>
+                <force_ped a="5" D="0.1"/>
+                <force_wall a="5" D="0.02"/>
+            </model_parameters>
+            <agent_parameters agent_parameter_id="0">
+                <v0 mu="1.34" sigma="0.001"/>
+                <bmax mu="0.15" sigma="0.00000"/> <!-- this is l, assuming peds are circles with constant radius-->
+                <bmin mu="0.15" sigma="0.00000"/>
+                <amin mu="0.15" sigma="0.00000"/>
+                <tau mu="0.5" sigma="0.001"/>
+                <atau mu="0.0" sigma="0.00000"/>
+                <T mu="1" sigma="0.001"/>
+            </agent_parameters>
+        </model>
+    </operational_models>
+
+    <route_choice_models>
+        <router router_id="1" description="local_shortest">
+            <parameters>
+                <!-- <navigation_lines file="routing.xml" /> -->
+            </parameters>
+        </router>
+
+        <router router_id="2" description="global_shortest">
+            <parameters>
+                <!--<navigation_lines file="routing.xml" />-->
+            </parameters>
+        </router>
+
+        <router router_id="3" description="quickest"> <!-- global quickest -->
+            <parameters>
+                <!-- <navigation_lines file="routing.xml" /> -->
+            </parameters>
+        </router>
+
+
+        <router router_id="4" description="ff_global_shortest"/> <!-- like global_shortest, without HLines -->
+        <router router_id="5" description="ff_quickest"/> <!-- like global quickest -->
+    </route_choice_models>
+</JuPedSim>

--- a/systemtest/router_tests/test_corridor_close/runtest_corridor_close.py
+++ b/systemtest/router_tests/test_corridor_close/runtest_corridor_close.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+
+"""
+Simple corridor with two exits, exit closer to pedestrian is closed. Check if pedestrian use further exit.
+"""
+
+import os
+import sys
+
+utestdir = os.path.abspath(os.path.dirname(os.path.dirname(sys.path[0])))
+from sys import *
+
+sys.path.append(utestdir)
+from JPSRunTest import JPSRunTestDriver
+from utils import *
+
+
+def runtest1(inifile, trajfile):
+    fps, N, traj = parse_file(trajfile)
+    failure = False
+    ids = np.unique(traj[:, 0]).astype(int)
+    e2 = [10, -5, 5]  # x, y1, y2
+    for ped in ids:
+        traj1 = traj[traj[:, 0] == ped]
+        if not PassedLineX(traj1, e2):
+            logging.critical("ped %d did not pass exit" % ped)
+            failure = True
+
+    if failure:
+        logging.critical("%s exists with failure!" % argv[0])
+        exit(FAILURE)
+
+
+if __name__ == "__main__":
+    test = JPSRunTestDriver(1, argv0=argv[0], testdir=sys.path[0], utestdir=utestdir, jpscore=argv[1])
+    test.run_test(testfunction=runtest1)
+    logging.info("%s exits with SUCCESS" % (argv[0]))
+    exit(SUCCESS)


### PR DESCRIPTION
When in the final subroom/room the FF router also considered closed doors. Hence the always went to the closest door even if it is closed and they should be redirected.

- Closed doors are now not considered by the router when in final subroom/room
- Add simple test: One corridor with doors at each end. Closer door to pedestrian is closed. Check if open door is used. (Tested for all routers)