### PR TITLE
Replace std::cout/cerr with Logger calls

### DIFF
--- a/jpsreport/Analysis.cpp
+++ b/jpsreport/Analysis.cpp
@@ -101,14 +101,12 @@ Analysis::~Analysis()
 // file.txt ---> file
 std::string Analysis::GetBasename(const std::string & str)
 {
-    std::cout << "Splitting: " << str << '\n';
     unsigned found = str.find_last_of(".");
     return str.substr(0, found);
 }
 // c:\\windows\\winhelp.exe ---> winhelp.exe
 std::string Analysis::GetFilename(const std::string & str)
 {
-    std::cout << "GetFilename: " << str << '\n';
     unsigned found = str.find_last_of("/\\");
     return str.substr(found + 1);
 }

--- a/jpsreport/geometry/Point.cpp
+++ b/jpsreport/geometry/Point.cpp
@@ -30,11 +30,10 @@
 
 #include "../general/Macros.h"
 
+#include <Logger.h>
 #include <cmath>
 #include <iostream>
 #include <sstream>
-
-
 /************************************************************
   Konstruktoren
  ************************************************************/
@@ -259,8 +258,7 @@ const Point operator/(const Point & p, double f)
     if(f > J_EPS * J_EPS)
         return Point(p._x / f, p._y / f);
     else {
-        std::cout << "Warning: Point::/operator. dividand " << f
-                  << " is to small. Set it to 1 instead" << std::endl;
+        LOG_WARNING("Point::operator/ dividend {} is too small. Using 1 instead.", f);
         return Point(p._x, p._y);
     }
     //return Point(p.GetX() / f, p.GetY() / f);

--- a/jpsreport/main.cpp
+++ b/jpsreport/main.cpp
@@ -66,7 +66,6 @@ int main(int argc, char ** argv)
             analysis.RunAnalysis(File, Path);
             LOG_INFO("**********************************************************************");
             LOG_INFO("End Analysis for the file: {}\n", File.string().c_str());
