### PR TITLE
Improve performance of linesegment point distance calculation

### DIFF
--- a/libsimulator/CMakeLists.txt
+++ b/libsimulator/CMakeLists.txt
@@ -120,7 +120,9 @@ endif()
 if (BUILD_BENCHMARKS)
     add_executable(libsimulator-benchmarks
         benchmark/BenchmarkMain.cpp
-        benchmark/benchmarkCollisionGeometry.hpp benchmark/benchmarkLineSegment.hpp benchmark/benchmarkPoint.hpp)
+        benchmark/benchmarkLineSegment.hpp
+    )
+
     target_link_libraries(libsimulator-benchmarks PRIVATE
         benchmark::benchmark
         simulator

--- a/libsimulator/CMakeLists.txt
+++ b/libsimulator/CMakeLists.txt
@@ -120,7 +120,7 @@ endif()
 if (BUILD_BENCHMARKS)
     add_executable(libsimulator-benchmarks
         benchmark/BenchmarkMain.cpp
-    )
+        benchmark/benchmarkCollisionGeometry.hpp benchmark/benchmarkLineSegment.hpp benchmark/benchmarkPoint.hpp)
     target_link_libraries(libsimulator-benchmarks PRIVATE
         benchmark::benchmark
         simulator

--- a/libsimulator/benchmark/BenchmarkMain.cpp
+++ b/libsimulator/benchmark/BenchmarkMain.cpp
@@ -2,4 +2,6 @@
 /// SPDX-License-Identifier: LGPL-3.0-or-later
 #include <benchmark/benchmark.h>
 
+#include "benchmarkLineSegment.hpp"
+
 BENCHMARK_MAIN();

--- a/libsimulator/benchmark/benchmarkLineSegment.hpp
+++ b/libsimulator/benchmark/benchmarkLineSegment.hpp
@@ -8,7 +8,7 @@
 #include "LineSegment.hpp"
 
 template <class... Args>
-void bmDistToCgalOnLine(benchmark::State& state, Args&&... args)
+void bmDistToOnLine(benchmark::State& state, Args&&... args)
 {
     auto args_tuple = std::make_tuple(std::move(args)...);
     auto lineSegment = std::get<0>(args_tuple);
@@ -22,7 +22,7 @@ void bmDistToCgalOnLine(benchmark::State& state, Args&&... args)
 }
 
 template <class... Args>
-void bmDistToCgal(benchmark::State& state, Args&&... args)
+void bmDistTo(benchmark::State& state, Args&&... args)
 {
     auto args_tuple = std::make_tuple(std::move(args)...);
     auto lineSegment = std::get<LineSegment>(args_tuple);
@@ -37,62 +37,17 @@ void bmDistToCgal(benchmark::State& state, Args&&... args)
 
     for(auto _ : state) {
         lineSegment.DistTo(point);
-    }
-}
-
-template <class... Args>
-void bmDistToOldOnLine(benchmark::State& state, Args&&... args)
-{
-    auto args_tuple = std::make_tuple(std::move(args)...);
-    auto lineSegment = std::get<0>(args_tuple);
-
-    auto factor = state.range(0) / 100.;
-    Point point(lineSegment.p1 + (lineSegment.p2 - lineSegment.p1) * factor);
-
-    for(auto _ : state) {
-        lineSegment.DistToOld(point);
-    }
-}
-
-template <class... Args>
-void bmDistToOld(benchmark::State& state, Args&&... args)
-{
-    auto args_tuple = std::make_tuple(std::move(args)...);
-    auto lineSegment = std::get<LineSegment>(args_tuple);
-
-    auto edgePoint = lineSegment.p2 + lineSegment.NormalVec() * 3.;
-
-    auto direction = edgePoint - lineSegment.p1;
-
-    auto factor = state.range(0) / 100.;
-
-    Point point(lineSegment.p1 + direction * factor);
-
-    for(auto _ : state) {
-        lineSegment.DistToOld(point);
     }
 }
 
 // CGAL implementation
 BENCHMARK_CAPTURE(
-    bmDistToCgalOnLine,
+    bmDistToOnLine,
     dist_to_point_on_line,
     LineSegment(Point(-1.3, 2.1), Point(3.6, -4.4)))
     ->DenseRange(0, 100, 20);
 
-BENCHMARK_CAPTURE(bmDistToCgal, dist_to_point, LineSegment(Point(-1.3, 2.1), Point(3.6, -4.4)))
-    ->DenseRange(-50, 150, 10)
-    ->Arg(-100000)
-    ->Arg(100000);
-
-// old implementation
-BENCHMARK_CAPTURE(
-    bmDistToOldOnLine,
-    dist_to_point_on_line,
-    LineSegment(Point(-1.3, 2.1), Point(3.6, -4.4)))
-    ->DenseRange(0, 100, 20);
-
-BENCHMARK_CAPTURE(bmDistToOld, dist_to_point, LineSegment(Point(-1.3, 2.1), Point(3.6, -4.4)))
+BENCHMARK_CAPTURE(bmDistTo, dist_to_point, LineSegment(Point(-1.3, 2.1), Point(3.6, -4.4)))
     ->DenseRange(-50, 150, 10)
     ->Arg(-100000)
     ->Arg(100000);

--- a/libsimulator/benchmark/benchmarkLineSegment.hpp
+++ b/libsimulator/benchmark/benchmarkLineSegment.hpp
@@ -1,0 +1,98 @@
+// Copyright © 2012-2023 Forschungszentrum Jülich GmbH
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+#include <benchmark/benchmark.h>
+
+#include "LineSegment.hpp"
+
+template <class... Args>
+void bmDistToCgalOnLine(benchmark::State& state, Args&&... args)
+{
+    auto args_tuple = std::make_tuple(std::move(args)...);
+    auto lineSegment = std::get<0>(args_tuple);
+
+    auto factor = state.range(0) / 100.;
+    Point point(lineSegment.p1 + (lineSegment.p2 - lineSegment.p1) * factor);
+
+    for(auto _ : state) {
+        lineSegment.DistTo(point);
+    }
+}
+
+template <class... Args>
+void bmDistToCgal(benchmark::State& state, Args&&... args)
+{
+    auto args_tuple = std::make_tuple(std::move(args)...);
+    auto lineSegment = std::get<LineSegment>(args_tuple);
+
+    auto edgePoint = lineSegment.p2 + lineSegment.NormalVec() * 3.;
+
+    auto direction = edgePoint - lineSegment.p1;
+
+    auto factor = state.range(0) / 100.;
+
+    Point point(lineSegment.p1 + direction * factor);
+
+    for(auto _ : state) {
+        lineSegment.DistTo(point);
+    }
+}
+
+template <class... Args>
+void bmDistToOldOnLine(benchmark::State& state, Args&&... args)
+{
+    auto args_tuple = std::make_tuple(std::move(args)...);
+    auto lineSegment = std::get<0>(args_tuple);
+
+    auto factor = state.range(0) / 100.;
+    Point point(lineSegment.p1 + (lineSegment.p2 - lineSegment.p1) * factor);
+
+    for(auto _ : state) {
+        lineSegment.DistToOld(point);
+    }
+}
+
+template <class... Args>
+void bmDistToOld(benchmark::State& state, Args&&... args)
+{
+    auto args_tuple = std::make_tuple(std::move(args)...);
+    auto lineSegment = std::get<LineSegment>(args_tuple);
+
+    auto edgePoint = lineSegment.p2 + lineSegment.NormalVec() * 3.;
+
+    auto direction = edgePoint - lineSegment.p1;
+
+    auto factor = state.range(0) / 100.;
+
+    Point point(lineSegment.p1 + direction * factor);
+
+    for(auto _ : state) {
+        lineSegment.DistToOld(point);
+    }
+}
+
+// CGAL implementation
+BENCHMARK_CAPTURE(
+    bmDistToCgalOnLine,
+    dist_to_point_on_line,
+    LineSegment(Point(-1.3, 2.1), Point(3.6, -4.4)))
+    ->DenseRange(0, 100, 20);
+
+BENCHMARK_CAPTURE(bmDistToCgal, dist_to_point, LineSegment(Point(-1.3, 2.1), Point(3.6, -4.4)))
+    ->DenseRange(-50, 150, 10)
+    ->Arg(-100000)
+    ->Arg(100000);
+
+// old implementation
+BENCHMARK_CAPTURE(
+    bmDistToOldOnLine,
+    dist_to_point_on_line,
+    LineSegment(Point(-1.3, 2.1), Point(3.6, -4.4)))
+    ->DenseRange(0, 100, 20);
+
+BENCHMARK_CAPTURE(bmDistToOld, dist_to_point, LineSegment(Point(-1.3, 2.1), Point(3.6, -4.4)))
+    ->DenseRange(-50, 150, 10)
+    ->Arg(-100000)
+    ->Arg(100000);

--- a/libsimulator/src/LineSegment.cpp
+++ b/libsimulator/src/LineSegment.cpp
@@ -11,7 +11,7 @@
 
 #include <vector>
 
-#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
+#include <CGAL/Simple_cartesian.h>
 #include <CGAL/intersections.h>
 #include <boost/variant.hpp>
 
@@ -82,9 +82,21 @@ Point LineSegment::ShortestPoint(const Point& p) const
  * dazu wird die Funktion Line::ShortestPoint()
  * benuzt
  * */
-double LineSegment::DistTo(const Point& p) const
+double LineSegment::DistToOld(const Point& p) const
 {
     return (p - ShortestPoint(p)).Norm();
+}
+
+double LineSegment::DistTo(const Point& p) const
+{
+    using Kernel = CGAL::Simple_cartesian<double>;
+    using PointCGAL = Kernel::Point_2;
+    using SegmentCGAL = Kernel::Segment_2;
+
+    PointCGAL point(p.x, p.y);
+    SegmentCGAL segment(PointCGAL(p1.x, p1.y), PointCGAL(p2.x, p2.y));
+
+    return sqrt(CGAL::squared_distance(point, segment));
 }
 
 double LineSegment::LengthSquare() const

--- a/libsimulator/src/LineSegment.cpp
+++ b/libsimulator/src/LineSegment.cpp
@@ -78,15 +78,6 @@ Point LineSegment::ShortestPoint(const Point& p) const
         return p2 + t * lambda;
 }
 
-/* Berechnet direkt den Abstand von p zum Segment l
- * dazu wird die Funktion Line::ShortestPoint()
- * benuzt
- * */
-double LineSegment::DistToOld(const Point& p) const
-{
-    return (p - ShortestPoint(p)).Norm();
-}
-
 double LineSegment::DistTo(const Point& p) const
 {
     using Kernel = CGAL::Simple_cartesian<double>;

--- a/libsimulator/src/LineSegment.hpp
+++ b/libsimulator/src/LineSegment.hpp
@@ -44,6 +44,7 @@ public:
     /**
      * @return the distance from the line to the point p
      */
+    double DistToOld(const Point& p) const;
     double DistTo(const Point& p) const;
 
     /**

--- a/libsimulator/src/LineSegment.hpp
+++ b/libsimulator/src/LineSegment.hpp
@@ -44,7 +44,6 @@ public:
     /**
      * @return the distance from the line to the point p
      */
-    double DistToOld(const Point& p) const;
     double DistTo(const Point& p) const;
 
     /**


### PR DESCRIPTION
Instead of using an own implementation of the line segment-point distance calculation, now use CGAL to compute the distance. 