### PR TITLE
Remove Agent collection from building

### DIFF
--- a/jpscore/src/main.cpp
+++ b/jpscore/src/main.cpp
@@ -74,7 +74,7 @@ int main(int argc, char ** argv)
         LOG_INFO("Build with {}({})", compiler_id, compiler_version);
 
         auto config         = ParseIniFile(a.IniFilePath());
-        auto building       = std::make_unique<Building>(&config, nullptr);
+        auto building       = std::make_unique<Building>(&config);
         auto * building_ptr = building.get();
         auto agents         = CreateAllPedestrians(&config, building.get(), config.tMax);
         auto geometry       = ParseGeometryXml(config.projectRootDir / config.geometryFile);

--- a/libcore/src/Simulation.cpp
+++ b/libcore/src/Simulation.cpp
@@ -301,10 +301,6 @@ bool Simulation::InitArgs()
 {
     _fps = _config->fps;
 
-
-    // IMPORTANT: do not change the order in the following..
-    _building->SetAgents(&_agents);
-
     //perform customs initialisation, like computing the phi for the gcfm
     //this should be called after the routing engine has been initialised
     // because a direction is needed for this initialisation.

--- a/libcore/src/agent-creation/AgentCreator.cpp
+++ b/libcore/src/agent-creation/AgentCreator.cpp
@@ -17,7 +17,6 @@ CreateAllPedestrians(Configuration * configuration, Building * building, double 
 {
     using AgentVec = std::vector<std::unique_ptr<Pedestrian>>;
     AgentVec agents;
-    building->SetAgents(&agents);
 
     PedDistributor pd(configuration, &agents);
     pd.Distribute(building);
@@ -36,14 +35,11 @@ CreateAllPedestrians(Configuration * configuration, Building * building, double 
     SimulationClock clock(configuration->dT);
 
     do {
-        building->SetAgents(&agents);
         auto agents = mgr.ProcessAllSources(clock.ElapsedTime());
         for(auto && ped : agents) {
             result.emplace(std::make_pair(clock.Iteration(), std::move(ped)));
         }
         clock.Advance();
     } while(!mgr.IsCompleted() && clock.ElapsedTime() < max_time);
-
-    building->SetAgents(nullptr);
     return result;
 }

--- a/libcore/src/geometry/Building.cpp
+++ b/libcore/src/geometry/Building.cpp
@@ -65,10 +65,7 @@
 #include <utility>
 #include <vector>
 
-Building::Building(
-    Configuration * configuration,
-    std::vector<std::unique_ptr<Pedestrian>> * agents) :
-    _configuration(configuration), _allPedestrians(agents)
+Building::Building(Configuration * configuration) : _configuration(configuration)
 {
     {
         std::unique_ptr<GeoFileParser> parser(new GeoFileParser(_configuration));
@@ -744,16 +741,6 @@ void Building::InitGrid()
     }
 
     LOG_INFO("Done with Initializing the grid");
-}
-
-void Building::GetPedestrians(int room, int subroom, std::vector<Pedestrian *> & peds) const
-{
-    for(auto && ped : *_allPedestrians) {
-        auto [ped_roomid, ped_subroomid, _] = GetRoomAndSubRoomIDs(ped->GetPos());
-        if((room == ped_roomid) && (subroom == ped_subroomid)) {
-            peds.push_back(ped.get());
-        }
-    }
 }
 
 Transition * Building::GetTransitionByUID(int uid) const

--- a/libcore/src/geometry/Building.hpp
+++ b/libcore/src/geometry/Building.hpp
@@ -52,7 +52,6 @@ class Building
 {
 private:
     Configuration * _configuration = nullptr;
-    std::vector<std::unique_ptr<Pedestrian>> * _allPedestrians;
     std::map<int, std::shared_ptr<Room>> _rooms;
     std::map<int, Crossing *> _crossings;
     std::map<int, Transition *> _transitions;
@@ -79,14 +78,10 @@ private:
     std::map<int, std::vector<Transition>> _trainDoorsAdded;
 
 public:
-    Building(Configuration * config, std::vector<std::unique_ptr<Pedestrian>> * agents);
+    explicit Building(Configuration * config);
 
     /// destructor
     ~Building();
-
-    void SetAgents(std::vector<std::unique_ptr<Pedestrian>> * agents) { _allPedestrians = agents; }
-
-    void GetPedestrians(int room, int subroom, std::vector<Pedestrian *> & peds) const;
 
     const std::map<int, std::shared_ptr<Room>> & GetAllRooms() const;
 

--- a/libcore/src/voronoi-boost/VoronoiPositionGenerator.cpp
+++ b/libcore/src/voronoi-boost/VoronoiPositionGenerator.cpp
@@ -82,7 +82,6 @@ bool ComputeBestPositionVoronoiBoost(
 
     std::vector<Pedestrian *> existing_peds;
     std::vector<Pedestrian *> peds_without_place;
-    building->GetPedestrians(roomID, subroomID, existing_peds);
     existing_peds.insert(existing_peds.end(), peds_queue.begin(), peds_queue.end());
 
     double radius =


### PR DESCRIPTION
Building still contained a reference to all existing Agents altough this
collection was already unused because it was always empty during
pedestrian creation. This has been the case since we made agent creation
event based.