-            std::cout << "INFO: \tEnd Analysis for the file: " << File.string().c_str() << "\n";
         }
     } else {
         LOG_INFO("Finishing...");
@@ -77,8 +76,6 @@ int main(int argc, char ** argv)
     float duration =
         std::chrono::duration_cast<std::chrono::microseconds>(end - begin).count() / 1000000.0;
     LOG_INFO("Time elapsed:\t {:.2f} [s]\n", duration);
-
-    std::cout << "Time elapsed:\t " << duration << " [s]\n";
 
     delete args;
     return (EXIT_SUCCESS);

--- a/jpsreport/methods/Method_D.cpp
+++ b/jpsreport/methods/Method_D.cpp
@@ -339,18 +339,20 @@ std::tuple<double, double> Method_D::GetVoronoiDensityVelocity(
             meanV += Velocity[temp] * area(v[0]);
             density += area(v[0]) / area(polygon_iterator);
             if((area(v[0]) - area(polygon_iterator)) > J_EPS) {
-                std::cout << "----------------------Now calculating "
-                             "density-velocity!!!-----------------\n ";
-                std::cout << "measure area: \t" << std::setprecision(16) << dsv(measureArea)
-                          << "\n";
-                std::cout << "Original polygon:\t" << std::setprecision(16) << dsv(polygon_iterator)
-                          << "\n";
-                std::cout << "intersected polygon: \t" << std::setprecision(16) << dsv(v[0])
-                          << "\n";
-                std::cout << "this is a wrong result in density calculation\t " << area(v[0])
-                          << '\t' << area(polygon_iterator)
-                          << "  (diff=" << (area(v[0]) - area(polygon_iterator)) << ")"
-                          << "\n";
+                std::stringstream stringStream;
+                stringStream << "----------------------Now calculating "
+                                "density-velocity!!!-----------------\n ";
+                stringStream << "measure area: \t" << std::setprecision(16) << dsv(measureArea)
+                             << "\n";
+                stringStream << "Original polygon:\t" << std::setprecision(16)
+                             << dsv(polygon_iterator) << "\n";
+                stringStream << "intersected polygon: \t" << std::setprecision(16) << dsv(v[0])
+                             << "\n";
+                stringStream << "this is a wrong result in density calculation\t " << area(v[0])
+                             << '\t' << area(polygon_iterator)
+                             << "  (diff=" << (area(v[0]) - area(polygon_iterator)) << ")"
+                             << "\n";
+                LOG_WARNING("{}", stringStream.str());
             }
         }
         temp++;

--- a/jpsreport/methods/Method_J.cpp
+++ b/jpsreport/methods/Method_J.cpp
@@ -195,7 +195,7 @@ bool Method_J::Process(
                 } else {
                     for(int i = 0; i < (int) IdInFrame.size(); i++) {
                         LOG_WARNING(
-                            "frame={}: id={} x={:.5} y={:.5}",
+                            "Polygons could not be obtained for frame={}: id={} x={:.5} y={:.5}",
                             frameNr,
                             IdInFrame[i],
                             XInFrame[i] * CMtoM,

--- a/jpsreport/methods/Method_J.cpp
+++ b/jpsreport/methods/Method_J.cpp
@@ -194,8 +194,12 @@ bool Method_J::Process(
                     }
                 } else {
                     for(int i = 0; i < (int) IdInFrame.size(); i++) {
-                        std::cout << XInFrame[i] * CMtoM << "   " << YInFrame[i] * CMtoM << "   "
-                                  << IdInFrame[i] << "\n";
+                        LOG_WARNING(
+                            "frame={}: id={} x={:.5} y={:.5}",
+                            frameNr,
+                            IdInFrame[i],
+                            XInFrame[i] * CMtoM,
+                            YInFrame[i] * CMtoM);
                     }
                     LOG_WARNING(
                         "Voronoi Diagrams are not obtained!. Frame: {} (minFrame = "
@@ -342,18 +346,20 @@ std::tuple<double, double> Method_J::GetVoronoiDensityVelocity(
             pedsinMeasureArea++;
             density += area(v[0]) / area(polygon_iterator);
             if((area(v[0]) - area(polygon_iterator)) > J_EPS) {
-                std::cout << "----------------------Now calculating "
-                             "density-velocity!!!-----------------\n ";
-                std::cout << "measure area: \t" << std::setprecision(16) << dsv(measureArea)
-                          << "\n";
-                std::cout << "Original polygon:\t" << std::setprecision(16) << dsv(polygon_iterator)
-                          << "\n";
-                std::cout << "intersected polygon: \t" << std::setprecision(16) << dsv(v[0])
-                          << "\n";
-                std::cout << "this is a wrong result in density calculation\t " << area(v[0])
-                          << '\t' << area(polygon_iterator)
-                          << "  (diff=" << (area(v[0]) - area(polygon_iterator)) << ")"
-                          << "\n";
+                std::stringstream stringStream;
+                stringStream << "----------------------Now calculating "
+                                "density-velocity!!!-----------------\n ";
+                stringStream << "measure area: \t" << std::setprecision(16) << dsv(measureArea)
+                             << "\n";
+                stringStream << "Original polygon:\t" << std::setprecision(16)
+                             << dsv(polygon_iterator) << "\n";
+                stringStream << "intersected polygon: \t" << std::setprecision(16) << dsv(v[0])
+                             << "\n";
+                stringStream << "this is a wrong result in density calculation\t " << area(v[0])
+                             << '\t' << area(polygon_iterator)
+                             << "  (diff=" << (area(v[0]) - area(polygon_iterator)) << ")"
+                             << "\n";
+                LOG_WARNING("{}", stringStream.str());
             }
         }
         i++;

--- a/libcore/src/JPSfire/generic/FDSMesh.cpp
+++ b/libcore/src/JPSfire/generic/FDSMesh.cpp
@@ -5,7 +5,6 @@
 #include <Logger.h>
 #include <cmath>
 #include <cnpy.h>
-
 std::vector<std::string> &
 split2(const std::string & s, char delim, std::vector<std::string> & elems)
 {
@@ -29,7 +28,7 @@ FDSMesh::FDSMesh(
     _statMesh(false)
 {
     SetUpMesh(xmin, ymin, xmax, ymax, cellsize);
-    std::cout << "FDSMesh set up!" << std::endl;
+    LOG_INFO("FDSMesh set up!");
 }
 
 FDSMesh::FDSMesh(const std::string & filename) : _statMesh(false)
@@ -159,7 +158,7 @@ void FDSMesh::ReadMatrix(std::string line, std::ifstream & pFile)
                 try {
                     temp = std::stod(elem);
                 } catch(...) {
-                    std::cout << "can not convert " << elem << std::endl;
+                    LOG_WARNING("can not convert {}", elem);
                 }
                 _matrix[m][n].SetValue(temp);
             }

--- a/libcore/src/JPSfire/generic/FDSMeshStorage.cpp
+++ b/libcore/src/JPSfire/generic/FDSMeshStorage.cpp
@@ -53,7 +53,7 @@ FDSMeshStorage::FDSMeshStorage(
     fs::path p(_filepath);
     p         = fs::canonical(p).make_preferred(); //remove ..
     _filepath = p.string(); // TODO: refactor this class. Use path instead of string
-    LOG_INFO("FDSMeshStorage: {}", p.c_str());
+    LOG_INFO("FDSMeshStorage: {}", p.string());
 
     if(fs::exists(p)) {
         LOG_INFO("Creating QuantityList ...");

--- a/libcore/src/JPSfire/generic/FDSMeshStorage.cpp
+++ b/libcore/src/JPSfire/generic/FDSMeshStorage.cpp
@@ -53,23 +53,24 @@ FDSMeshStorage::FDSMeshStorage(
     fs::path p(_filepath);
     p         = fs::canonical(p).make_preferred(); //remove ..
     _filepath = p.string(); // TODO: refactor this class. Use path instead of string
-    std::cout << "\nFDSMeshStorage: <" << p << ">\n";
+    LOG_INFO("FDSMeshStorage: {}", p.c_str());
+
     if(fs::exists(p)) {
-        std::cout << "\nCreating QuantityList..." << std::endl;
+        LOG_INFO("Creating QuantityList ...");
         CreateQuantityList();
-        std::cout << "Success!" << std::endl;
-        std::cout << "\nCreating ElevationList..." << std::endl;
+        LOG_INFO("Success!");
+        LOG_INFO("Creating ElevationList ...");
         CreateElevationList();
-        std::cout << "Success!" << std::endl;
-        std::cout << "\nCreating DoorList..." << std::endl;
+        LOG_INFO("Success!");
+        LOG_INFO("Creating DoorList ...");
         CreateDoorList();
-        std::cout << "Success!" << std::endl;
-        std::cout << "\nCreating TimeList..." << std::endl;
+        LOG_INFO("Success!");
+        LOG_INFO("Creating TimeList ...");
         CreateTimeList();
-        std::cout << "Success!" << std::endl;
-        std::cout << "\nCreating FDSMeshes..." << std::endl;
+        LOG_INFO("Success!");
+        LOG_INFO("Creating FDSMeshes ...");
         CreateFDSMeshes();
-        std::cout << "Success!" << std::endl;
+        LOG_INFO("Success!");
     } else {
         LOG_ERROR("Could not find directory {}", _filepath);
         exit(EXIT_FAILURE);
@@ -95,7 +96,7 @@ bool FDSMeshStorage::CreateQuantityList()
         LOG_ERROR("Could not find suitable quantities in {}", _filepath);
         return false;
     }
-    std::cout << "_quantitylist.size(): " << _quantitylist.size() << "\n";
+    LOG_INFO("_quantitylist.size(): {}", _quantitylist.size());
     return true;
 }
 
@@ -119,7 +120,7 @@ bool FDSMeshStorage::CreateElevationList()
         exit(EXIT_FAILURE);
         return false;
     }
-    std::cout << "_elevationlist.size(): " << _elevationlist.size() << "\n";
+    LOG_INFO("_elevationlist.size(): {}", _elevationlist.size());
     return true;
 }
 
@@ -162,7 +163,7 @@ void FDSMeshStorage::CreateDoorList()
             }
         }
     }
-    std::cout << "_doorlist.size(): " << _doorlist.size() << "\n";
+    LOG_INFO("_doorlist.size(): {}", _doorlist.size());
 }
 void FDSMeshStorage::CreateTimeList()
 {
@@ -194,12 +195,11 @@ void FDSMeshStorage::CreateTimeList()
             exit(EXIT_FAILURE);
         }
     }
-    std::cout << "_timelist.size(): " << _timelist.size() << "\n";
+    LOG_INFO("_timelist.size(): {}", _timelist.size());
 }
 
 void FDSMeshStorage::CreateFDSMeshes()
 {
-    std::cout << "Enter CreateFDSMeshes\n";
     _fMContainer.clear();
     if(_doorlist.size() > 0) {        // Smoke sensor active
         for(auto & h : _quantitylist) //list of quantities
@@ -235,7 +235,7 @@ void FDSMeshStorage::CreateFDSMeshes()
             }
         }
     }
