### PR TITLE
Update GCC to version 9 and Ubuntu to 20.04

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -298,9 +298,9 @@ if(UNIX)
             ERROR_QUIET
             OUTPUT_STRIP_TRAILING_WHITESPACE
         )
-        if(version_string MATCHES "^clang-format version .*")
+        if(version_string MATCHES "^.*clang-format version .*")
             string(REGEX REPLACE
-                "clang-format version ([.0-9]+).*"
+                "^.*clang-format version ([.0-9]+).*"
                 "\\1"
                 version
                 "${version_string}"

--- a/container/build/Dockerfile
+++ b/container/build/Dockerfile
@@ -10,7 +10,8 @@ RUN apt-get update && apt-get install -y wget \
                        libboost-dev \
                        libcgal-dev \
                        python3 \
-                       python3-pip
+                       python3-pip \
+                       python3-matplotlib
 
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 6084F3CF814B57C1CF12EFD515CF4D18AF4F7421 && \
     add-apt-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-10 main" && \
@@ -23,7 +24,6 @@ COPY scripts/setup-deps.sh /opt/
 RUN cd /opt && CXX=/usr/bin/g++-9 CC=/usr/bin/gcc-9 ./setup-deps.sh
 
 RUN pip3 install numpy && \
-    pip3 install matplotlib && \
     pip3 install pandas && \
     pip3 install dataclasses && \
     pip3 install scipy

--- a/container/build/Dockerfile
+++ b/container/build/Dockerfile
@@ -1,34 +1,29 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 RUN apt-get update && apt-get install -y software-properties-common
 
 RUN apt-get update && apt-get install -y wget \
                        git \
-                       g++-8 \
+                       g++ \
                        clang-8 \
                        cmake \
                        make \
                        libboost-dev \
                        libcgal-dev \
-                       clang-format-8 \
                        python3 \
-                       python3-pip \
-                       python \
-                       python-pip
+                       python3-pip
 
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 6084F3CF814B57C1CF12EFD515CF4D18AF4F7421 && \
-    add-apt-repository "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-10 main" && \
+    add-apt-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-10 main" && \
     apt-get update && \
     apt-get install -y clang-format-10
 
 
 COPY scripts/setup-deps.sh /opt/
 
-RUN cd /opt && CXX=/usr/bin/g++-8 CC=/usr/bin/gcc-8 ./setup-deps.sh
+RUN cd /opt && CXX=/usr/bin/g++-9 CC=/usr/bin/gcc-9 ./setup-deps.sh
 
 RUN pip3 install numpy && \
     pip3 install matplotlib && \
     pip3 install pandas && \
     pip3 install dataclasses && \
-    pip3 install scipy && \
-    pip install numpy && \
-    pip install scipy
+    pip3 install scipy


### PR DESCRIPTION
We get frequent internal compiler errors using gcc 8 at the moment. With this PR we update the Docker container used for CI to Ubuntu 20.04 and the GCC compiler to gcc-9. After this PR we drop the support for GCC-8.