### PR TITLE
documentation, add option to write logging information to log file

### DIFF
--- a/docs/pages/jpscore/jpscore_introduction.md
+++ b/docs/pages/jpscore/jpscore_introduction.md
@@ -48,10 +48,10 @@ Taking the 7th demo as input, we run a simulation as follows:
  ./bin/jpscore  demos/corner_ini.xml
 ```
 
-It is possible to redirect the output and write it to a file like:
+Information on processing steps, warnings and errors of jpscore are written to the console. This output can be redirected to a file by:
 
 ```bash
- ./bin/jpscore  demos/corner_ini.xml &> log_example.txt
+ ./bin/jpscore  demos/corner_ini.xml > log_example.txt
 ```
 
 This program call produces a trajectory file in the folder `results` in the same directory. This can be visualized with `jpsvis`

--- a/docs/pages/jpscore/jpscore_introduction.md
+++ b/docs/pages/jpscore/jpscore_introduction.md
@@ -48,7 +48,13 @@ Taking the 7th demo as input, we run a simulation as follows:
  ./bin/jpscore  demos/corner_ini.xml
 ```
 
-which produces a trajectory file in the folder `results` in the same directory. This can be visualized with `jpsvis`
+It is possible to redirect the output and write it to a file like:
+
+```bash
+ ./bin/jpscore  demos/corner_ini.xml &> log_example.txt
+```
+
+This program call produces a trajectory file in the folder `results` in the same directory. This can be visualized with `jpsvis`
 
 ```bash
  jpsvis demos/scenario_7_floorfield/results/Kobes_traj.xml

--- a/docs/pages/jpsreport/jpsreport_inifile.md
+++ b/docs/pages/jpsreport/jpsreport_inifile.md
@@ -25,7 +25,7 @@ The output of the logger regarding errors, warnings and basic information is wri
 It is possible to redirect the output and write it to a file by:
 
 ```bash
-./jpsreport <path_to_inifile> &> log_example.txt
+./jpsreport <path_to_inifile> > log_example.txt
 ```
 
 {%include note.html content="The definition of a logfile in the inifile is not supported anymore."%}

--- a/docs/pages/jpsreport/jpsreport_introdcution.md
+++ b/docs/pages/jpsreport/jpsreport_introdcution.md
@@ -39,7 +39,7 @@ run `jpsreport` in a terminal as follows:
 ./bin/jpsreport inifile.xml
 ```
 
-{%include note.html content="It is possible to redirect the output and write it to a file. See [inifile - Logfile](jpsreport_inifile#logfile)"%}
+{%include note.html content="It is possible to redirect the console output and write it to a file. See [inifile - Logfile](jpsreport_inifile#logfile)"%}
 
 ## Results
 

--- a/docs/pages/jpsreport/jpsreport_introdcution.md
+++ b/docs/pages/jpsreport/jpsreport_introdcution.md
@@ -39,6 +39,7 @@ run `jpsreport` in a terminal as follows:
 ./bin/jpsreport inifile.xml
 ```
 
+{%include note.html content="It is possible to redirect the output and write it to a file. See [inifile - Logfile](jpsreport_inifile#logfile)"%}
 
 ## Results
 


### PR DESCRIPTION
Added notes on logfiles when calling the program jpscore and jpsreport to write logging information to log file.

resolve #644 