### PR TITLE
Update vcpkg.json for installing library dependencies on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ During the CMake invocation listed in the next section, add this to your invocat
 
 ```bash
 -DCMAKE_TOOLCHAIN_FILE=<PATH-TO-VCPKG-INSTALLATION>/scripts/buildsystems/vcpkg.cmake
--DVCPKG_MANIFEST_DIR=<PATH-TO-SOURCE-FOLDER>/vcpkg.json
+-DVCPKG_MANIFEST_DIR=<PATH-TO-SOURCE-FOLDER>/vcpkg
 ```
 
 ## Contributing to JuPedSim

--- a/vcpkg/vcpkg.json
+++ b/vcpkg/vcpkg.json
@@ -68,5 +68,15 @@
             "version>=": "0.9.9.8#1"
         }
     ],
-    "builtin-baseline": "35443ee2753f46c52ac342fa6c9c48e9f5eb9105"
+    "builtin-baseline": "a1737683a6f8ec5d8673890581c2a8c55838d411",
+    "overrides": [
+        {
+            "name": "qt5",
+            "version": "5.15.2"
+        },
+        {
+            "name": "fmt",
+            "version": "8.0.1"
+        }
+    ]
 }


### PR DESCRIPTION
some changes has been made on vcpkg, which lead to errors when using it to build library dependencies for Jupedsim on Windows
- pcre2 is now fetch from github instead of from ftp https://github.com/microsoft/vcpkg/commit/afc69921807ea827887c39634ef0ba2af6dc301b
- libharu is updated to 2.4.0-rc1, https://github.com/microsoft/vcpkg/pull/25569