### PR TITLE
Hot fix for memory leak in CollisionGeometry::IntersectsAny

### DIFF
--- a/libsimulator/src/CollisionGeometry.cpp
+++ b/libsimulator/src/CollisionGeometry.cpp
@@ -124,17 +124,19 @@ CollisionGeometry::LineSegmentsInDistanceTo(double distance, Point p) const
 bool CollisionGeometry::IntersectsAny(LineSegment linesegment) const
 {
     const auto cellsToQuery = cellsFromLineSegment(linesegment);
-    std::vector<LineSegment> segments{};
     for(const auto& cell : cellsToQuery) {
         const auto iter = _grid.find(cell);
         if(iter == std::end(_grid)) {
             continue;
         }
-        segments.insert(std::end(segments), std::begin(iter->second), std::end(iter->second));
+        if(std::find_if(
+               iter->second.cbegin(), iter->second.cend(), [&linesegment](const auto candidate) {
+                   return intersects(linesegment, candidate);
+               }) != iter->second.end()) {
+            return true;
+        }
     }
-    return std::find_if(segments.cbegin(), segments.cend(), [&linesegment](const auto candidate) {
-               return intersects(linesegment, candidate);
-           }) != segments.end();
+    return false;
 }
 
 bool CollisionGeometry::InsideGeometry(Point p) const

--- a/libsimulator/src/CollisionGeometry.cpp
+++ b/libsimulator/src/CollisionGeometry.cpp
@@ -124,13 +124,13 @@ CollisionGeometry::LineSegmentsInDistanceTo(double distance, Point p) const
 bool CollisionGeometry::IntersectsAny(LineSegment linesegment) const
 {
     const auto cellsToQuery = cellsFromLineSegment(linesegment);
-    std::set<LineSegment> segments{};
+    std::vector<LineSegment> segments{};
     for(const auto& cell : cellsToQuery) {
         const auto iter = _grid.find(cell);
         if(iter == std::end(_grid)) {
             continue;
         }
-        segments.insert(std::begin(iter->second), std::end(iter->second));
+        segments.insert(std::end(segments), std::begin(iter->second), std::end(iter->second));
     }
     return std::find_if(segments.cbegin(), segments.cend(), [&linesegment](const auto candidate) {
                return intersects(linesegment, candidate);


### PR DESCRIPTION
Replace std::set with std::vector as there seem to be a bug in the std:set insert method which leads to a memory leak.