### PR TITLE
Train files traj

### DIFF
--- a/libcore/src/IO/Trajectories.cpp
+++ b/libcore/src/IO/Trajectories.cpp
@@ -86,6 +86,13 @@ void TrajectoriesTXT::WriteHeader(long nPeds, double fps, Building * building, i
     header.append(fmt::format(
         "#geometry: {:s}\n", building->GetConfig()->GetGeometryFile().filename().string()));
 
+    header.append(fmt::format(
+        "#trainTimeTable: {:s}\n",
+        building->GetConfig()->GetTrainTimeTableFile().filename().string()));
+
+    header.append(fmt::format(
+        "#trainType: {:s}\n", building->GetConfig()->GetTrainTypeFile().filename().string()));
+
     // if used: add source file name
     if(!building->GetConfig()->GetSourceFile().empty()) {
         header.append(fmt::format(

--- a/libcore/src/IO/Trajectories.cpp
+++ b/libcore/src/IO/Trajectories.cpp
@@ -86,13 +86,16 @@ void TrajectoriesTXT::WriteHeader(long nPeds, double fps, Building * building, i
     header.append(fmt::format(
         "#geometry: {:s}\n", building->GetConfig()->GetGeometryFile().filename().string()));
 
-    header.append(fmt::format(
-        "#trainTimeTable: {:s}\n",
-        building->GetConfig()->GetTrainTimeTableFile().filename().string()));
+    // if used: add two necessary files time table and train types
+    if(!building->GetConfig()->GetTrainTimeTableFile().empty() &&
+       !building->GetConfig()->GetTrainTypeFile().empty()) {
+        header.append(fmt::format(
+            "#trainTimeTable: {:s}\n",
+            building->GetConfig()->GetTrainTimeTableFile().filename().string()));
 
-    header.append(fmt::format(
-        "#trainType: {:s}\n", building->GetConfig()->GetTrainTypeFile().filename().string()));
-
+        header.append(fmt::format(
+            "#trainType: {:s}\n", building->GetConfig()->GetTrainTypeFile().filename().string()));
+    }
     // if used: add source file name
     if(!building->GetConfig()->GetSourceFile().empty()) {
         header.append(fmt::format(


### PR DESCRIPTION
- Write out the train files in the trajectory header. 

- Two files are written out, since the train-simulations need two files: 
   - [train types](https://www.jupedsim.org/jpscore_trains.html#train-types) 
   - [train time table](https://www.jupedsim.org/jpscore_trains.html#train-timetable)

- Write out the files only if the trains are used in the simulation.


fixes #838 