### PR TITLE
Consistent defintion of points in ini and geometry files

### DIFF
--- a/docs/pages/jpsreport/jpsreport_inifile.md
+++ b/docs/pages/jpsreport/jpsreport_inifile.md
@@ -124,22 +124,23 @@ The parameter `zPos` is used to indicate the position of measurement area in z a
   ```xml
   <measurement_areas unit="m">
       <area_B id="1" type="BoundingBox" zPos="None">
-          <vertex x="-2.40" y="1.00" /> <!-- Clockwise -->
-          <vertex x="-2.40" y="3.00" />
-          <vertex x="0" y="3.00" />
-          <vertex x="0" y="1.00" />
+          <vertex px="-2.40" py="1.00" /> <!-- Clockwise -->
+          <vertex px="-2.40" py="3.00" />
+          <vertex px="0" py="3.00" />
+          <vertex px="0" py="1.00" />
           <length_in_movement_direction distance="2.0" />
       </area_B>
       <area_L id="2" type="Line" zPos="None">
-          <start x="-2.40" y="1.00" />
-          <end x="0" y="1.00" />
+          <start px="-2.40" py="1.00" />
+          <end px="0" py="1.00" />
       </area_L>
       <area_L id="3" type="Line" zPos="None">
-          <start x="-2.40" y="2.00" />
-          <end x="0" y="2.00" />
+          <start px="-2.40" py="2.00" />
+          <end px="0" py="2.00" />
       </area_L>
   </measurement_areas>
   ```
+{%include note.html content="The old definition of points with the format `x=-2.40 y=1.00` is still working but deprecated. This input format will be removed in future.  "%}
 
 ## Velocity
 precises the method for calculating the instantaneous velocity $$v_i(t)$$

--- a/docs/pages/jupedsim/jupedsim_install_executables.md
+++ b/docs/pages/jupedsim/jupedsim_install_executables.md
@@ -71,7 +71,7 @@ Finally, complete the installation by clicking on `Finish`.
 
 ### Start a simulation 
 
-{%include important.html content="Before starting a simulation make sure to copy the directory jpscore_samples files to a direction, where you have write permissions, e.g. Desktop."%}
+{%include important.html content="Before starting a simulation make sure to copy the directory jpscore_samples files to a directory, where you have write permissions, e.g. Desktop."%}
 
 Open `Powershell` in the directory of `jpscore_samples` as shown in the following screenshot:
 