-    std::cout << "_fdcontainer.size(): " << _fMContainer.size() << "\n";
+    LOG_INFO("_fdcontainer.size(): {}", _fMContainer.size());
 }
 
 const FDSMesh & FDSMeshStorage::GetFDSMesh(
@@ -258,7 +258,7 @@ const FDSMesh & FDSMeshStorage::GetFDSMesh(
     Ztime = _filepath / Ztime;
     Ztime = fs::canonical(Ztime).make_preferred();
     if(_fMContainer.count(Ztime.string()) == 0) {
-        std::cout << "\n time ERROR: requested grid not available: " << Ztime.string() << std::endl;
+        LOG_ERROR("requested grid not available: {}", Ztime.string());
         std::exit(EXIT_FAILURE);
     }
     return _fMContainer.at(Ztime.string());
@@ -288,8 +288,7 @@ FDSMeshStorage::GetFDSMesh(const double & pedElev, const Point & doorCentre, con
     door_xy = _filepath / door_xy;
     door_xy = fs::canonical(door_xy).make_preferred();
     if(_fMContainer.count(door_xy.string()) == 0) {
-        std::cout << "\n > ERROR: requested sfgrid not available: " << door_xy.string()
-                  << std::endl;
+        LOG_ERROR("requested sfgrid not available: {}", door_xy.string());
         std::exit(EXIT_FAILURE);
     }
 

--- a/libcore/src/Simulation.cpp
+++ b/libcore/src/Simulation.cpp
@@ -371,9 +371,8 @@ double Simulation::RunBody(double maxSimTime)
     //important since the number of peds is used
     //to break the main simulation loop
     AddNewAgents();
-    _nPeds = _building->GetAllPedestrians().size();
-    std::cout << "\n";
-    std::string description = "Evacutation ";
+    _nPeds                  = _building->GetAllPedestrians().size();
+    std::string description = "Evacuation ";
     int initialnPeds        = _nPeds;
     // main program loop
     while((_nPeds || (!_agentSrcManager.IsCompleted() && _gotSources)) && t < maxSimTime) {

--- a/libcore/src/geometry/Building.cpp
+++ b/libcore/src/geometry/Building.cpp
@@ -863,7 +863,7 @@ void Building::AddPedestrian(Pedestrian * ped)
            std::begin(_allPedestrians), std::end(_allPedestrians), [ped](const Pedestrian * other) {
                return ped->GetID() == other->GetID();
            }) != std::end(_allPedestrians)) {
-        LOG_ERROR("Pedestrian {} already in the romm.", ped->GetID());
+        LOG_WARNING("Pedestrian {} already in the room.", ped->GetID());
     } else {
         _allPedestrians.push_back(ped);
     }

--- a/libcore/src/geometry/Building.cpp
+++ b/libcore/src/geometry/Building.cpp
@@ -859,14 +859,14 @@ const std::vector<Pedestrian *> & Building::GetAllPedestrians() const
 
 void Building::AddPedestrian(Pedestrian * ped)
 {
-    for(unsigned int p = 0; p < _allPedestrians.size(); p++) {
-        Pedestrian * ped1 = _allPedestrians[p];
-        if(ped->GetID() == ped1->GetID()) {
-            std::cout << "Pedestrian " << ped->GetID() << " already in the room." << std::endl;
-            return;
-        }
+    if(std::find_if(
+           std::begin(_allPedestrians), std::end(_allPedestrians), [ped](const Pedestrian * other) {
+               return ped->GetID() == other->GetID();
+           }) != std::end(_allPedestrians)) {
+        LOG_ERROR("Pedestrian {} already in the romm.", ped->GetID());
+    } else {
+        _allPedestrians.push_back(ped);
     }
-    _allPedestrians.push_back(ped);
 }
 
 void Building::GetPedestrians(int room, int subroom, std::vector<Pedestrian *> & peds) const

--- a/libcore/src/geometry/Point.cpp
+++ b/libcore/src/geometry/Point.cpp
@@ -28,8 +28,8 @@
 
 #include "general/Macros.h"
 
+#include <Logger.h>
 #include <sstream>
-
 /************************************************************
   Konstruktoren
  ************************************************************/
@@ -219,8 +219,7 @@ const Point operator/(const Point & p, double f)
     if(f > J_EPS * J_EPS)
         return Point(p._x / f, p._y / f);
     else {
-        std::cout << "Warning: Point::/operator. dividand " << f
-                  << " is to small. Set it to 1 instead" << std::endl;
+        LOG_WARNING("Point::operator/ dividend {} is too small. Using 1 instead.", f);
         return Point(p._x, p._y);
     }
 }
@@ -229,7 +228,6 @@ std::ostream & Point::SaveToXml(std::ostream & ostream) const
 {
     ostream << "<vertex px=" << _x << " py=" << _y << " />" << std::endl;
     return ostream;
-    ;
 }
 
 bool Point::operator<(const Point & rhs) const

--- a/libcore/src/math/Mathematics.cpp
+++ b/libcore/src/math/Mathematics.cpp
@@ -31,7 +31,6 @@
 // ok that is not perfect. For a profound discussion see http://randomascii.wordpress.com/2012/02/25/comparing-floating-point-numbers-2012-edition/
 bool almostEqual(double a, double b, double eps)
 {
-    // std::cout<< "a=" << a << "  b=" << b<< "diff= "<<std::fabs(a-b)<<std::endl;
     return fabs(a - b) < eps; //std::numeric_limits<double>::epsilon();
 }
 

--- a/libcore/src/math/VelocityModel.cpp
+++ b/libcore/src/math/VelocityModel.cpp
@@ -98,7 +98,7 @@ bool VelocityModel::Init(Building * building)
         if(ped->GetExitLine())
             target = ped->GetExitLine()->ShortestPoint(ped->GetPos());
         else {
-            LOG_ERROR("Ped {} has no exit line in INIT", ped->GetID());
+            LOG_WARNING("Ped {} has no exit line in INIT", ped->GetID());
         }
         Point d     = target - ped->GetPos();
         double dist = d.Norm();

--- a/libcore/src/math/VelocityModel.cpp
+++ b/libcore/src/math/VelocityModel.cpp
@@ -76,7 +76,6 @@ bool VelocityModel::Init(Building * building)
         // to wait in waiting areas
         int res = ped->FindRoute();
         if(!ped_is_waiting && res == -1) {
-            std::cout << ped->GetID() << " has no route\n";
             LOG_ERROR(
                 "VelocityModel::Init() cannot initialise route. ped {:d} is deleted in Room "
                 "%d %d.\n",
@@ -99,7 +98,7 @@ bool VelocityModel::Init(Building * building)
         if(ped->GetExitLine())
             target = ped->GetExitLine()->ShortestPoint(ped->GetPos());
         else {
-            std::cout << "Ped " << ped->GetID() << " has no exit line in INIT\n";
+            LOG_ERROR("Ped {} has no exit line in INIT", ped->GetID());
         }
         Point d     = target - ped->GetPos();
         double dist = d.Norm();
@@ -166,9 +165,6 @@ void VelocityModel::ComputeNextTimeStep(
             int size = (int) neighbours.size();
             for(int i = 0; i < size; i++) {
                 Pedestrian * ped1 = neighbours[i];
-                if(ped1 == nullptr) {
-                    std::cout << "Velocity Model debug: " << size << std::endl;
-                }
                 //if they are in the same subroom
                 Point p1 = ped->GetPos();
 
@@ -306,7 +302,7 @@ Point VelocityModel::e0(Pedestrian * ped, Room * room) const
         // target is where the ped wants to be after the next timestep
         target = _direction->GetTarget(room, ped);
     } else { //@todo: we need a model for waiting pedestrians
-        std::cout << ped->GetID() << " VelocityModel::e0 Ped has no navline.\n";
+        LOG_WARNING("VelocityModel::e0 Ped {} has no navline.", ped->GetID());
         // set random destination
         std::mt19937 mt(ped->GetBuilding()->GetConfig()->GetSeed());
         std::uniform_real_distribution<double> dist(0, 1.0);

--- a/libcore/src/pedestrian/AgentsSource.cpp
+++ b/libcore/src/pedestrian/AgentsSource.cpp
@@ -235,11 +235,13 @@ void AgentsSource::GenerateAgents(std::vector<Pedestrian *> & peds, int count, B
             auto ped = GetStartDistribution()->GenerateAgent(building, &pid, emptyPositions);
             peds.push_back(ped);
         } else {
-            std::cout << " \n Source: StartDistribution is null!\n"
-                         " This happens when group_id in <source> does not much any group_id in "
-                         "<agents>\n"
-                         " Check again your inifile. If the problem persists report an issue\n";
-            exit(EXIT_FAILURE);
+            std::string message =
+                "Source: StartDistribution is null!\n"
+                " This happens when group_id in <source> does not much any group_id in "
+                "<agents>\n"
+                " Check again your inifile. If the problem persists report an issue\n";
+
+            throw std::runtime_error(message);
         }
     }
 }

--- a/libcore/src/pedestrian/Pedestrian.cpp
+++ b/libcore/src/pedestrian/Pedestrian.cpp
@@ -170,9 +170,7 @@ void Pedestrian::SetID(int i)
 {
     _id = i;
     if(i <= 0) {
-        std::cerr << ">> Invalid pedestrians ID " << i << std::endl;
-        std::cerr << ">> Pedestrian ID should be > 0. Exit." << std::endl;
-        exit(0);
+        throw std::logic_error("Invalid pedestrians ID: Pedestrian ID should be > 0.");
     }
 }
 

--- a/libcore/src/routing/global_shortest/AccessPoint.cpp
+++ b/libcore/src/routing/global_shortest/AccessPoint.cpp
@@ -226,7 +226,7 @@ void AccessPoint::RemoveConnectingAP(AccessPoint * ap)
     std::vector<AccessPoint *>::iterator it;
     it = find(_connectingAPs.begin(), _connectingAPs.end(), ap);
     if(it == _connectingAPs.end()) {
-        std::cout << " there is no connection to AP: " << ap->GetID() << std::endl;
+        LOG_WARNING("AP {} RemoveConnection: There is no connection to AP {}", _id, ap->GetID());
     } else {
         _connectingAPs.erase(it);
     }
@@ -272,59 +272,57 @@ DoorState AccessPoint::GetState() const
 
 void AccessPoint::Dump()
 {
-    std::cout << std::endl << "--------> Dumping AP <-----------" << std::endl << std::endl;
-    //cout<<" ID: " <<_id<<" centre = [ "<< _center[0] <<", " <<_center[1] <<" ]"<<endl;
-    std::cout << " Friendly ID: " << _friendlyName << " centre = [ " << _center[0] << ", "
-              << _center[1] << " ]" << std::endl;
-    std::cout << " Real ID: " << _id << std::endl;
-    std::cout << " Length:  " << _navLine->LengthSquare() << std::endl;
+    std::stringstream dumpStream;
+    dumpStream << std::endl << "--------> Dumping AP <-----------" << std::endl << std::endl;
+    dumpStream << " Friendly ID: " << _friendlyName << " centre = [ " << _center[0] << ", "
+               << _center[1] << " ]" << std::endl;
+    dumpStream << " Real ID: " << _id << std::endl;
+    dumpStream << " Length:  " << _navLine->LengthSquare() << std::endl;
 
-    std::cout << " Is final exit to outside :" << GetFinalExitToOutside() << std::endl;
-    std::cout << " Distance to final goals" << std::endl;
+    dumpStream << " Is final exit to outside :" << GetFinalExitToOutside() << std::endl;
+    dumpStream << " Distance to final goals" << std::endl;
 
     for(std::map<int, double>::iterator p = _mapDestToDist.begin(); p != _mapDestToDist.end();
         ++p) {
-        std::cout << "\t [ " << p->first << ", " << p->second << " m ]";
+        dumpStream << "\t [ " << p->first << ", " << p->second << " m ]";
     }
-    std::cout << std::endl << std::endl;
+    dumpStream << std::endl << std::endl;
 
-    std::cout << " transit to final goals:" << std::endl;
+    dumpStream << " transit to final goals:" << std::endl;
     for(std::map<int, std::vector<AccessPoint *>>::iterator p = _navigationGraphTo.begin();
         p != _navigationGraphTo.end();
         ++p) {
-        std::cout << std::endl << "\t to UID ---> [ " << p->first << " ]";
+        dumpStream << std::endl << "\t to UID ---> [ " << p->first << " ]";
 
         if(p->second.size() == 0) {
-            std::cout << "\t ---> [ Nothing ]";
+            dumpStream << "\t ---> [ Nothing ]";
         } else {
             for(unsigned int i = 0; i < p->second.size(); i++) {
-                std::cout << "\t distance ---> [ "
-                          << GetDistanceTo(p->second[i]) + p->second[i]->GetDistanceTo(p->first)
-                          << " m via " << p->second[i]->GetID() << " ]";
-                //cout<<"\t distance ---> [ "<<p->second[i]->GetID()<<" @ " << GetDistanceTo(p->first)<<" ]";
+                dumpStream << "\t distance ---> [ "
+                           << GetDistanceTo(p->second[i]) + p->second[i]->GetDistanceTo(p->first)
+                           << " m via " << p->second[i]->GetID() << " ]";
             }
         }
     }
 
-    std::cout << std::endl << std::endl;
+    dumpStream << std::endl << std::endl;
 
-    std::cout << " connected to aps : ";
+    dumpStream << " connected to aps : ";
     for(unsigned int p = 0; p < _connectingAPs.size(); p++) {
-        //cout<<" [ "<<_connectingAPs[p]->GetID()<<" , "<<_connectingAPs[p]->GetDistanceTo(this)<<" m ]";
-        std::cout << std::endl
-                  << "\t [ " << _connectingAPs[p]->GetID() << "_"
-                  << _connectingAPs[p]->GetFriendlyName() << " , "
-                  << _connectingAPs[p]->GetDistanceTo(this) << " m ]";
+        dumpStream << std::endl
+                   << "\t [ " << _connectingAPs[p]->GetID() << "_"
+                   << _connectingAPs[p]->GetFriendlyName() << " , "
+                   << _connectingAPs[p]->GetDistanceTo(this) << " m ]";
     }
 
-    std::cout << std::endl << std::endl;
-    std::cout << " queue [ ";
+    dumpStream << std::endl << std::endl;
+    dumpStream << " queue [ ";
     for(unsigned int p = 0; p < _transitPedestrians.size(); p++) {
-        std::cout << " " << _transitPedestrians[p]->GetID();
+        dumpStream << " " << _transitPedestrians[p]->GetID();
     }
-    std::cout << " ]" << std::endl;
+    dumpStream << " ]" << std::endl;
 
-    //cout<<endl<<" connected to rooms: "<<_room1ID<<" and "<<_room2ID<<endl;
-    std::cout << std::endl;
-    std::cout << std::endl << "------------------------------" << std::endl << std::endl;
+    dumpStream << std::endl;
+    dumpStream << std::endl << "------------------------------" << std::endl << std::endl;
+    LOG_DEBUG("{}", dumpStream.str());
 }

--- a/libcore/src/routing/quickest/QuickestPathRouter.cpp
+++ b/libcore/src/routing/quickest/QuickestPathRouter.cpp
@@ -764,8 +764,8 @@ int QuickestPathRouter::GetBestDefaultRandomExit(Pedestrian * ped)
                 }
             }
         } else {
-            std::cout << "Unknown Strategy: " << _defaultStrategy << std::endl;
-            exit(0);
+            throw std::runtime_error(
+                fmt::format(FMT_STRING("Unknown strategy: {}"), _defaultStrategy));
         }
     }
 

