### PR TITLE
Add missing titlepage template.

### DIFF
--- a/docs/jps_guide/titlepage.tex.in
+++ b/docs/jps_guide/titlepage.tex.in
@@ -10,19 +10,18 @@
 \textsc{\small Forschungszentrum Jülich GmbH} \\ [0.5cm]
 
 \HRule \\ [0.4cm]
-{ \huge \bfseries User's Guide Version @PROJECT_VERSION@} \\ [0.4cm]
+{ \huge \bfseries User's Guide} \\ [0.4cm]
 
 
 \HRule \\ [1.5cm]
 
-{\large Stand: \today}
 \end{center}
 %>>>>>>>>>>>>>
 \vfill
 \vfill
 \begin{minipage}{0.8\textwidth}
     \begin{flushleft} \large
-      \color{gray}{\sffamily jpscore \hspace{0.22cm} \textbullet~{$@GIT_TAG@$} \textbullet~{@GIT_DATE@
+      \color{gray}{\sffamily {@GIT_DATE@}~\textbullet~{@GIT_SHA1@
         }}
     \end{flushleft}
 \end{minipage}

--- a/docs/jps_guide/titlepage.tex.in
+++ b/docs/jps_guide/titlepage.tex.in
@@ -1,0 +1,30 @@
+%% this file is generated automatically. All manual changes will be deleted.
+\newcommand{\HRule}{\rule{\linewidth}{0.5mm}}
+\begin{titlepage}
+\begin{center}
+
+\includegraphics[width=0.75\textwidth]{../images/jupedsim_small.png} \\ [1cm]
+
+\textsc{\LARGE Jülich Pedestrian Simulator} \\ [1.5cm]
+
+\textsc{\small Forschungszentrum Jülich GmbH} \\ [0.5cm]
+
+\HRule \\ [0.4cm]
+{ \huge \bfseries User's Guide Version @PROJECT_VERSION@} \\ [0.4cm]
+
+
+\HRule \\ [1.5cm]
+
+{\large Stand: \today}
+\end{center}
+%>>>>>>>>>>>>>
+\vfill
+\vfill
+\begin{minipage}{0.8\textwidth}
+    \begin{flushleft} \large
+      \color{gray}{\sffamily jpscore \hspace{0.22cm} \textbullet~{$@GIT_TAG@$} \textbullet~{@GIT_DATE@
+        }}
+    \end{flushleft}
+\end{minipage}
+\end{titlepage}
+


### PR DESCRIPTION
To produce the guide:

```
cmake with -DBUILD_DOC=ON
```

This will copy `titlepage.tex.in` in  `titelpage.tex` and change some GIT-variables and the version number.
(these values are issues from cmake)
 
<img width="421" alt="Screenshot 2020-08-10 at 20 35 58" src="https://user-images.githubusercontent.com/5772973/89817862-1b93fb80-db49-11ea-8fa4-8f7297506608.png">


Finally, to produce the pdf file run

```
make guide
```