### PR TITLE
Set outflow rate for train doors

### DIFF
--- a/docs/pages/jpscore/jpscore_trains.md
+++ b/docs/pages/jpscore/jpscore_trains.md
@@ -26,6 +26,7 @@ A train is defined through the following information:
     - `id` (int): id of the train door
     - `distance` (float): distance to train start
     - `width` (float): width of the door
+    - (optional) `outflow` (float): maximum flow at the specific train door (persons per second).
     
 {%include note.html content="The parameter `length` is not used yet. In future it will be used for sanity checks and for avoiding overlapping trains."%}
 
@@ -35,13 +36,13 @@ A train is defined through the following information:
 <train_type>
     <train type="RE" agents_max="15" length="9">
         <door id="1" distance="1" width="1"/>
-        <door id="3" distance="5" width="1"/>
+        <door id="3" distance="5" width="1" outflow="2."/>
     </train>
 
     <train type="ICE" agents_max="20" length="23">
-        <door id="1" distance="1.5" width="2"/>
-        <door id="2" distance="10" width="3"/>
-        <door id="3" distance="18" width="2"/>
+        <door id="1" distance="1.5" width="2" outflow="1.5"/>
+        <door id="2" distance="10" width="3" outflow="3."/>
+        <door id="3" distance="18" width="2" outflow="1.5"/>
     </train>
 </train_type>
 ```

--- a/libcore/src/geometry/TrainGeometryInterface.h
+++ b/libcore/src/geometry/TrainGeometryInterface.h
@@ -39,6 +39,7 @@ struct Track {
  * Information of train doors, as position, width, and allowed flow.
  */
 struct TrainDoor {
+    int _id;          /** ID of the train door. */
     double _distance; /** Distance to start of train. */
     double _width;    /** Width of train door. */
     double _flow;     /** Max. allowed flow at train door. */
@@ -51,5 +52,5 @@ struct TrainType {
     std::string _type; /** Name of the train type, used for stating which train arrives/deptarts. */
     int _maxAgents;    /** Max. number of agents allowed in the train. */
     double _length;    /** Length of the train. */
-    std::vector<TrainDoor> _doors; /** Doors of the train. */
+    std::map<int, TrainDoor> _doors; /** Doors of the train. */
 };

--- a/libcore/src/geometry/helper/CorrectGeometry.h
+++ b/libcore/src/geometry/helper/CorrectGeometry.h
@@ -32,6 +32,7 @@ class Transition;
 #include "geometry/TrainGeometryInterface.h"
 
 #include <optional>
+#include <unordered_map>
 #include <vector>
 
 namespace geometry::helper
@@ -107,7 +108,7 @@ bool RemoveBigWalls(SubRoom & subroom);
   * @param fromEnd train should be added from end or beginning of track walls
   * @return All found endpoints of the train doors on the track walls
   */
-std::vector<std::pair<Point, Point>> ComputeTrainDoorCoordinates(
+std::map<int, std::pair<Point, Point>> ComputeTrainDoorCoordinates(
     const TrainType & train,
     const Track & track,
     double trainStartOffset,

--- a/libcore/test/catch2/geometry/GeometryHelperTest.cpp
+++ b/libcore/test/catch2/geometry/GeometryHelperTest.cpp
@@ -52,7 +52,8 @@ TEST_CASE(
             {
                 double flow = std::numeric_limits<double>::max();
 
-                std::vector<TrainDoor> trainDoors;
+                std::map<int, TrainDoor> trainDoors;
+                int doorID = 0;
                 for(auto wallItr = std::begin(trackWalls); wallItr != std::end(trackWalls);
                     ++wallItr) {
                     double width    = 0.5 * wallItr->GetLength();
@@ -61,7 +62,8 @@ TEST_CASE(
                             return sum + wall.GetLength();
                         });
                     distance += 0.25 * wallItr->GetLength();
-                    trainDoors.emplace_back(TrainDoor{distance, width, flow});
+                    trainDoors.emplace(doorID, TrainDoor{doorID, distance, width, flow});
+                    doorID++;
                 }
                 TrainType train{"TEST", 20, 10, trainDoors};
 
@@ -114,7 +116,8 @@ TEST_CASE(
             {
                 double flow = std::numeric_limits<double>::max();
 
-                std::vector<TrainDoor> trainDoors;
+                std::map<int, TrainDoor> trainDoors;
+                int doorID = 0;
                 for(auto wallItr = std::begin(trackWalls); wallItr != std::end(trackWalls) - 1;
                     ++wallItr) {
                     double distance = std::accumulate(
@@ -129,7 +132,8 @@ TEST_CASE(
                         [](double & sum, const Wall & wall) { return sum + wall.GetLength(); });
                     distanceDoorEnd += 0.25 * std::next(wallItr)->GetLength();
                     double width = distanceDoorEnd - distance;
-                    trainDoors.emplace_back(TrainDoor{distance, width, flow});
+                    trainDoors.emplace(doorID, TrainDoor{doorID, distance, width, flow});
+                    doorID++;
                 }
                 TrainType train{"TEST", 20, 10, trainDoors};
 
@@ -182,7 +186,8 @@ TEST_CASE(
             {
                 double flow = std::numeric_limits<double>::max();
 
-                std::vector<TrainDoor> trainDoors;
+                std::map<int, TrainDoor> trainDoors;
+                int doorID = 0;
                 for(size_t i = 0; i < trainDoors.size() - 2; i += 2) {
                     auto wallItr = std::begin(trackWalls);
                     std::advance(wallItr, i);
@@ -199,7 +204,8 @@ TEST_CASE(
                         });
                     distanceDoorEnd += 0.5 * wallItr->GetLength();
                     double width = distanceDoorEnd - distance;
-                    trainDoors.emplace_back(TrainDoor{distance, width, flow});
+                    trainDoors.emplace(doorID, TrainDoor{doorID, distance, width, flow});
+                    doorID++;
                 }
 
                 TrainType train{"TEST", 20, 10, trainDoors};
@@ -252,7 +258,8 @@ TEST_CASE(
             {
                 double flow = std::numeric_limits<double>::max();
 
-                std::vector<TrainDoor> trainDoors;
+                std::map<int, TrainDoor> trainDoors;
+                int doorID = 0;
                 for(size_t i = 0; i < trainDoors.size() - 2; i += 2) {
                     auto wallItr = std::begin(trackWalls);
                     std::advance(wallItr, i);
@@ -263,7 +270,8 @@ TEST_CASE(
                     distance += wallItr->GetLength();
 
                     double width = std::next(wallItr)->GetLength();
-                    trainDoors.emplace_back(TrainDoor{distance, width, flow});
+                    trainDoors.emplace(doorID, TrainDoor{doorID, distance, width, flow});
+                    doorID++;
                 }
 
                 TrainType train{"TEST", 20, 10, trainDoors};
@@ -318,20 +326,23 @@ TEST_CASE(
 
                 double flow = std::numeric_limits<double>::max();
 
-                std::vector<TrainDoor> trainDoors;
-
+                std::map<int, TrainDoor> trainDoors;
+                int doorID      = 0;
                 double distance = 0;
                 double width    = 0.25 * trackWall2.GetLength();
-                trainDoors.emplace_back(TrainDoor{distance, width, flow});
+                trainDoors.emplace(doorID, TrainDoor{doorID, distance, width, flow});
+                doorID++;
 
                 distance = distance + width + 0.25 * trackWall2.GetLength();
                 width    = 0.25 * trackWall2.GetLength() + 0.25 * trackWall3.GetLength();
-                trainDoors.emplace_back(TrainDoor{distance, width, flow});
+                trainDoors.emplace(doorID, TrainDoor{doorID, distance, width, flow});
+                doorID++;
 
                 distance = distance + width + 0.5 * trackWall3.GetLength();
                 width    = 0.25 * trackWall3.GetLength() + trackWall4.GetLength() +
                         0.25 * trackWall5.GetLength();
-                trainDoors.emplace_back(TrainDoor{distance, width, flow});
+                trainDoors.emplace(doorID, TrainDoor{doorID, distance, width, flow});
+                doorID++;
 
                 TrainType train{"TEST", 20, 10, trainDoors};
 
@@ -385,7 +396,8 @@ TEST_CASE(
             {
                 double flow = std::numeric_limits<double>::max();
 
-                std::vector<TrainDoor> trainDoors;
+                std::map<int, TrainDoor> trainDoors;
+                int doorID = 0;
                 for(auto wallItr = std::begin(trackWalls); wallItr != std::end(trackWalls);
                     ++wallItr) {
                     double width    = 0.3 * wallItr->GetLength();
@@ -393,10 +405,14 @@ TEST_CASE(
                         std::begin(trackWalls), wallItr, 0., [](double & sum, const Wall & wall) {
                             return sum + wall.GetLength();
                         });
-                    trainDoors.emplace_back(
-                        TrainDoor{distance + 0.1 * wallItr->GetLength(), width, flow});
-                    trainDoors.emplace_back(
-                        TrainDoor{distance + 0.4 * wallItr->GetLength(), width, flow});
+                    trainDoors.emplace(
+                        doorID,
+                        TrainDoor{doorID, distance + 0.1 * wallItr->GetLength(), width, flow});
+                    doorID++;
+                    trainDoors.emplace(
+                        doorID,
+                        TrainDoor{doorID, distance + 0.4 * wallItr->GetLength(), width, flow});
+                    doorID++;
                 }
 
                 TrainType train{"TEST", 20, 10, trainDoors};
@@ -450,7 +466,8 @@ TEST_CASE(
             {
                 double flow = std::numeric_limits<double>::max();
 
-                std::vector<TrainDoor> trainDoors;
+                std::map<int, TrainDoor> trainDoors;
+                int doorID = 0;
                 for(auto wallItr = std::begin(trackWalls); wallItr != std::end(trackWalls);
                     ++wallItr) {
                     double width    = 0.5 * wallItr->GetLength();
@@ -459,7 +476,8 @@ TEST_CASE(
                             return sum + wall.GetLength();
                         });
                     distance += 0.25 * wallItr->GetLength();
-                    trainDoors.emplace_back(TrainDoor{distance, width, flow});
+                    trainDoors.emplace(doorID, TrainDoor{doorID, distance, width, flow});
+                    doorID++;
                 }
 
                 // Create door not on track walls
@@ -471,7 +489,8 @@ TEST_CASE(
                         [](double & sum, const Wall & wall) { return sum + wall.GetLength(); }) +
                     1.;
                 double width = 1.;
-                trainDoors.emplace_back(TrainDoor{distance, width, flow});
+                trainDoors.emplace(doorID, TrainDoor{doorID, distance, width, flow});
+                doorID++;
 
                 TrainType train{"TEST", 20, 10, trainDoors};
 
@@ -527,7 +546,8 @@ TEST_CASE(
             {
                 double flow = std::numeric_limits<double>::max();
 
-                std::vector<TrainDoor> trainDoors;
+                std::map<int, TrainDoor> trainDoors;
+                int doorID = 0;
                 for(auto wallItr = std::rbegin(trackWalls); wallItr != std::rend(trackWalls);
                     ++wallItr) {
                     double width    = 0.5 * wallItr->GetLength();
@@ -536,7 +556,8 @@ TEST_CASE(
                             return sum + wall.GetLength();
                         });
                     distance += 0.25 * wallItr->GetLength();
-                    trainDoors.emplace_back(TrainDoor{distance, width, flow});
+                    trainDoors.emplace(doorID, TrainDoor{doorID, distance, width, flow});
+                    doorID++;
                 }
                 TrainType train{"TEST", 20, 10, trainDoors};
 
@@ -589,7 +610,8 @@ TEST_CASE(
             {
                 double flow = std::numeric_limits<double>::max();
 
-                std::vector<TrainDoor> trainDoors;
+                std::map<int, TrainDoor> trainDoors;
+                int doorID = 0;
                 for(auto wallItr = std::rbegin(trackWalls); wallItr != std::rend(trackWalls) - 1;
                     ++wallItr) {
                     double distance = std::accumulate(
@@ -604,7 +626,8 @@ TEST_CASE(
                         [](double & sum, const Wall & wall) { return sum + wall.GetLength(); });
                     distanceDoorEnd += 0.25 * std::next(wallItr)->GetLength();
                     double width = distanceDoorEnd - distance;
-                    trainDoors.emplace_back(TrainDoor{distance, width, flow});
+                    trainDoors.emplace(doorID, TrainDoor{doorID, distance, width, flow});
+                    doorID++;
                 }
                 TrainType train{"TEST", 20, 10, trainDoors};
 
@@ -657,7 +680,8 @@ TEST_CASE(
             {
                 double flow = std::numeric_limits<double>::max();
 
-                std::vector<TrainDoor> trainDoors;
+                std::map<int, TrainDoor> trainDoors;
+                int doorID = 0;
                 for(size_t i = 0; i < trainDoors.size() - 2; i += 2) {
                     auto wallItr = std::rbegin(trackWalls);
                     std::advance(wallItr, i);
@@ -674,7 +698,8 @@ TEST_CASE(
                         });
                     distanceDoorEnd += 0.5 * wallItr->GetLength();
                     double width = distanceDoorEnd - distance;
-                    trainDoors.emplace_back(TrainDoor{distance, width, flow});
+                    trainDoors.emplace(doorID, TrainDoor{doorID, distance, width, flow});
+                    doorID++;
                 }
 
                 TrainType train{"TEST", 20, 10, trainDoors};
@@ -727,7 +752,8 @@ TEST_CASE(
             {
                 double flow = std::numeric_limits<double>::max();
 
-                std::vector<TrainDoor> trainDoors;
+                std::map<int, TrainDoor> trainDoors;
+                int doorID = 0;
                 for(size_t i = 0; i < trainDoors.size() - 2; i += 2) {
                     auto wallItr = std::rbegin(trackWalls);
                     std::advance(wallItr, i);
@@ -738,7 +764,8 @@ TEST_CASE(
                     distance += wallItr->GetLength();
 
                     double width = std::next(wallItr)->GetLength();
-                    trainDoors.emplace_back(TrainDoor{distance, width, flow});
+                    trainDoors.emplace(doorID, TrainDoor{doorID, distance, width, flow});
+                    doorID++;
                 }
 
                 TrainType train{"TEST", 20, 10, trainDoors};
@@ -793,20 +820,24 @@ TEST_CASE(
 
                 double flow = std::numeric_limits<double>::max();
 
-                std::vector<TrainDoor> trainDoors;
+                std::map<int, TrainDoor> trainDoors;
+                int doorID = 0;
 
                 double distance = 0;
                 double width    = 0.25 * trackWall4.GetLength();
-                trainDoors.emplace_back(TrainDoor{distance, width, flow});
+                trainDoors.emplace(doorID, TrainDoor{doorID, distance, width, flow});
+                doorID++;
 
                 distance = distance + width + 0.25 * trackWall4.GetLength();
                 width    = 0.25 * trackWall4.GetLength() + 0.25 * trackWall3.GetLength();
-                trainDoors.emplace_back(TrainDoor{distance, width, flow});
+                trainDoors.emplace(doorID, TrainDoor{doorID, distance, width, flow});
+                doorID++;
 
                 distance = distance + width + 0.5 * trackWall3.GetLength();
                 width    = 0.25 * trackWall3.GetLength() + trackWall2.GetLength() +
                         0.25 * trackWall1.GetLength();
-                trainDoors.emplace_back(TrainDoor{distance, width, flow});
+                trainDoors.emplace(doorID, TrainDoor{doorID, distance, width, flow});
+                doorID++;
 
                 TrainType train{"TEST", 20, 10, trainDoors};
 
@@ -860,7 +891,8 @@ TEST_CASE(
             {
                 double flow = std::numeric_limits<double>::max();
 
-                std::vector<TrainDoor> trainDoors;
+                std::map<int, TrainDoor> trainDoors;
+                int doorID = 0;
                 for(auto wallItr = std::rbegin(trackWalls); wallItr != std::rend(trackWalls);
                     ++wallItr) {
                     double width    = 0.3 * wallItr->GetLength();
@@ -868,10 +900,14 @@ TEST_CASE(
                         std::rbegin(trackWalls), wallItr, 0., [](double & sum, const Wall & wall) {
                             return sum + wall.GetLength();
                         });
-                    trainDoors.emplace_back(
-                        TrainDoor{distance + 0.1 * wallItr->GetLength(), width, flow});
-                    trainDoors.emplace_back(
-                        TrainDoor{distance + 0.4 * wallItr->GetLength(), width, flow});
+                    trainDoors.emplace(
+                        doorID,
+                        TrainDoor{doorID, distance + 0.1 * wallItr->GetLength(), width, flow});
+                    doorID++;
+                    trainDoors.emplace(
+                        doorID,
+                        TrainDoor{doorID, distance + 0.4 * wallItr->GetLength(), width, flow});
+                    doorID++;
                 }
 
                 TrainType train{"TEST", 20, 10, trainDoors};
@@ -925,7 +961,8 @@ TEST_CASE(
             {
                 double flow = std::numeric_limits<double>::max();
 
-                std::vector<TrainDoor> trainDoors;
+                std::map<int, TrainDoor> trainDoors;
+                int doorID = 0;
                 for(auto wallItr = std::rbegin(trackWalls); wallItr != std::rend(trackWalls);
                     ++wallItr) {
                     double width    = 0.5 * wallItr->GetLength();
@@ -934,7 +971,8 @@ TEST_CASE(
                             return sum + wall.GetLength();
                         });
                     distance += 0.25 * wallItr->GetLength();
-                    trainDoors.emplace_back(TrainDoor{distance, width, flow});
+                    trainDoors.emplace(doorID, TrainDoor{doorID, distance, width, flow});
+                    doorID++;
                 }
 
                 // Create door not on track walls
@@ -946,7 +984,8 @@ TEST_CASE(
                         [](double & sum, const Wall & wall) { return sum + wall.GetLength(); }) +
                     1.;
                 double width = 1.;
-                trainDoors.emplace_back(TrainDoor{distance, width, flow});
+                trainDoors.emplace(doorID, TrainDoor{doorID, distance, width, flow});
+                doorID++;
 
                 TrainType train{"TEST", 20, 10, trainDoors};
 


### PR DESCRIPTION
The outflow rate of train doors can be specified with:
```xml
    <train type="RE" agents_max="15" length="9">
        <door id="1" distance="1" width="1"/>
        <door id="3" distance="5" width="1" outflow="2."/>
    </train>
```
The default flow regulation will be used.

Fixes #801 