### PR TITLE
Escalators

### DIFF
--- a/demos/04_stairs/stairs_geo.xml
+++ b/demos/04_stairs/stairs_geo.xml
@@ -17,7 +17,7 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 					<vertex px="0.0" py="3.0" />
 				</polygon>
 			</subroom>
-			<subroom id="1" closed="0" class="stair" A_x="-1.2" B_y="0" C_z="0">
+			<subroom id="1" closed="0" class="escalator_up" speed ="1" A_x="-1.2" B_y="0" C_z="0">
 				<polygon caption="wall">
 					<vertex px="0.0" py="1.0" />
 					<vertex px="-5.0" py="1.0" />

--- a/demos/04_stairs/stairs_ini.xml
+++ b/demos/04_stairs/stairs_ini.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 
 <JuPedSim project="Subway-Project" version="0.7"
-xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
   <header>
     <!-- seed used for initialising random generator -->
@@ -19,39 +19,39 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <logfile>log_stairs</logfile>
   </header>
 
-	<!-- traffic information: e.g closed doors or smoked rooms -->
-	<traffic_constraints>
-		<!-- doors states are: close or open -->
-		<doors>
-		</doors>
-	</traffic_constraints>
+  <!-- traffic information: e.g closed doors or smoked rooms -->
+  <traffic_constraints>
+    <!-- doors states are: close or open -->
+    <doors>
+    </doors>
+  </traffic_constraints>
 
 
-	<routing>
-		<goals>
-			<goal id="0" final="true" caption="goal 0">
-				<polygon>
-					<vertex px="0.0" py="-5.0" />
-					<vertex px="2.0" py="-5.0" />
-					<vertex px="2.0" py="-7.0" />
-					<vertex px="0.0" py="-7.0" />
-					<vertex px="0.0" py="-5.0" />
-				</polygon>
-			</goal>
-		</goals>
-	</routing>
+  <routing>
+    <goals>
+      <goal id="0" final="true" caption="goal 0">
+	<polygon>
+	  <vertex px="0.0" py="-5.0" />
+	  <vertex px="2.0" py="-5.0" />
+	  <vertex px="2.0" py="-7.0" />
+	  <vertex px="0.0" py="-7.0" />
+	  <vertex px="0.0" py="-5.0" />
+	</polygon>
+      </goal>
+    </goals>
+  </routing>
 
 
-	<!--persons information and distribution -->
-	<agents operational_model_id="1">
-		<agents_distribution>
-		<group group_id="1" agent_parameter_id="1"  room_id="0" subroom_id="0" number="7" router_id="2" x_min="1.0" x_max="5.0"/>
-		</agents_distribution>
-	</agents>
+  <!--persons information and distribution -->
+  <agents operational_model_id="1">
+    <agents_distribution>
+      <group group_id="1" agent_parameter_id="1"  room_id="0" subroom_id="0" number="7" router_id="2" x_min="1.0" x_max="5.0"/>
+    </agents_distribution>
+  </agents>
 
-	<!-- These parameters may be overwritten -->
-	    <!-- These parameters may be overwritten -->
- <operational_models>
+  <!-- These parameters may be overwritten -->
+  <!-- These parameters may be overwritten -->
+  <operational_models>
     <model operational_model_id="1" description="gcfm">
       <model_parameters>
         <stepsize>0.01</stepsize>
@@ -62,6 +62,7 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
       </model_parameters>
       <agent_parameters agent_parameter_id="1">
         <v0 mu="0.5" sigma="0.0" />
+        <v0_idle_escalator_upstairs mu="0.6" sigma="0.0" c="13"/>
         <bmax mu="0.25" sigma="0.001" />
         <bmin mu="0.20" sigma="0.001" />
         <amin mu="0.18" sigma="0.001" />
@@ -80,16 +81,16 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
   </operational_models>
 
-	<route_choice_models>
-		<router router_id="1" description="global_shortest">
-			<parameters>
-			  <navigation_lines file="stairs_routing.xml" />
-			</parameters>
-		</router>
-                <router router_id="2" description="ff_global_shortest">
-			<parameters>
-			</parameters>
-		</router>
+  <route_choice_models>
+    <router router_id="1" description="global_shortest">
+      <parameters>
+	<navigation_lines file="stairs_routing.xml" />
+      </parameters>
+    </router>
+    <router router_id="2" description="ff_global_shortest">
+      <parameters>
+      </parameters>
+    </router>
 
-	</route_choice_models>
+  </route_choice_models>
 </JuPedSim>

--- a/docs/pages/jpscore/jpscore_desired_speed.md
+++ b/docs/pages/jpscore/jpscore_desired_speed.md
@@ -10,17 +10,16 @@ last_updated: Dec 25, 2019
 ---
 {% include note.html content="This modelling of the desired speed in the transition area of planes and stairs is not validated, since experimental data are missing."%}
 
-
 ## Definitions
+
 Assume the following scenario, with two horizontal planes and a stair, where
 $$z_0<z_1$$ and the inclination of the stair $$\alpha$$.
 
 ![Speed curve in the transition area between levels and stairs]({{ site.baseurl }}/images/desired_speed.png)
 
+The agent has a desired speed on the horizontal plane $$v^0_{\text{horizontal}}$$ and a *different* desired speed on the stair $$v^0_{\text{stair}}$$.
 
-The agent has a desired speed on the horizontal plane $$v^0_{\text{horizonal}}$$ and a *different* desired speed on the stair $$v^0_{\text{stair}}$$.
-
-Given a stair connecting two hirozontal floors, we define the following functions:
+Given a stair connecting two horizontal floors, we define the following functions:
 
 $$
 f(z) = \frac{2}{1 + \exp\Big(-c\cdot \alpha (z-z_1)^2)\Big)} - 1,
