### PR TITLE
Exit jpsreport, if measurement are is misconfigured.

### DIFF
--- a/jpsreport/Analysis.cpp
+++ b/jpsreport/Analysis.cpp
@@ -44,9 +44,11 @@
 #include <Logger.h>
 #include <algorithm> // std::min_element, std::max_element
 #include <cfloat>
+#include <fmt/format.h>
 #include <fstream>
 #include <iostream>
 #include <sstream>
+#include <stdexcept>
 #include <stdlib.h>
 #include <vector>
 
@@ -246,8 +248,9 @@ std::map<int, polygon_2d> Analysis::ReadGeometry(
         } //room
 
         if(geoPoly.count(area->_id) == 0) {
-            LOG_ERROR("No polygon containing the measurement id {}.", area->_id);
             geoPoly[area->_id] = area->_poly;
+            throw std::runtime_error(
+                fmt::format(FMT_STRING("No polygon containing the measurement id {}."), area->_id));
         }
     }
 

--- a/jpsreport/main.cpp
+++ b/jpsreport/main.cpp
@@ -35,6 +35,7 @@
 
 #include <Logger.h>
 #include <chrono>
+#include <exception>
 
 using namespace std;
 using namespace std::chrono;
@@ -55,7 +56,13 @@ int main(int argc, char ** argv)
             Analysis analysis     = Analysis();
             LOG_INFO("Start Analysis for the file: {}", File.string().c_str());
             LOG_INFO("**********************************************************************");
-            analysis.InitArgs(args);
+            try {
+                analysis.InitArgs(args);
+            } catch(const std::exception & e) {
+                LOG_ERROR("Exception in Analysis::InitArgs thrown, what: {}", e.what());
+
+                return EXIT_FAILURE;
+            }
             analysis.RunAnalysis(File, Path);
             LOG_INFO("**********************************************************************");
             LOG_INFO("End Analysis for the file: {}\n", File.string().c_str());


### PR DESCRIPTION
There is not a sane case where this situation should be tolerated.
Therefore, exit calculation at once. The user is expected to
configure measurement areas properly.

Fixes  #706