### PR TITLE
Extend C/Python API

### DIFF
--- a/libjupedsim/include/jupedsim/jupedsim.h
+++ b/libjupedsim/include/jupedsim/jupedsim.h
@@ -426,6 +426,19 @@ JUPEDSIM_API JPS_AgentId JPS_Simulation_AddAgent(
     JPS_Simulation handle,
     JPS_AgentParameters parameters,
     JPS_ErrorMessage* errorMessage);
+
+/**
+ * Removes an agent from the simuation.
+ * @param handle to the simulation to act on
+ * @param agentID to remove
+ * @param[out] errorMessage if not NULL: will be set to a JPS_ErrorMessage in case of an error.
+ * @return bool true if the agent existed and was removed otherwise false
+ */
+JUPEDSIM_API bool JPS_Simulation_RemoveAgent(
+    JPS_Simulation handle,
+    JPS_AgentId agentId,
+    JPS_ErrorMessage* errorMessage);
+
 /*
  * Access the agent data.
  * @param handle to the simulation object

--- a/libjupedsim/src/jupedsim.cpp
+++ b/libjupedsim/src/jupedsim.cpp
@@ -439,6 +439,30 @@ JPS_AgentId JPS_Simulation_AddAgent(
     return result;
 }
 
+JUPEDSIM_API bool JPS_Simulation_RemoveAgent(
+    JPS_Simulation handle,
+    JPS_AgentId agentId,
+    JPS_ErrorMessage* errorMessage)
+{
+    assert(handle);
+    auto simulation = reinterpret_cast<Simulation*>(handle);
+    bool result{false};
+    try {
+        simulation->RemoveAgent(agentId);
+        result = true;
+    } catch(const std::exception& ex) {
+        if(errorMessage) {
+            *errorMessage = reinterpret_cast<JPS_ErrorMessage>(new JPS_ErrorMessage_t{ex.what()});
+        }
+    } catch(...) {
+        if(errorMessage) {
+            *errorMessage = reinterpret_cast<JPS_ErrorMessage>(
+                new JPS_ErrorMessage_t{"Unknown internal error."});
+        }
+    }
+    return result;
+}
+
 JPS_Agent
 JPS_Simulation_ReadAgent(JPS_Simulation handle, JPS_AgentId id, JPS_ErrorMessage* errorMessage)
 {

--- a/librarytest/test_py_jupedsim.py
+++ b/librarytest/test_py_jupedsim.py
@@ -67,6 +67,9 @@ def main():
 
     print("Running simulation")
 
+    agent_id = simulation.add_agent(agent_parameters)
+    simulation.remove_agent(agent_id)
+
     while simulation.agent_count() > 0:
         simulation.iterate()
         if simulation.iteration_count() % 100 == 0:

--- a/python_bindings_jupedsim/bindings_jupedsim.cpp
+++ b/python_bindings_jupedsim/bindings_jupedsim.cpp
@@ -282,6 +282,18 @@ PYBIND11_MODULE(py_jupedsim, m)
                 throw std::runtime_error{msg};
             })
         .def(
+            "remove_agent",
+            [](JPS_Simulation_Wrapper& simulation, JPS_AgentId id) {
+                JPS_ErrorMessage errorMsg{};
+                auto result = JPS_Simulation_RemoveAgent(simulation.handle, id, &errorMsg);
+                if(result) {
+                    return result;
+                }
+                auto msg = std::string(JPS_ErrorMessage_GetMessage(errorMsg));
+                JPS_ErrorMessage_Free(errorMsg);
+                throw std::runtime_error{msg};
+            })
+        .def(
             "read_agent",
             [](JPS_Simulation_Wrapper& simulation, JPS_AgentId id) {
                 JPS_ErrorMessage errorMsg{};

--- a/systemtest/test_py_jupedsim.py
+++ b/systemtest/test_py_jupedsim.py
@@ -50,6 +50,11 @@ def test_can_run_simulation():
         agent_parameters.y = y
         simulation.add_agent(agent_parameters)
 
+    agent_id = simulation.add_agent(agent_parameters)
+    assert simulation.remove_agent(agent_id)
+    with pytest.raises(RuntimeError, match=r"Unknown agent id \d+"):
+        assert simulation.remove_agent(agent_id)
+
     while simulation.agent_count() > 0:
         simulation.iterate()
         assert simulation.iteration_count() < 2000


### PR DESCRIPTION
Agents can now be removed from the simulation by ID.