### PR TITLE
Add information about pedestrian ID to door statistics

### DIFF
--- a/libcore/src/Simulation.cpp
+++ b/libcore/src/Simulation.cpp
@@ -293,7 +293,7 @@ void Simulation::PrintStatistics(double simTime)
                 statOutput.Write(
                     "#Flow at exit " + goal->GetCaption() + "( ID " +
                     std::to_string(goal->GetID()) + " )");
-                statOutput.Write("#Time (s)  cummulative number of agents \n");
+                statOutput.Write("#Time (s), cummulative number of agents, pedestrian ID\n");
                 statOutput.Write(goal->GetFlowCurve());
             }
         }

--- a/libcore/src/SimulationHelper.cpp
+++ b/libcore/src/SimulationHelper.cpp
@@ -149,7 +149,7 @@ void SimulationHelper::UpdateFlowAtDoors(
             return;
         }
 
-        closestTransition.value()->IncreaseDoorUsage(1, Pedestrian::GetGlobalTime());
+        closestTransition.value()->IncreaseDoorUsage(1, Pedestrian::GetGlobalTime(), ped->GetID());
         closestTransition.value()->IncreasePartialDoorUsage(1);
     }
 }

--- a/libcore/src/geometry/Crossing.cpp
+++ b/libcore/src/geometry/Crossing.cpp
@@ -36,8 +36,9 @@ Crossing::Crossing()
     _id            = -1;
     _doorUsage     = 0;
     _tempDoorUsage = 0;
-    _maxDoorUsage = (std::numeric_limits<int>::max)(); //avoid name conflicts in windows winmindef.h
-    _outflowRate  = (std::numeric_limits<double>::max)();
+    _maxDoorUsage =
+        (std::numeric_limits<int>::max) (); //avoid name conflicts in windows winmindef.h
+    _outflowRate         = (std::numeric_limits<double>::max) ();
     _lastPassingTime     = 0;
     _lastFlowMeasurement = 0;
     _DT                  = 1;
@@ -185,12 +186,13 @@ int Crossing::CommonSubroomWith(Crossing * other, SubRoom *& subroom)
     return result;
 }
 
-void Crossing::IncreaseDoorUsage(int number, double time)
+void Crossing::IncreaseDoorUsage(int number, double time, int ped_id)
 {
     _doorUsage += number;
     _tempDoorUsage += number;
     _lastPassingTime = time;
-    _flowAtExit += std::to_string(time) + "  " + std::to_string(_doorUsage) + "\n";
+    _flowAtExit += std::to_string(time) + "  " + std::to_string(_doorUsage) + "  " +
+                   std::to_string(ped_id) + "\n";
 }
 
 void Crossing::IncreasePartialDoorUsage(int number)

--- a/libcore/src/geometry/Crossing.cpp
+++ b/libcore/src/geometry/Crossing.cpp
@@ -36,9 +36,8 @@ Crossing::Crossing()
     _id            = -1;
     _doorUsage     = 0;
     _tempDoorUsage = 0;
-    _maxDoorUsage =
-        (std::numeric_limits<int>::max) (); //avoid name conflicts in windows winmindef.h
-    _outflowRate         = (std::numeric_limits<double>::max) ();
+    _maxDoorUsage = (std::numeric_limits<int>::max)(); //avoid name conflicts in windows winmindef.h
+    _outflowRate  = (std::numeric_limits<double>::max)();
     _lastPassingTime     = 0;
     _lastFlowMeasurement = 0;
     _DT                  = 1;

--- a/libcore/src/geometry/Crossing.h
+++ b/libcore/src/geometry/Crossing.h
@@ -195,8 +195,9 @@ public:
      * Increment the number of persons that used that crossing.
      * @param number, how many person have passed the crossing.
      * @param time, at which time persons have passed.
+     * @param ped_id, id of the person that has passed
      */
-    void IncreaseDoorUsage(int number, double time);
+    void IncreaseDoorUsage(int number, double time, int ped_id);
 
     /**
      * Increment the number of persons that used that crossing in time span \a _DT.

--- a/systemtest/door_tests/closed_doors/01_closed_door_max_agents.py
+++ b/systemtest/door_tests/closed_doors/01_closed_door_max_agents.py
@@ -35,7 +35,7 @@ def read_flow():
                                    skip_blank_lines=True,
                                    header=None,
                                    engine='python')
-                flow.columns = ['time', 'peds']
+                flow.columns = ['time', 'peds', 'pedIDs']
                 flow_dict[door_id] = flow.shape[0]
 
     if len(flow_dict.keys()) > 0:

--- a/systemtest/door_tests/test_flow_regulation/01_door_flow_regulation.py
+++ b/systemtest/door_tests/test_flow_regulation/01_door_flow_regulation.py
@@ -33,7 +33,7 @@ def readFlow(outflow):
                                    skip_blank_lines=True,
                                    header=None,
                                    engine='python')
-                flow.columns = ['time', 'peds']
+                flow.columns = ['time', 'peds', 'pedIDs']
                 return flow
 
     logging.error('Could not find flow file to expected flow {}.'.format(outflow))


### PR DESCRIPTION
To analyze travel times between rooms the information of the actual pedestrian (ID) crossing the doors would be helpful. I have added this information to the door statistics output. Please note that pedestrians can cross several times. This needs to be considered when preprocessing the door statistics.