--- a/libcore/src/routing/smoke_router/BrainStorage.cpp
+++ b/libcore/src/routing/smoke_router/BrainStorage.cpp
@@ -205,7 +205,6 @@ void BrainStorage::ParseCogMap(BStorageKeyType ped)
                     std::stod(asso_a),
                     std::stod(asso_b)));
                 assolandmark->SetId(std::stod(asso_id));
-                //std::cout << assolandmark->GetId() << std::endl;
                 assolandmark->SetCaption(asso_caption);
                 //assolandmark->AddConnection(std::stoi(connection));
                 //assolandmark->SetPriority(std::stod(priority));

--- a/libcore/src/routing/smoke_router/navigation_graph/GraphEdge.cpp
+++ b/libcore/src/routing/smoke_router/navigation_graph/GraphEdge.cpp
@@ -100,7 +100,6 @@ double GraphEdge::GetWeight(const Point & position) const
     //double weight = GetFactorWithDistance(GetApproximateDistance(position));
     //double weight = GetApproximateDistance(position) * GetSpecificFactor("SmokeSensor");
     double weight = GetApproximateDistance(position) * GetFactor();
-    //std::cout << " End Weight from Graph Edge: " << weight << " approx distance: " << GetApproximateDistance(position) << std::endl;
     //getc(stdin);
     return weight;
 }
@@ -112,7 +111,6 @@ double GraphEdge::GetFactor() const
     for(FactorContainer::const_iterator it = factors.begin(); it != factors.end(); ++it) {
         factor = factor * it->second.first;
     }
-    //std::cout << "Total Factor from Graph Edge: " << factor << std::endl;
     return factor;
 }
 


### PR DESCRIPTION
Replace std::cout/std::cerr calls with logger in our code:
- replace by Logger call when it makes sense
- remove output otherwise

Note: Some third party libraries may still put there output to std::cout/cerr
Note: Some calls just replaced by stringstreams as the return value of some function could not be used by our Logger without more work, e.g. dsv output in jpsreport.