@@ -36,22 +35,16 @@ $$
 
 ## Function of the desired speed
 
-Taking the previously introduced quantities into consideration, we can define the desired speed od the agent with respect to its $$z-$$component as
+Taking the previously introduced quantities into consideration, we can define the desired speed of the agent with respect to its $$z-$$component as
 
 $$
-v^0(z) = v^0_{\text{horizonal}}\cdot\Big(1 − f(z)\cdot g(z)\Big)   + v^0_{\text{stair}}\cdot f(z)\cdot g(z),
+v^0(z) = v^0_{\text{horizontal}}\cdot\Big(1 − f(z)\cdot g(z)\Big)   + v^0_{\text{stair}}\cdot f(z)\cdot g(z),
 $$
-
 
 $$c$$ is a constant.
 
-The following figure shows the changes of the desired speed with repsect to the inclination of the stair $$\alpha$$. The steepter the inclination of the stair, the faster is the change of the desired speed.
+The following figure shows the changes of the desired speed with respect to the inclination of the stair $$\alpha$$. The steeper the inclination of the stair, the faster is the change of the desired speed.
 
 ![Transition area of levels and stairs]({{ site.baseurl }}/images/desired_speed2.png)
 
-
 {%include note.html content="The value of *c* should be chosen so that the function grows fast (but smooth) from 0 to 1. However, in force-based models the speed is adapted exponentially from zero to the desired speed.  Therefore, the parameter tau must be taken into consideration."%}
-
-
-
-

