### PR TITLE
Fix missing resetting of waiting position

### DIFF
--- a/libcore/src/pedestrian/Pedestrian.cpp
+++ b/libcore/src/pedestrian/Pedestrian.cpp
@@ -897,7 +897,9 @@ void Pedestrian::StartWaiting()
 
 void Pedestrian::EndWaiting()
 {
-    _waiting = false;
+    _waiting       = false;
+    _waitingPos._x = std::numeric_limits<double>::max();
+    _waitingPos._y = std::numeric_limits<double>::max();
 }
 
 const Point & Pedestrian::GetWaitingPos() const


### PR DESCRIPTION
The waiting position was not reset after the waiting of pedestrians is over, hence they returned to this position even if they were in a different room.