### PR TITLE
Update python api

### DIFF
--- a/librarytest/test_py_jupedsim.py
+++ b/librarytest/test_py_jupedsim.py
@@ -33,14 +33,16 @@ def main():
     jps.set_error_callback(log_error)
 
     geo_builder = jps.GeometryBuilder()
-    geo_builder.add_accessible_area([0, 0, 10, 0, 10, 10, 0, 10])
-    geo_builder.add_accessible_area([10, 4, 20, 4, 20, 6, 10, 6])
+    geo_builder.add_accessible_area([(0, 0), (10, 0), (10, 10), (0, 10)])
+    geo_builder.add_accessible_area([(10, 4), (20, 4), (20, 6), (10, 6)])
     geometry = geo_builder.build()
 
     destination = 1
     areas_builder = jps.AreasBuilder()
     areas_builder.add_area(
-        destination, [18, 4, 20, 4, 20, 6, 18, 6], ["exit", "other-label"]
+        destination,
+        [(18, 4), (20, 4), (20, 6), (18, 6)],
+        ["exit", "other-label"],
     )
     areas = areas_builder.build()
 

--- a/python_bindings_jupedsim/bindings_jupedsim.cpp
+++ b/python_bindings_jupedsim/bindings_jupedsim.cpp
@@ -110,15 +110,29 @@ PYBIND11_MODULE(py_jupedsim, m)
         }))
         .def(
             "add_accessible_area",
-            [](const JPS_GeometryBuilder_Wrapper& w, std::vector<double> points) {
-                JPS_GeometryBuilder_AddAccessibleArea(w.handle, points.data(), points.size() / 2);
+            [](const JPS_GeometryBuilder_Wrapper& w,
+               std::vector<std::tuple<double, double>> points) {
+                std::vector<double> values{};
+                values.reserve(points.size() * 2);
+                for(const auto [x, y] : points) {
+                    values.emplace_back(x);
+                    values.emplace_back(y);
+                }
+                JPS_GeometryBuilder_AddAccessibleArea(w.handle, values.data(), values.size() / 2);
             },
             "Add area where agents can move")
         .def(
             "exclude_from_accssible_area",
-            [](const JPS_GeometryBuilder_Wrapper& w, std::vector<double> points) {
+            [](const JPS_GeometryBuilder_Wrapper& w,
+               std::vector<std::tuple<double, double>> points) {
+                std::vector<double> values{};
+                values.reserve(points.size() * 2);
+                for(const auto [x, y] : points) {
+                    values.emplace_back(x);
+                    values.emplace_back(y);
+                }
                 JPS_GeometryBuilder_ExcludeFromAccessibleArea(
-                    w.handle, points.data(), points.size() / 2);
+                    w.handle, values.data(), values.size() / 2);
             },
             "Add areas where agents can not move (obstacles)")
         .def(
@@ -243,8 +257,14 @@ PYBIND11_MODULE(py_jupedsim, m)
             "add_area",
             [](const JPS_AreasBuilder_Wrapper& w,
                uint64_t id,
-               std::vector<double> points,
+               std::vector<std::tuple<double, double>> points,
                std::vector<std::string> tags) {
+                std::vector<double> values{};
+                values.reserve(points.size() * 2);
+                for(const auto [x, y] : points) {
+                    values.emplace_back(x);
+                    values.emplace_back(y);
+                }
                 std::vector<const char*> tags_as_c_str;
                 tags_as_c_str.reserve(tags.size());
                 std::transform(
@@ -256,8 +276,8 @@ PYBIND11_MODULE(py_jupedsim, m)
                 JPS_AreasBuilder_AddArea(
                     w.handle,
                     id,
-                    points.data(),
-                    points.size() / 2,
+                    values.data(),
+                    values.size() / 2,
                     tags_as_c_str.data(),
                     tags.size());
             },

--- a/systemtest/test_py_jupedsim.py
+++ b/systemtest/test_py_jupedsim.py
@@ -14,15 +14,15 @@ def test_can_run_simulation():
     jps.set_error_callback(log_msg_handler)
 
     geo_builder = jps.GeometryBuilder()
-    geo_builder.add_accessible_area([0, 0, 10, 0, 10, 10, 0, 10])
-    geo_builder.add_accessible_area([10, 4, 20, 4, 20, 6, 10, 6])
+    geo_builder.add_accessible_area([(0, 0), (10, 0), (10, 10), (0, 10)])
+    geo_builder.add_accessible_area([(10, 4), (20, 4), (20, 6), (10, 6)])
     geometry = geo_builder.build()
 
     destination = 1
     areas_builder = jps.AreasBuilder()
     areas_builder.add_area(
         id=destination,
-        polygon=[18, 4, 20, 4, 20, 6, 18, 6],
+        polygon=[(18, 4), (20, 4), (20, 6), (18, 6)],
         labels=["exit", "other-label"],
     )
     areas = areas_builder.build()


### PR DESCRIPTION
Polygons now defined by iterables of tuples. This allows to use for example shapely.Polygon e.g.

```
Polygon p(...)
geo_builder.add_accessible_area(p.exterior.coords)
```