--- a/docs/pages/jpscore/jpscore_geometry.md
+++ b/docs/pages/jpscore/jpscore_geometry.md
@@ -94,7 +94,7 @@ Each `subroom` is bounded by at least one `crossing`.
 Here a sample:
 
 ```xml
- <subroom id="1" class="stair" A_x="−1.2" B_y="0" C="0">
+ <subroom id="1" class="escalator" speed="0.7" A_x="−1.2" B_y="0" C="0">
      <polygon caption="wall">
          <vertex px="0.0" py="1.0"/>
          <vertex px="−5.0" py="1.0"/>
@@ -111,10 +111,10 @@ Here a sample:
 - `id` mandatory parameter, also referred by crossings and transitions.
 - `class` optional parameter defining the type of the subroom. At the moment three classes are defined:
   - `floor`
-  - `stairs` take additionally
+  - `stair` take additionally
     `<up px="-5.0" py="2" />` and   `<down px="0.0" py="2"/>`, which are
     used for visualisation purposes.
-  - `escalator_up` and `escalator_down` require `<up px="-5.0" py="2" />` and `<down px="0.0" py="2"/>` to initialise their directions. Used by the router.
+  - `escalator_up` and `escalator_down` require `<up px="-5.0" py="2" />` and `<down px="0.0" py="2"/>` to initialise their directions. Used by the router. Additionally, escalators have a *speed*.
   - `platform` needs additionally walls of type `track-n`, see also [here](jpscore_trains.html).
 - $$A\_x,\; B\_y,\text{and}\; C$$ are optional parameter for the explicit plane equation of the subroom,
    for the construction of a 3D environment and should be used to describe stairs.

--- a/docs/pages/jpscore/jpscore_operativ.md
+++ b/docs/pages/jpscore/jpscore_operativ.md
@@ -10,11 +10,13 @@ last_updated: Aug 11, 2020
 ---
 
 ## Introduction
+
 In the definition of agent's properties it is mandatory to precise the number of the model to be used e.g.:
 
 ```xml
  <agents operational_model_id="n">
 ```
+
 The definition of any model parameter is composed of two different
 sections:
 
@@ -23,6 +25,7 @@ sections:
     or other pedestrian properties like desired speed, reaction time etc.
 
 ## Model parameters (in general)
+
 - `<stepsize>0.001</stepsize>`:
      - The time step for the solver. This should be choosed with care. For force-based model it is recommended to take a value between $$ 10^{-2} $$ and $$10^{-3}$$ s.
        For first-order models, a value of 0.05 s should be OK.
@@ -41,11 +44,14 @@ numerical instabilities, collisions and overlapping among pedestrians.
 
 
 ## Agent's parameter (in general)
-The *agent parameters* are mostly identical for all models. Exceptions will be mentioned explicitly.
+
+The *agent parameters* are mostly identical for all models. Exceptions will be
+mentioned explicitly.
 
 The parameters that can be specified in this section are Gauss distributed (default value are given).
 
 ### Desired speed
+
 - `<v0 mu="1.2" sigma="0.0" />`
     - Desired speed
     - Unit: m/s
@@ -55,11 +61,11 @@ The parameters that can be specified in this section are Gauss distributed (defa
 - `<v0_downstairs mu="0.6" sigma="0.188" />`
     - Desired speed downstairs
     - Unit: m/s
-- `<v0_idle_escalator_upstairs mu="0.6" sigma="0.0" />`
-    - Speed of idle escalators upstairs
+- `<escalator_upstairs mu="0.6" sigma="0.0" />`
+    - Desired speed of agents on escalators upstairs
     - Unit: m/s
-- `<v0_idle_escalator_downstairs mu="0.6" sigma="0.0" />`
-    - Speed of idle escalators downstairs
+- `<escalator_downstairs mu="0.6" sigma="0.0" />`
+    - Speed of agents on escalators downstairs
     - Unit: m/s
 
 {%include important.html content="The desired speed changes *smoothly* from one plane to another. See this [documentation](jpscore_desired_speed.html) for more details."%}
@@ -179,12 +185,8 @@ This defines circles with radius 15 cm.
 
 Other parameters in this section are:
 
-- `<tau mu="0.5" sigma="0.0" />`
-    - Reaction time. This constant is used in the driving force of the force-based forces. Small $$\rightarrow$$ instantaneous acceleration.
-    - Unit: s
 - `<T mu="1" sigma="0.0" />`
     - Specific parameter for model 3 (Tordeux2015). Defines the slope of the speed function.
-
 
 In summary the relevant section for this model could look like:
 
@@ -201,13 +203,12 @@ In summary the relevant section for this model could look like:
         <v0 mu="1.34" sigma="0.0" />
         <v0_upstairs mu="0.668" sigma="0.167" />
         <v0_downstairs mu="0.750" sigma="0.188" />
-        <v0_idle_escalator_upstairs mu="0.5" sigma="0.0" />
-        <v0_idle_escalator_downstairs mu="0.5" sigma="0.0" />
+        <escalator_upstairs mu="0.5" sigma="0.0" />
+        <escalator_downstairs mu="0.5" sigma="0.0" />
         <bmax mu="0.15" sigma="0.0" />
         <bmin mu="0.15" sigma="0.0" />
         <amin mu="0.15" sigma="0.0" />
-        <atau mu="0." sigma="0.0" />
-        <tau mu="0.5" sigma="0.0" />
+        <atau mu="0." sigma="0.0" />        
         <T mu="1" sigma="0.0" />
     </agent_parameters>
  </model>
@@ -218,8 +219,6 @@ In summary the relevant section for this model could look like:
 Moreover, some parameter values, for instance $$\nu$$ in the GCFM or $$a$$ in Tordeux2015, have to be chosen wisely.
 Otherwise, it is possible that the agents overlap excessively, since no explicit collision-detection algorithms are implemented in these models. In case of excessive overlapping we recommend to perform  the simulation again with different values.
 "%}
-
-
 
 [#GCFM]: http://journals.aps.org/pre/abstract/10.1103/PhysRevE.82.046111 "Mohcine Chraibi, Armin Seyfried, and Andreas Schadschneider Phys. Rev. E 82, 046111"
 [#GCFM_PREPRINT]: https://arxiv.org/abs/1008.4297 "Preprint ArXiv"

--- a/libcore/CMakeLists.txt
+++ b/libcore/CMakeLists.txt
@@ -21,7 +21,6 @@ set(source_files
     src/geometry/Crossing.cpp
     src/geometry/Goal.cpp
     src/geometry/GoalManager.cpp
-    src/geometry/helper/CorrectGeometry.cpp
     src/geometry/Hline.cpp
     src/geometry/Line.cpp
     src/geometry/NavLine.cpp
@@ -29,9 +28,12 @@ set(source_files
     src/geometry/Point.cpp
     src/geometry/Room.cpp
     src/geometry/SubRoom.cpp
+    src/geometry/SubroomType.cpp
+    src/geometry/SubroomType.h
     src/geometry/Transition.cpp
     src/geometry/WaitingArea.cpp
     src/geometry/Wall.cpp
+    src/geometry/helper/CorrectGeometry.cpp
     src/IO/EventFileParser.cpp
     src/IO/GeoFileParser.cpp
     src/IO/IniFileParser.cpp

--- a/libcore/src/Enum.h
+++ b/libcore/src/Enum.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <string>
+#include <type_traits>
+
+/// Provide a template specialization for this template method of the Enum you want to create.
+/// For example you have the following enum:
+/// enum class Foo {
+///     A,
+///     B
+/// };
+/// template<> Foo from_string(const std::string& str) {
+///     if(str == "a"){
+///         return Foo::A;
+///     }
+///     if(str == "b"){
+///         return Foo::B;
+///     }
+/// }
+/// This allows to use a uniform sythax when creating enums from string, e.g.
+/// Foo my_enum = from_string<Foo>("a");
+/// This is intentionally constrained to enums.
+template <typename Enum, typename = std::enable_if_t<std::is_enum_v<Enum>>>
+Enum from_string(const std::string &);

--- a/libcore/src/IO/IniFileParser.cpp
+++ b/libcore/src/IO/IniFileParser.cpp
@@ -616,64 +616,47 @@ void IniFileParser::ParseAgentParameters(TiXmlElement * operativModel, TiXmlNode
             auto agentParameters = std::shared_ptr<AgentsParameters>(
                 new AgentsParameters(para_id, _config->GetSeed()));
             _config->AddAgentsParameters(agentParameters, para_id);
-
+            std::string attrib = "v0"; // avoid repetitions and evtl. typos
             //desired speed
-            if(xAgentPara->FirstChild("v0")) {
-                double mu    = xmltof(xAgentPara->FirstChildElement("v0")->Attribute("mu"));
-                double sigma = xmltof(xAgentPara->FirstChildElement("v0")->Attribute("sigma"));
+            if(xAgentPara->FirstChild(attrib)) {
+                double mu    = xmltof(xAgentPara->FirstChildElement(attrib)->Attribute("mu"));
+                double sigma = xmltof(xAgentPara->FirstChildElement(attrib)->Attribute("sigma"));
                 agentParameters->InitV0(mu, sigma);
-                agentParameters->InitV0DownStairs(mu, sigma);
-                agentParameters->InitV0UpStairs(mu, sigma);
                 LOG_INFO("Desired speed mu={} , sigma={}", mu, sigma);
             }
-
-            if(xAgentPara->FirstChild("v0_upstairs")) {
-                double mu = xmltof(xAgentPara->FirstChildElement("v0_upstairs")->Attribute("mu"));
-                double sigma =
-                    xmltof(xAgentPara->FirstChildElement("v0_upstairs")->Attribute("sigma"));
-                agentParameters->InitV0UpStairs(mu, sigma);
-                LOG_INFO("Desired speed upstairs mu={} , sigma={}", mu, sigma);
+            attrib = "v0_upstairs";
+            if(xAgentPara->FirstChild(attrib)) {
+                double mu    = xmltof(xAgentPara->FirstChildElement(attrib)->Attribute("mu"));
+                double sigma = xmltof(xAgentPara->FirstChildElement(attrib)->Attribute("sigma"));
+                double c     = xmltof(xAgentPara->FirstChildElement(attrib)->Attribute("c"), 15);
+                agentParameters->InitV0UpStairs(mu, sigma, c);
+                LOG_INFO("Desired speed upstairs mu={} , sigma={}, c={}", mu, sigma, c);
             }
-
-            if(xAgentPara->FirstChild("v0_downstairs")) {
-                double mu = xmltof(xAgentPara->FirstChildElement("v0_downstairs")->Attribute("mu"));
-                double sigma =
-                    xmltof(xAgentPara->FirstChildElement("v0_downstairs")->Attribute("sigma"));
-                agentParameters->InitV0DownStairs(mu, sigma);
-                LOG_INFO("Desired speed downstairs mu={} , sigma={}", mu, sigma);
+            attrib = "v0_downstairs";
+            if(xAgentPara->FirstChild(attrib)) {
+                double mu    = xmltof(xAgentPara->FirstChildElement(attrib)->Attribute("mu"));
+                double sigma = xmltof(xAgentPara->FirstChildElement(attrib)->Attribute("sigma"));
+                double c     = xmltof(xAgentPara->FirstChildElement(attrib)->Attribute("c"), 15);
+                agentParameters->InitV0DownStairs(mu, sigma, c);
+                LOG_INFO("Desired speed downstairs mu={} , sigma={}, c={}", mu, sigma, c);
             } //------------------------------------------------------------------------
-            if(xAgentPara->FirstChild("escalator_upstairs")) {
-                double mu =
-                    xmltof(xAgentPara->FirstChildElement("escalator_upstairs")->Attribute("mu"));
-                double sigma =
-                    xmltof(xAgentPara->FirstChildElement("escalator_upstairs")->Attribute("sigma"));
-                agentParameters->InitEscalatorUpStairs(mu, sigma);
-                LOG_INFO("speed of escalator upstairs mu={} , sigma={}", mu, sigma);
+            attrib = "escalator_upstairs";
+            if(xAgentPara->FirstChild(attrib)) {
+                double mu    = xmltof(xAgentPara->FirstChildElement(attrib)->Attribute("mu"));
+                double sigma = xmltof(xAgentPara->FirstChildElement(attrib)->Attribute("sigma"));
+                double c     = xmltof(xAgentPara->FirstChildElement(attrib)->Attribute("c"), 15);
+                agentParameters->InitEscalatorUpStairs(mu, sigma, c);
+                LOG_INFO("speed of escalator upstairs mu={} , sigma={}, c={}", mu, sigma, c);
             }
-            if(xAgentPara->FirstChild("escalator_downstairs")) {
-                double mu =
-                    xmltof(xAgentPara->FirstChildElement("escalator_downstairs")->Attribute("mu"));
-                double sigma = xmltof(
-                    xAgentPara->FirstChildElement("escalator_downstairs")->Attribute("sigma"));
-                agentParameters->InitEscalatorDownStairs(mu, sigma);
-                LOG_INFO("speed of escalator downstairs mu={} , sigma={}", mu, sigma);
+            attrib = "escalator_downstairs";
+            if(xAgentPara->FirstChild(attrib)) {
+                double mu    = xmltof(xAgentPara->FirstChildElement(attrib)->Attribute("mu"));
+                double sigma = xmltof(xAgentPara->FirstChildElement(attrib)->Attribute("sigma"));
+                double c     = xmltof(xAgentPara->FirstChildElement(attrib)->Attribute("c"), 15);
+                agentParameters->InitEscalatorDownStairs(mu, sigma, c);
+                LOG_INFO("speed of escalator downstairs mu={} , sigma={}, c={}", mu, sigma, c);
             }
-            if(xAgentPara->FirstChild("v0_idle_escalator_upstairs")) {
-                double mu = xmltof(
-                    xAgentPara->FirstChildElement("v0_idle_escalator_upstairs")->Attribute("mu"));
-                double sigma = xmltof(xAgentPara->FirstChildElement("v0_idle_escalator_upstairs")
-                                          ->Attribute("sigma"));
-                agentParameters->InitV0IdleEscalatorUpStairs(mu, sigma);
-                LOG_INFO("Desired speed idle escalator upstairs mu={} , sigma={}", mu, sigma);
-            }
-            if(xAgentPara->FirstChild("v0_idle_escalator_downstairs")) {
-                double mu = xmltof(
-                    xAgentPara->FirstChildElement("v0_idle_escalator_downstairs")->Attribute("mu"));
-                double sigma = xmltof(xAgentPara->FirstChildElement("v0_idle_escalator_downstairs")
-                                          ->Attribute("sigma"));
-                agentParameters->InitV0IdleEscalatorDownStairs(mu, sigma);
-                LOG_INFO("Desired speed idle escalator downstairs mu={} , sigma={}", mu, sigma);
-            }
+
             //bmax
             if(xAgentPara->FirstChild("bmax")) {
                 double mu    = xmltof(xAgentPara->FirstChildElement("bmax")->Attribute("mu"));

--- a/libcore/src/geometry/Building.cpp
+++ b/libcore/src/geometry/Building.cpp
@@ -898,8 +898,10 @@ bool Building::SaveGeometry(const fs::path & filename) const
             auto && sub          = itr_sub.second;
             const double * plane = sub->GetPlaneEquation();
             geometry << "\t\t<subroom id =\"" << sub->GetSubRoomID() << "\" caption=\"dummy_caption"
-                     << "\" class=\"" << sub->GetType() << "\" A_x=\"" << plane[0] << "\" B_y=\""
-                     << plane[1] << "\" C_z=\"" << plane[2] << "\">" << std::endl;
+                     << "\" class=\""
+                     << "SUBROOM"
+                     << "\" A_x=\"" << plane[0] << "\" B_y=\"" << plane[1] << "\" C_z=\""
+                     << plane[2] << "\">" << std::endl;
 
             for(auto && wall : sub->GetAllWalls()) {
                 const Point & p1 = wall.GetPoint1();
@@ -914,7 +916,7 @@ bool Building::SaveGeometry(const fs::path & filename) const
                          << "\t\t\t</polygon>" << std::endl;
             }
 
-            if(sub->GetType() == "stair") {
+            if(sub->GetType() == SubroomType::STAIR) {
                 const Point & up   = ((Stair *) sub.get())->GetUp();
                 const Point & down = ((Stair *) sub.get())->GetDown();
                 geometry << "\t\t\t<up px=\"" << up._x << "\" py=\"" << up._y << "\"/>"

--- a/libcore/src/geometry/SubRoom.cpp
+++ b/libcore/src/geometry/SubRoom.cpp
@@ -826,6 +826,11 @@ NormalSubRoom::NormalSubRoom(const NormalSubRoom & orig) : SubRoom(orig) {}
 
 NormalSubRoom::~NormalSubRoom() {}
 
+double NormalSubRoom::GetEscalatorSpeed() const
+{
+    return 0.0;
+}
+
 std::string NormalSubRoom::WriteSubRoom() const
 {
     std::string s;
@@ -1122,6 +1127,12 @@ void Stair::SetDown(const Point & p)
     pDown = p;
 }
 
+double Stair::GetEscalatorSpeed() const
+{
+    return 0.0;
+}
+
+
 // Getter-Funktionen
 
 const Point & Stair::GetUp() const
@@ -1326,12 +1337,12 @@ bool Stair::ConvertLineToPoly(const std::vector<Line *> & goals)
 }
 
 
-void SubRoom::SetType(const std::string & type)
+void SubRoom::SetType(SubroomType type)
 {
     _type = type;
 }
 
-const std::string & SubRoom::GetType() const
+SubroomType SubRoom::GetType() const
 {
     return _type;
 }
@@ -1426,7 +1437,10 @@ void Escalator::SetEscalatorDown()
 {
     isEscalator_Up = false;
 }
-
+void Escalator::SetEscalatorSpeed(double speed)
+{
+    _speed = speed;
+}
 // Getter-Funktionen
 bool Escalator::IsEscalatorUp() const
 {
@@ -1435,4 +1449,9 @@ bool Escalator::IsEscalatorUp() const
 bool Escalator::IsEscalatorDown() const
 {
     return !isEscalator_Up;
+}
+
+double Escalator::GetEscalatorSpeed() const
+{
+    return _speed;
 }

--- a/libcore/src/geometry/SubRoom.h
+++ b/libcore/src/geometry/SubRoom.h
@@ -26,6 +26,7 @@
  **/
 #pragma once
 
+#include "SubroomType.h"
 #include "general/Macros.h"
 #include "routing/global_shortest/DTriangulation.h"
 
@@ -63,7 +64,7 @@ private:
     double _planeEquation[3];
     double _cosAngleWithHorizontalPlane;
     double _tanAngleWithHorizontalPlane;
-    std::string _type;
+    SubroomType _type;
     double _minElevation;
     double _maxElevation;
 
@@ -101,6 +102,11 @@ public:
       * Destructor
       */
     virtual ~SubRoom();
+    /**
+      * Get Escalator Speed.
+      * returns 0 for anything other than escalators
+      */
+    virtual double GetEscalatorSpeed() const = 0;
 
     /**
       * Set/Get the subroom id
@@ -181,14 +187,15 @@ public:
       * Possible types are: stairs, room and floor.
       * @return the type of the subroom.
       */
-    const std::string & GetType() const;
+    SubroomType GetType() const;
+
 
     /**
       * Set/Get the type of the subroom.
       * Possible types are: stairs, room and floor.
       * @return the type of the subroom.
       */
-    void SetType(const std::string & type);
+    void SetType(SubroomType type);
 
     /**
       * @return the status
@@ -425,6 +432,7 @@ public:
      * @return \p is inside subroom
      */
     bool IsInSubRoom(const Point & p) const;
+    double GetEscalatorSpeed() const;
 };
 
 class Stair : public NormalSubRoom
@@ -457,13 +465,14 @@ public:
     std::string WriteSubRoom() const;
     std::string WritePolyLine() const;
     virtual bool ConvertLineToPoly(const std::vector<Line *> & goals);
+    double GetEscalatorSpeed() const;
 };
 
 class Escalator : public Stair
 {
 private:
     bool isEscalator_Up;
-
+    double _speed; /// if speed is 0 then this is an IdleEscalator
 public:
     Escalator();
 
@@ -473,8 +482,10 @@ public:
     // Setter-Funktionen
     void SetEscalatorUp();
     void SetEscalatorDown();
+    void SetEscalatorSpeed(double speed);
 
     // Getter-Funktionen
     bool IsEscalatorUp() const;
     bool IsEscalatorDown() const;
+    double GetEscalatorSpeed() const;
 };

--- a/libcore/src/geometry/SubroomType.cpp
+++ b/libcore/src/geometry/SubroomType.cpp
@@ -1,0 +1,39 @@
+#include "SubroomType.h"
+
+template <>
+SubroomType from_string(const std::string & str)
+{
+    if(str == "escalator_up") {
+        return SubroomType::ESCALATOR_UP;
+    }
+
+    if(str == "escalator_down") {
+        return SubroomType::ESCALATOR_DOWN;
+    }
+
+    if(str == "stair") {
+        return SubroomType::STAIR;
+    }
+
+    if(str == "floor") {
+        return SubroomType::FLOOR;
+    }
+
+    if(str == "corridor") {
+        return SubroomType::CORRIDOR;
+    }
+
+    if(str == "entrance") {
+        return SubroomType::ENTRANCE;
+    }
+
+    if(str == "lobby") {
+        return SubroomType::LOBBY;
+    }
+
+    if(str == "dA") {
+        return SubroomType::DA;
+    }
+
+    return SubroomType::UNKNOWN;
+}

--- a/libcore/src/geometry/SubroomType.h
+++ b/libcore/src/geometry/SubroomType.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "Enum.h"
+
+#include <string>
+
+enum class SubroomType {
+    ESCALATOR_UP,
+    ESCALATOR_DOWN,
+    STAIR,
+    FLOOR,
+    CORRIDOR,
+    ENTRANCE,
+    LOBBY,
+    DA, // used in ff router. meaning unknown
+    UNKNOWN
+};
+
+template <>
+SubroomType from_string(const std::string & str);

--- a/libcore/src/pedestrian/AgentsParameters.cpp
+++ b/libcore/src/pedestrian/AgentsParameters.cpp
@@ -52,52 +52,40 @@ void AgentsParameters::InitV0(double mean, double stdv)
     _V0 = std::normal_distribution<double>(mean, stdv);
 }
 
-void AgentsParameters::InitV0UpStairs(double mean, double stdv)
+void AgentsParameters::InitV0UpStairs(double mean, double stdv, double smoothFactor)
 {
     if(stdv == 0) {
         stdv = judge;
     }
-    _V0UpStairs = std::normal_distribution<double>(mean, stdv);
+    _V0UpStairs           = std::normal_distribution<double>(mean, stdv);
+    _smoothFactorUpStairs = smoothFactor;
 }
 
-void AgentsParameters::InitV0DownStairs(double mean, double stdv)
+void AgentsParameters::InitV0DownStairs(double mean, double stdv, double smoothFactor)
 {
     if(stdv == 0) {
         stdv = judge;
     }
-    _V0DownStairs = std::normal_distribution<double>(mean, stdv);
+    _V0DownStairs           = std::normal_distribution<double>(mean, stdv);
+    _smoothFactorDownStairs = smoothFactor;
 }
 
-void AgentsParameters::InitEscalatorUpStairs(double mean, double stdv)
+void AgentsParameters::InitEscalatorUpStairs(double mean, double stdv, double smoothFactor)
 {
     if(stdv == 0) {
         stdv = judge;
     }
-    _EscalatorUpStairs = std::normal_distribution<double>(mean, stdv);
+    _EscalatorUpStairs             = std::normal_distribution<double>(mean, stdv);
+    _smoothFactorEscalatorUpStairs = smoothFactor;
 }
 
-void AgentsParameters::InitEscalatorDownStairs(double mean, double stdv)
+void AgentsParameters::InitEscalatorDownStairs(double mean, double stdv, double smoothFactor)
 {
     if(stdv == 0) {
         stdv = judge;
     }
-    _EscalatorDownStairs = std::normal_distribution<double>(mean, stdv);
-}
-
-void AgentsParameters::InitV0IdleEscalatorUpStairs(double mean, double stdv)
-{
-    if(stdv == 0) {
-        stdv = judge;
-    }
-    _V0IdleEscalatorUpStairs = std::normal_distribution<double>(mean, stdv);
-}
-
-void AgentsParameters::InitV0IdleEscalatorDownStairs(double mean, double stdv)
-{
-    if(stdv == 0) {
-        stdv = judge;
-    }
-    _V0IdleEscalatorDownStairs = std::normal_distribution<double>(mean, stdv);
+    _EscalatorDownStairs             = std::normal_distribution<double>(mean, stdv);
+    _smoothFactorEscalatorDownStairs = smoothFactor;
 }
 
 void AgentsParameters::InitBmax(double mean, double stdv)
@@ -199,26 +187,6 @@ double AgentsParameters::GetEscalatorDownStairs()
         return _EscalatorDownStairs(_generator);
     }
 }
-
-
-double AgentsParameters::GetV0IdleEscalatorUpStairs()
-{
-    if(_V0IdleEscalatorUpStairs.stddev() == judge) {
-        return _V0IdleEscalatorUpStairs.mean();
-    } else {
-        return _V0IdleEscalatorUpStairs(_generator);
-    }
-}
-
-double AgentsParameters::GetV0IdleEscalatorDownStairs()
-{
-    if(_V0IdleEscalatorDownStairs.stddev() == judge) {
-        return _V0IdleEscalatorDownStairs.mean();
-    } else {
-        return _V0IdleEscalatorDownStairs(_generator);
-    }
-}
-
 
 double AgentsParameters::GetBmax()
 {

--- a/libcore/src/pedestrian/AgentsParameters.h
+++ b/libcore/src/pedestrian/AgentsParameters.h
@@ -65,43 +65,33 @@ public:
      * Initialize the desired velocity distribution walking up stairs
      * @param mean, mean value
      * @param stv, standard deviation
+     * @param smoothFactor, smooth factor for transition from v0 to v0Up and vice versa
      */
-    void InitV0UpStairs(double mean, double stv);
+    void InitV0UpStairs(double mean, double stv, double smoothFactor);
 
     /**
      * Initialize the desired velocity distribution walking downstairs
      * @param mean, mean value
      * @param stv, standard deviation
+     * @param smoothFactor, smooth factor for transition from v0 to v0Up and vice versa
      */
-    void InitV0DownStairs(double mean, double stv);
+    void InitV0DownStairs(double mean, double stv, double smoothFactor);
 
     /**
      * Initialize the speed distribution of escalators upstairs
      * @param mean, mean value
      * @param stv, standard deviation
+     * @param smoothFactor, smooth factor for transition from v0 to v0Up or vice versa
      */
-    void InitEscalatorUpStairs(double mean, double stv);
+    void InitEscalatorUpStairs(double mean, double stv, double smoothFactor);
 
     /**
      * Initialize the speed distribution of escalators downstairs
      * @param mean, mean value
      * @param stv, standard deviation
+     * @param smoothFactor, smooth factor for transition from v0 to v0Up or vice versa
      */
-    void InitEscalatorDownStairs(double mean, double stv);
-
-    /**
-     * Initialize the desired speed distribution walking idle escalators upstairs
-     * @param mean, mean value
-     * @param stv, standard deviation
-     */
-    void InitV0IdleEscalatorUpStairs(double mean, double stv);
-
-    /**
-     * Initialize the desired speed distribution walking idle escalators downstairs
-     * @param mean, mean value
-     * @param stv, standard deviation
-     */
-    void InitV0IdleEscalatorDownStairs(double mean, double stv);
+    void InitEscalatorDownStairs(double mean, double stv, double smoothFactor);
 
     /**
      * Initialize the maximal value if the major axis
@@ -176,16 +166,6 @@ public:
     /**
      * @return a random number following the distribution
      */
-    double GetV0IdleEscalatorUpStairs();
-
-    /**
-     * @return a random number following the distribution
-     */
-    double GetV0IdleEscalatorDownStairs();
-
-    /**
-     * @return a random number following the distribution
-     */
     double GetBmax();
 
     /**
@@ -245,6 +225,18 @@ private:
     std::normal_distribution<double> _Amin;
     std::normal_distribution<double> _Tau;
     std::normal_distribution<double> _T;
-
     const double judge = 10000;
+
+public:
+    /**
+     * this is the constant c in f and g in 
+     * \include ../../../docs/pages/jpscore/jpscore_desired_speed.md
+     * function for up- and downstairs is assumed to be symmetrical.     
+     */
+    double _smoothFactorUpStairs;
+    double _smoothFactorDownStairs;
+    double _smoothFactorEscalatorUpStairs;
+    double _smoothFactorEscalatorDownStairs;
+    double _smoothFactorIdleEscalatorUpStairs;
+    double _smoothFactorIdleEscalatorDownStairs;
 };

--- a/libcore/src/pedestrian/Pedestrian.h
+++ b/libcore/src/pedestrian/Pedestrian.h
@@ -33,6 +33,7 @@
 #include "PedDistributor.h"
 #include "general/Macros.h"
 #include "geometry/NavLine.h"
+#include "geometry/SubroomType.h"
 #include "pedestrian/Knowledge.h"
 
 #include <map>
@@ -68,8 +69,14 @@ private:
     double _v0DownStairs;
     double _v0EscalatorUpStairs;
     double _v0EscalatorDownStairs;
-    double _v0IdleEscalatorUpStairs;
-    double _v0IdleEscalatorDownStairs;
+    /// c in f() and g() for v0 transition on stairs up
+    double _smoothFactorUpStairs;
+    /// c in f() and g() for v0 transition on stairs down
+    double _smoothFactorDownStairs;
+    /// c in f() and g() for v0 transition on escalators up
+    double _smoothFactorEscalatorUpStairs;
+    /// c in f() and g() for v0 transition on escalators down
+    double _smoothFactorEscalatorDownStairs;
     int _roomID;
     int _subRoomID;
     int _subRoomUID;
@@ -135,7 +142,26 @@ public:
     explicit Pedestrian(const StartDistribution & agentsParameters, Building & building);
     virtual ~Pedestrian();
 
-    // Setter-Funktionen
+    /** 
+     * Select desired speed based on the type of subroom
+     * where the agent is moving. 
+     * @param type, type of subroom
+     * @param delta, negative when moving downstairs and positiv otherwise. 
+     * Nearly zero for horizontal movement.
+     */
+    double SelectV0(SubroomType type, double delta) const;
+    /** 
+     * Select Smooth factor based on the type of subroom
+     * where the agent is moving. 
+     * @param type, type of subroom
+     * @param delta, negative when moving downstairs and positiv otherwise. 
+     * Nearly zero for horizontal movement.
+     */
+    double SelectSmoothFactor(SubroomType type, double delta) const;
+    void SetSmoothFactorUpStairs(double c);
+    void SetSmoothFactorDownStairs(double c);
+    void SetSmoothFactorEscalatorUpStairs(double c);
+    void SetSmoothFactorEscalatorDownStairs(double c);
     void SetID(int i);
     void SetRoomID(int i);
     void SetSubRoomID(int i);
@@ -165,9 +191,7 @@ public:
         double v0UpStairs,
         double v0DownStairs,
         double escalatorUp,
-        double escalatorDown,
-        double v0IdleEscalatorUp,
-        double v0IdleEscalatorDown);
+        double escalatorDown);
     void SetSmoothTurning(); // activate the smooth turning with a delay of 2 sec
     void SetPhiPed();
     void SetFinalDestination(int UID);
@@ -360,7 +384,6 @@ public:
       * and the  maximal count must be known in advance.
       */
     static int GetAgentsCreated();
-
 
     /**
       * Set the color mode for the pedestrians

--- a/libcore/src/pedestrian/StartDistribution.cpp
+++ b/libcore/src/pedestrian/StartDistribution.cpp
@@ -190,9 +190,12 @@ StartDistribution::GenerateAgent(Building * building, int * pid, std::vector<Poi
         _groupParameters->GetV0UpStairs(),
         _groupParameters->GetV0DownStairs(),
         _groupParameters->GetEscalatorUpStairs(),
-        _groupParameters->GetEscalatorDownStairs(),
-        _groupParameters->GetV0IdleEscalatorUpStairs(),
-        _groupParameters->GetV0IdleEscalatorDownStairs());
+        _groupParameters->GetEscalatorDownStairs());
+    ped->SetSmoothFactorEscalatorUpStairs(_groupParameters->_smoothFactorEscalatorUpStairs);
+    ped->SetSmoothFactorEscalatorDownStairs(_groupParameters->_smoothFactorEscalatorDownStairs);
+    ped->SetSmoothFactorUpStairs(_groupParameters->_smoothFactorUpStairs);
+    ped->SetSmoothFactorDownStairs(_groupParameters->_smoothFactorDownStairs);
+
     // first default Position
     int index = -1;
 
@@ -283,7 +286,7 @@ void StartDistribution::SetPatience(double patience)
     _patience = patience;
 }
 
-AgentsParameters * StartDistribution::GetGroupParameters()
+AgentsParameters * StartDistribution::GetGroupParameters() const
 {
     return _groupParameters;
 }

--- a/libcore/src/pedestrian/StartDistribution.h
+++ b/libcore/src/pedestrian/StartDistribution.h
@@ -110,7 +110,7 @@ public:
     void SetBounds(double xMin, double xMax, double yMin, double yMax);
     void Getbounds(double bounds[4]);
     void Setbounds(double bounds[4]);
-    AgentsParameters * GetGroupParameters();
+    AgentsParameters * GetGroupParameters() const;
     void SetGroupParameters(AgentsParameters * groupParameters);
     void InitPremovementTime(double mean, double stdv);
     double GetPremovementTime() const;

--- a/libcore/src/routing/ff_router/ffRouter.cpp
+++ b/libcore/src/routing/ff_router/ffRouter.cpp
@@ -303,8 +303,8 @@ void FFRouter::CalculateFloorFields()
         penaltyList.clear();
         for(const auto & room : _building->GetAllRooms()) {
             for(const auto & [_, subroom] : room.second->GetAllSubRooms()) {
-                if((subroom->GetType() == "escalator_up") ||
-                   (subroom->GetType() == "escalator_down")) {
+                if((subroom->GetType() == SubroomType::ESCALATOR_UP) ||
+                   (subroom->GetType() == SubroomType::ESCALATOR_DOWN)) {
                     _directionalEscalatorsUID.emplace_back(subroom->GetUID());
                 }
             }

--- a/libcore/src/routing/global_shortest/GlobalRouter.cpp
+++ b/libcore/src/routing/global_shortest/GlobalRouter.cpp
@@ -269,7 +269,7 @@ bool GlobalRouter::Init(Building * building)
             // The penalty factor should discourage pedestrians to evacuation through rooms
             auto && sub    = (std::shared_ptr<SubRoom> &&) it_sub.second;
             double penalty = 1.0;
-            if((sub->GetType() != "floor") && (sub->GetType() != "dA")) {
+            if((sub->GetType() != SubroomType::FLOOR) && (sub->GetType() != SubroomType::DA)) {
                 penalty = _edgeCost;
             }
 

--- a/libcore/src/routing/smoke_router/navigation_graph/GraphEdge.cpp
+++ b/libcore/src/routing/smoke_router/navigation_graph/GraphEdge.cpp
@@ -151,7 +151,7 @@ double GraphEdge::GetRoomToFloorFactor() const
     if(GetDest() == nullptr ||
        GetDest()->GetSubRoom()->GetType() == GetSrc()->GetSubRoom()->GetType())
         return 1.0;
-    if(GetDest()->GetSubRoom()->GetType() == "floor")
+    if(GetDest()->GetSubRoom()->GetType() == SubroomType::FLOOR)
         return 1.0;
     else
         return 5.0;


### PR DESCRIPTION
Initially, with this PR, the hard-coded constant [c](https://www.jupedsim.org/jpscore_desired_speed.html#definitions) in `f` and `g` should be passed from the inifile. It's now called `smoothFactor`.

But then, Escalators are a mess. So, now many things happen, especially:

- subroom's type is no longer a string.
- escalators have a speed. So no `idleEscalators` anymore.
- Color of agents on stairs is now relative to `v0` on the plane.
- the function `GetV0Norm()` was really bloated, therefore it was drastically simplified. 
