### PR TITLE
Fix jpsreport warnings

### DIFF
--- a/jpsreport/geometry/Point.cpp
+++ b/jpsreport/geometry/Point.cpp
@@ -41,12 +41,6 @@ Point::Point() : _x(0), _y(0) {}
 
 Point::Point(double x, double y) : _x(x), _y(y) {}
 
-Point::Point(const Point & orig)
-{
-    _x = orig._x;
-    _y = orig._y;
-}
-
 std::string Point::toString() const
 {
     std::stringstream tmp;

--- a/jpsreport/geometry/Point.h
+++ b/jpsreport/geometry/Point.h
@@ -40,7 +40,7 @@ public:
     // constructors
     Point();
     Point(double x, double y);
-    Point(const Point & orig);
+    Point(const Point & orig) = default;
 
 
     /**


### PR DESCRIPTION
Fix warning for implicitly defined operator= when defining a user specific copy constructor.