### PR TITLE
Generate env file on linux/macos 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,6 +202,9 @@ target_compile_definitions(git-info INTERFACE
     GIT_BRANCH="${GIT_BRANCH}"
 )
 configure_file(cmake_templates/BuildInfo.cpp.in ${CMAKE_BINARY_DIR}/generated/BuildInfo.cpp @ONLY)
+if(UNIX)
+    configure_file(cmake_templates/unix_env.in ${CMAKE_BINARY_DIR}/environment @ONLY)
+endif()
 ################################################################################
 # Documentation
 ################################################################################

--- a/cmake_templates/unix_env.in
+++ b/cmake_templates/unix_env.in
@@ -1,0 +1,2 @@
+export PYTHONPATH="@CMAKE_SOURCE_DIR@/python_modules/jupedsim:@CMAKE_SOURCE_DIR@/python_modules/visdbg:@CMAKE_LIBRARY_OUTPUT_DIRECTORY@"
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pytest~=7.2.1
 scipy~=1.10.1
 sympy~=1.11.1
 matplotlib~=3.7.0
+shapely~=2.0.1


### PR DESCRIPTION
On linux / macos a file called `environemnt` is generated during cmake
configure that updates PYTHONPATH with locations to our internal python
modules as well as the location of py_jupedsim.