--- a/jpsreport/general/ArgumentParser.cpp
+++ b/jpsreport/general/ArgumentParser.cpp
@@ -419,7 +419,7 @@ bool ArgumentParser::ParseIniFile(const string & inifile)
             for(TiXmlElement * xVertex = xMeasurementArea_B->FirstChildElement("vertex"); xVertex;
                 xVertex                = xVertex->NextSiblingElement("vertex")) {
                 // Note: Attributes are optional, their existence needs to be checked since xmltof returns 0.0 if unknown
-                if(xVertex->Attribute("x") != NULL and xVertex->Attribute("y") != NULL) {
+                if(xVertex->Attribute("x") != NULL && xVertex->Attribute("y") != NULL) {
                     // DEPRECATED FORMAT should be removed in future
                     double box_px = xmltof(xVertex->Attribute("x")) * M2CM;
                     double box_py = xmltof(xVertex->Attribute("y")) * M2CM;
@@ -427,7 +427,7 @@ bool ArgumentParser::ParseIniFile(const string & inifile)
                     Log->Write(
                         "\t\tMeasure area points  < %.3f, %.3f>", box_px * CMtoM, box_py * CMtoM);
                     num_verteces++;
-                } else if(xVertex->Attribute("px") != NULL and xVertex->Attribute("py") != NULL) {
+                } else if(xVertex->Attribute("px") != NULL && xVertex->Attribute("py") != NULL) {
                     // NEW FORMAT
                     double box_px = xmltof(xVertex->Attribute("px")) * M2CM;
                     double box_py = xmltof(xVertex->Attribute("py")) * M2CM;
@@ -517,14 +517,14 @@ bool ArgumentParser::ParseIniFile(const string & inifile)
             Log->Write(
                 "INFO: \tMeasure area id  <%d> with type <%s>", areaL->_id, areaL->_type.c_str());
 
-            if(xMeasurementArea_L->FirstChildElement("start")->Attribute("x") != NULL and
+            if(xMeasurementArea_L->FirstChildElement("start")->Attribute("x") != NULL &&
                xMeasurementArea_L->FirstChildElement("start")->Attribute("y") != NULL) {
                 areaL->_lineStartX =
                     xmltof(xMeasurementArea_L->FirstChildElement("start")->Attribute("x")) * M2CM;
                 areaL->_lineStartY =
                     xmltof(xMeasurementArea_L->FirstChildElement("start")->Attribute("y")) * M2CM;
             } else if(
-                xMeasurementArea_L->FirstChildElement("start")->Attribute("px") != NULL and
+                xMeasurementArea_L->FirstChildElement("start")->Attribute("px") != NULL &&
                 xMeasurementArea_L->FirstChildElement("start")->Attribute("py") != NULL) {
                 // NEW FORMAT
                 // Note: argument can be changed to "required" (once the deprecated format is removed), existence would no longer need to be checked
@@ -538,7 +538,7 @@ bool ArgumentParser::ParseIniFile(const string & inifile)
                 exit(EXIT_FAILURE);
             }
 
-            if(xMeasurementArea_L->FirstChildElement("end")->Attribute("x") != NULL and
+            if(xMeasurementArea_L->FirstChildElement("end")->Attribute("x") != NULL &&
                xMeasurementArea_L->FirstChildElement("end")->Attribute("y") != NULL) {
                 // DEPRECATED FORMAT should be removed in future
                 areaL->_lineEndX =
@@ -546,7 +546,7 @@ bool ArgumentParser::ParseIniFile(const string & inifile)
                 areaL->_lineEndY =
                     xmltof(xMeasurementArea_L->FirstChildElement("end")->Attribute("y")) * M2CM;
             } else if(
-                xMeasurementArea_L->FirstChildElement("end")->Attribute("px") != NULL and
+                xMeasurementArea_L->FirstChildElement("end")->Attribute("px") != NULL &&
                 xMeasurementArea_L->FirstChildElement("end")->Attribute("py") != NULL) {
                 // NEW FORMAT
                 // Note: argument can be changed to "required" (once the deprecated format is removed), existence would no longer need to be checked

--- a/jpsreport/general/ArgumentParser.cpp
+++ b/jpsreport/general/ArgumentParser.cpp
@@ -419,7 +419,7 @@ bool ArgumentParser::ParseIniFile(const string & inifile)
             for(TiXmlElement * xVertex = xMeasurementArea_B->FirstChildElement("vertex"); xVertex;
                 xVertex                = xVertex->NextSiblingElement("vertex")) {
                 // Note: Attributes are optional, their existence needs to be checked since xmltof returns 0.0 if unknown
-                if(xVertex->Attribute("x") != NULL && xVertex->Attribute("y") != NULL) {
+                if(xVertex->Attribute("x") != nullptr && xVertex->Attribute("y") != nullptr) {
                     // DEPRECATED FORMAT should be removed in future
                     double box_px = xmltof(xVertex->Attribute("x")) * M2CM;
                     double box_py = xmltof(xVertex->Attribute("y")) * M2CM;
@@ -427,7 +427,8 @@ bool ArgumentParser::ParseIniFile(const string & inifile)
                     Log->Write(
                         "\t\tMeasure area points  < %.3f, %.3f>", box_px * CMtoM, box_py * CMtoM);
                     num_verteces++;
-                } else if(xVertex->Attribute("px") != NULL && xVertex->Attribute("py") != NULL) {
+                } else if(
+                    xVertex->Attribute("px") != nullptr && xVertex->Attribute("py") != nullptr) {
                     // NEW FORMAT
                     double box_px = xmltof(xVertex->Attribute("px")) * M2CM;
                     double box_py = xmltof(xVertex->Attribute("py")) * M2CM;
@@ -517,15 +518,15 @@ bool ArgumentParser::ParseIniFile(const string & inifile)
             Log->Write(
                 "INFO: \tMeasure area id  <%d> with type <%s>", areaL->_id, areaL->_type.c_str());
 
-            if(xMeasurementArea_L->FirstChildElement("start")->Attribute("x") != NULL &&
-               xMeasurementArea_L->FirstChildElement("start")->Attribute("y") != NULL) {
+            if(xMeasurementArea_L->FirstChildElement("start")->Attribute("x") != nullptr &&
+               xMeasurementArea_L->FirstChildElement("start")->Attribute("y") != nullptr) {
                 areaL->_lineStartX =
                     xmltof(xMeasurementArea_L->FirstChildElement("start")->Attribute("x")) * M2CM;
                 areaL->_lineStartY =
                     xmltof(xMeasurementArea_L->FirstChildElement("start")->Attribute("y")) * M2CM;
             } else if(
-                xMeasurementArea_L->FirstChildElement("start")->Attribute("px") != NULL &&
-                xMeasurementArea_L->FirstChildElement("start")->Attribute("py") != NULL) {
+                xMeasurementArea_L->FirstChildElement("start")->Attribute("px") != nullptr &&
+                xMeasurementArea_L->FirstChildElement("start")->Attribute("py") != nullptr) {
                 // NEW FORMAT
                 // Note: argument can be changed to "required" (once the deprecated format is removed), existence would no longer need to be checked
                 areaL->_lineStartX =
@@ -538,16 +539,16 @@ bool ArgumentParser::ParseIniFile(const string & inifile)
                 exit(EXIT_FAILURE);
             }
 
-            if(xMeasurementArea_L->FirstChildElement("end")->Attribute("x") != NULL &&
-               xMeasurementArea_L->FirstChildElement("end")->Attribute("y") != NULL) {
+            if(xMeasurementArea_L->FirstChildElement("end")->Attribute("x") != nullptr &&
+               xMeasurementArea_L->FirstChildElement("end")->Attribute("y") != nullptr) {
                 // DEPRECATED FORMAT should be removed in future
                 areaL->_lineEndX =
                     xmltof(xMeasurementArea_L->FirstChildElement("end")->Attribute("x")) * M2CM;
                 areaL->_lineEndY =
                     xmltof(xMeasurementArea_L->FirstChildElement("end")->Attribute("y")) * M2CM;
             } else if(
-                xMeasurementArea_L->FirstChildElement("end")->Attribute("px") != NULL &&
-                xMeasurementArea_L->FirstChildElement("end")->Attribute("py") != NULL) {
+                xMeasurementArea_L->FirstChildElement("end")->Attribute("px") != nullptr &&
+                xMeasurementArea_L->FirstChildElement("end")->Attribute("py") != nullptr) {
                 // NEW FORMAT
                 // Note: argument can be changed to "required" (once the deprecated format is removed), existence would no longer need to be checked
                 areaL->_lineEndX =

--- a/jpsreport/general/ArgumentParser.cpp
+++ b/jpsreport/general/ArgumentParser.cpp
@@ -418,12 +418,26 @@ bool ArgumentParser::ParseIniFile(const string & inifile)
             int num_verteces = 0;
             for(TiXmlElement * xVertex = xMeasurementArea_B->FirstChildElement("vertex"); xVertex;
                 xVertex                = xVertex->NextSiblingElement("vertex")) {
-                double box_px = xmltof(xVertex->Attribute("x")) * M2CM;
-                double box_py = xmltof(xVertex->Attribute("y")) * M2CM;
-                boost::geometry::append(poly, boost::geometry::make<point_2d>(box_px, box_py));
-                Log->Write(
-                    "\t\tMeasure area points  < %.3f, %.3f>", box_px * CMtoM, box_py * CMtoM);
-                num_verteces++;
+                // Note: Attributes are optional, their existence needs to be checked
+                if(xVertex->Attribute("x") != NULL and xVertex->Attribute("y") != NULL) {
+                    // DEPRECATED FORMAT should be removed in future
+                    double box_px = xmltof(xVertex->Attribute("x")) * M2CM;
+                    double box_py = xmltof(xVertex->Attribute("y")) * M2CM;
+                    boost::geometry::append(poly, boost::geometry::make<point_2d>(box_px, box_py));
+                    Log->Write(
+                        "\t\tMeasure area points  < %.3f, %.3f>", box_px * CMtoM, box_py * CMtoM);
+                    num_verteces++;
+                } else if(xVertex->Attribute("px") != NULL and xVertex->Attribute("py") != NULL) {
+                    // NEW FORMAT
+                    double box_px = xmltof(xVertex->Attribute("px")) * M2CM;
+                    double box_py = xmltof(xVertex->Attribute("py")) * M2CM;
+                    boost::geometry::append(poly, boost::geometry::make<point_2d>(box_px, box_py));
+                    Log->Write(
+                        "\t\tMeasure area points  < %.3f, %.3f>", box_px * CMtoM, box_py * CMtoM);
+                    num_verteces++;
+                } else {
+                    Log->Write("\tWARNING: Unvalid vertex format given.");
+                }
             }
             if(num_verteces < 3 && num_verteces > 0)
                 Log->Write(

--- a/jpsreport/xsd/jps_report.xsd
+++ b/jpsreport/xsd/jps_report.xsd
@@ -106,8 +106,10 @@
                       <xs:complexType>
                         <xs:simpleContent>
                           <xs:extension base="xs:string">
-                            <xs:attribute type="xs:float" name="x" use="required"/>
-                            <xs:attribute type="xs:float" name="y" use="required"/>
+                            <xs:attribute type="xs:float" name="x" use="optional"/>
+                            <xs:attribute type="xs:float" name="y" use="optional"/>
+                            <xs:attribute type="xs:float" name="px" use="optional"/>
+                            <xs:attribute type="xs:float" name="py" use="optional"/>
                           </xs:extension>
                         </xs:simpleContent>
                       </xs:complexType>
@@ -116,8 +118,10 @@
                       <xs:complexType>
                         <xs:simpleContent>
                           <xs:extension base="xs:string">
-                            <xs:attribute type="xs:float" name="x" use="required"/>
-                            <xs:attribute type="xs:float" name="y" use="required"/>
+                            <xs:attribute type="xs:float" name="x" use="optional"/>
+                            <xs:attribute type="xs:float" name="y" use="optional"/>
+                            <xs:attribute type="xs:float" name="px" use="optional"/>
+                            <xs:attribute type="xs:float" name="py" use="optional"/>
                           </xs:extension>
                         </xs:simpleContent>
                       </xs:complexType>

--- a/jpsreport/xsd/jps_report.xsd
+++ b/jpsreport/xsd/jps_report.xsd
@@ -78,6 +78,8 @@
                           <xs:extension base="xs:string">
                             <xs:attribute type="xs:float" name="x"  use="optional"/>
                             <xs:attribute type="xs:float" name="y"  use="optional"/>
+                            <xs:attribute type="xs:float" name="px" use="optional"/>
+                            <xs:attribute type="xs:float" name="py" use="optional"/>
                           </xs:extension>
                         </xs:simpleContent>
                       </xs:complexType>


### PR DESCRIPTION
Added additional `px` and `py`attritbutes to `area_L` and `area_B`.
Lots of redundant code in `ArgumentParser.cpp` since the old definition with `x` and `y` is still supported.

jpsreport tests must be adapted afterwards.

Once the old definition is not supported anymore the attributes of `area_L` should be changed back to `required` because the error when these attributes are missing is not caught at this point.
Missing attributes for `area_B` lead to creation of a big bounding box which should be fine.

Solves #747 