### PR TITLE
Expressive warning for overlapping pedestrians

### DIFF
--- a/docs/pages/jpscore/jpscore_operativ.md
+++ b/docs/pages/jpscore/jpscore_operativ.md
@@ -6,7 +6,7 @@ sidebar: jupedsim_sidebar
 folder: jpscore
 permalink: jpscore_operativ.html
 summary: Several operational models are implemented in jpscore. An operational model defines how pedestrians interact with each other and with their environment.
-last_updated: Jul 22, 2020
+last_updated: Aug 11, 2020
 ---
 
 ## Introduction
@@ -213,7 +213,11 @@ In summary the relevant section for this model could look like:
  </model>
 ```
 
-{%include note.html content="The recommended values are by no means universal, and may/should be calibrated to fit your scenario."%}
+{%include note.html content="The recommended values are by no means universal, and may/should be calibrated to fit your scenario.
+
+Moreover, some parameter values, for instance $$\nu$$ in the GCFM or $$a$$ in Tordeux2015, have to be chosen wisely.
+Otherwise, it is possible that the agents overlap excessively, since no explicit collision-detection algorithms are implemented in these models. In case of excessive overlapping we recommend to perform  the simulation again with different values.
+"%}
 
 
 

--- a/libcore/src/math/GCFMModel.cpp
+++ b/libcore/src/math/GCFMModel.cpp
@@ -304,9 +304,11 @@ Point GCFMModel::ForceRepPed(Pedestrian * ped1, Pedestrian * ped2) const
         ep12 = distp12.Normalized();
 
     } else {
-        LOG_ERROR("GCFMModel::forcePedPed() ep12 cannot be computed.");
-        return F_rep; // FIXME: should never happen
-        exit(EXIT_FAILURE);
+        LOG_WARNING(
+            "Distance between two pedestrians is small ({}<{}). Force can not be calculated.",
+            distp12.Norm(),
+            J_EPS);
+        return F_rep; // Parameter values are not chosen wisely --> unrealistic overlaping ... ignore.
     }
     // calculate the parameter (whatever dist is)
     tmp  = (vp1 - vp2).ScalarProduct(ep12); // < v_ij , e_ij >


### PR DESCRIPTION
Total overlap of pedestrians in force-based models (gcfm)
can not be fixed in a reliable way.

Here, we give a warning and let the user decide whether the simulation results
can be trusted or not. Normally, "a little" overlapping is acceptable. However,
if the simulation produces too much warnings of this kind, the strength of the
force should be adjusted and the simulation has to be performed with different
parameter values.

Fixes #811 