### PR TITLE
Remove duplicates from vector before deleting pedestrians

### DIFF
--- a/libcore/src/SimulationHelper.cpp
+++ b/libcore/src/SimulationHelper.cpp
@@ -270,6 +270,9 @@ void SimulationHelper::RemoveFaultyPedestrians(
 
 void SimulationHelper::RemovePedestrians(Building & building, std::vector<Pedestrian *> & peds)
 {
+    sort(peds.begin(), peds.end());
+    peds.erase(unique(peds.begin(), peds.end()), peds.end());
+
     std::for_each(std::begin(peds), std::end(peds), [&building](Pedestrian * ped) {
         building.DeletePedestrian(ped);
     });


### PR DESCRIPTION
When checking #832 some pedestrians were deleted multiple times as they reached their goal and were outside. This lead to a an error message, that the pedestrian could not be found (as it was deleted already). 
To avoid this, before deletion the duplicates are deleted from the vector containing the pedestrians to delete.