### PR TITLE
Fix faulty navigation for waiting areas

### DIFF
--- a/libcore/src/geometry/Goal.cpp
+++ b/libcore/src/geometry/Goal.cpp
@@ -232,9 +232,17 @@ bool Goal::ConvertLineToPoly()
         _crossing.SetPoint1(point1);
         _crossing.SetPoint2(point2);
     } else {
-        _crossing.SetPoint1(_poly[0]);
+        point1 = _poly[0];
         Line tmp_line(_poly[_poly.size() / 2], _poly[(_poly.size() / 2) + 1], 0);
-        _crossing.SetPoint2(tmp_line.GetCentre());
+
+        tmp    = tmp_line.GetCentre();
+        diff   = point1 - tmp;
+
+        point1 = tmp + diff * 0.51;
+        point2 = tmp + diff * 0.49;
+
+        _crossing.SetPoint1(point1);
+        _crossing.SetPoint2(point2);
     }
 
     return true;

--- a/libcore/src/geometry/Goal.cpp
+++ b/libcore/src/geometry/Goal.cpp
@@ -235,8 +235,8 @@ bool Goal::ConvertLineToPoly()
         point1 = _poly[0];
         Line tmp_line(_poly[_poly.size() / 2], _poly[(_poly.size() / 2) + 1], 0);
 
-        tmp    = tmp_line.GetCentre();
-        diff   = point1 - tmp;
+        tmp  = tmp_line.GetCentre();
+        diff = point1 - tmp;
 
         point1 = tmp + diff * 0.51;
         point2 = tmp + diff * 0.49;

--- a/libcore/src/pedestrian/Pedestrian.cpp
+++ b/libcore/src/pedestrian/Pedestrian.cpp
@@ -897,7 +897,9 @@ void Pedestrian::StartWaiting()
 
 void Pedestrian::EndWaiting()
 {
-    _waiting = false;
+    _waiting       = false;
+    _waitingPos._x = std::numeric_limits<double>::max();
+    _waitingPos._y = std::numeric_limits<double>::max();
 }
 
 const Point & Pedestrian::GetWaitingPos() const


### PR DESCRIPTION
When approaching a waiting area, formatting along a diagonal line was observed. After entering this waiting area, the pedestrians did not wait and moved on to another goal (while leaving the actual waiting area).

![Screenshot 2021-06-15 at 16 13 54](https://user-images.githubusercontent.com/55226854/122410825-8b9eb980-cf84-11eb-8e1f-0a7bbeb83830.png)

Two things were changed to solve this: 
- The diagonal line (target) was narrowed down to the center
- Waiting position is reset after waiting ended

Thanks for helping @schroedtert 
