### PR TITLE
[SUMO] Changed the way obstacles are excluded

### DIFF
--- a/libsimulator/src/GeometryBuilder.cpp
+++ b/libsimulator/src/GeometryBuilder.cpp
@@ -99,7 +99,7 @@ Geometry GeometryBuilder::Build()
         std::back_inserter(accessibleList));
 
     if(accessibleList.size() != 1) {
-        throw SimulationError("accessisble area not connected");
+        throw SimulationError("accessibleArea not connected");
     }
 
     auto accessibleArea = *accessibleList.begin();
@@ -111,15 +111,25 @@ Geometry GeometryBuilder::Build()
         std::end(_exclusions),
         std::back_inserter(exclusionAreaInput),
         [](const auto& p) { return intoCGALPolygon(p, Ordering::CCW); });
+    PolyWithHolesList obstacleList{};
+    CGAL::join(
+        std::begin(exclusionAreaInput),
+        std::end(exclusionAreaInput),
+        std::back_inserter(obstacleList));
+    for(const auto& ob : obstacleList) {
+            PolyWithHolesList res{};
+            CGAL::difference(accessibleArea, ob, std::back_inserter(res));
+            accessibleArea = *res.begin();
+    }
 
-    for(const auto& ex : exclusionAreaInput) {
+    /*for(const auto& ex : exclusionAreaInput) {
         PolyWithHolesList res{};
         CGAL::difference(accessibleArea, ex, std::back_inserter(res));
         if(res.size() != 1) {
             throw SimulationError("Exclusion splits accessibleArea");
         }
         accessibleArea = *res.begin();
-    }
+    }*/
 
     auto Convert = [](const auto& begin, const auto& end) {
         std::vector<Point> result{};

--- a/libsimulator/src/GeometryBuilder.cpp
+++ b/libsimulator/src/GeometryBuilder.cpp
@@ -122,15 +122,6 @@ Geometry GeometryBuilder::Build()
             accessibleArea = *res.begin();
     }
 
-    /*for(const auto& ex : exclusionAreaInput) {
-        PolyWithHolesList res{};
-        CGAL::difference(accessibleArea, ex, std::back_inserter(res));
-        if(res.size() != 1) {
-            throw SimulationError("Exclusion splits accessibleArea");
-        }
-        accessibleArea = *res.begin();
-    }*/
-
     auto Convert = [](const auto& begin, const auto& end) {
         std::vector<Point> result{};
         result.reserve(end - begin);


### PR DESCRIPTION
With respect to the DXF file I was provided (see [this ticket](https://jugit.fz-juelich.de/pedestrian-dynamics-modeling/sumo-jupedsim/-/issues/30)):

- Some polygons were closed, some not, I closed all of them.
- A second problem appeared with obstacles that have a common boundary. I obtained the "splits accessibleArea error" and after looking at the code, thought that the problem came from the way the exclusion is done, namely one obstacle at a time. I now take a union of the obstacles and it solves the problem.