### PR TITLE
Fix  jupedsim pages domain CNAME.

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,1 +1,1 @@
-www.jupedsim.org
+jupedsim.org


### PR DESCRIPTION
using www.jupedsim.org uses the www subdomain. We want to have the to
level domain jupedsim.org without www.