### PR TITLE
Link jpsreport with OpenMP if available

### DIFF
--- a/jpsreport/CMakeLists.txt
+++ b/jpsreport/CMakeLists.txt
@@ -61,6 +61,7 @@ add_library(report STATIC
 
 target_link_libraries(report PUBLIC
     shared
+    $<$<BOOL:${USE_OPENMP}>:OpenMP::OpenMP_CXX>
     spdlog::spdlog
     fmt::fmt
     tinyxml


### PR DESCRIPTION
By mistake we did not link jpsreport with OpenMP until now. This is fixed by adding generator expression to link openmp depending on availability of OpenMP.

related to #805 