### PR TITLE
Checks simulation return code in Test execution

### DIFF
--- a/systemtest/JPSRunTest.py
+++ b/systemtest/JPSRunTest.py
@@ -179,7 +179,11 @@ class JPSRunTestDriver(object):
     def __execute_test(self, executable, inifile, testfunction, trajfile="", *args):
         cmd = "%s %s"%(executable, inifile)
         logging.info('start simulating with exe=<%s>', cmd)
-        subprocess.call([executable, "%s" % inifile])
+        returncode = subprocess.call([executable, "%s" % inifile])
+        if returncode:
+            logging.error("Simulation returned with error code: " + str(returncode) + ".")
+            exit(self.FAILURE)
+
         logging.info('end simulation ...\n--------------\n')
         logging.info("inifile <%s>", inifile)
         if not trajfile:


### PR DESCRIPTION
At the moment the return code of the jpscore execution is ignored in
all systemtests based on JPSRunTest. This leads to false successful
test in CI and test execution. With this PR the return code is checked
and an error is emitted for non zero return codes.