### PR TITLE
AABB now setting xmax/ymax correctly when only negative inputs

### DIFF
--- a/libsimulator/src/AABB.hpp
+++ b/libsimulator/src/AABB.hpp
@@ -10,9 +10,9 @@
 
 struct AABB {
     double xmin{std::numeric_limits<double>::max()};
-    double xmax{std::numeric_limits<double>::min()};
+    double xmax{std::numeric_limits<double>::lowest()};
     double ymin{std::numeric_limits<double>::max()};
-    double ymax{std::numeric_limits<double>::min()};
+    double ymax{std::numeric_limits<double>::lowest()};
 
     AABB() = default;
 

--- a/libsimulator/test/TestAABB.cpp
+++ b/libsimulator/test/TestAABB.cpp
@@ -21,12 +21,30 @@ TEST(AABB, CannotConstructFromEmptyVector)
     ASSERT_THROW(const AABB aabb(c), SimulationError);
 }
 
-TEST(AABB, CanConstructFromPoints)
+TEST(AABB, CanConstructFromPositivePoints)
 {
     const AABB aabb({0, 0}, {1, 1});
     ASSERT_EQ(aabb.xmin, 0);
     ASSERT_EQ(aabb.xmax, 1);
     ASSERT_EQ(aabb.ymin, 0);
+    ASSERT_EQ(aabb.ymax, 1);
+}
+
+TEST(AABB, CanConstructFromNegativePoints)
+{
+    const AABB aabb({-10, -1}, {-4, -5});
+    ASSERT_EQ(aabb.xmin, -10);
+    ASSERT_EQ(aabb.xmax, -4);
+    ASSERT_EQ(aabb.ymin, -5);
+    ASSERT_EQ(aabb.ymax, -1);
+}
+
+TEST(AABB, CanConstructFromPoints)
+{
+    const AABB aabb({-2, 1}, {3, -5});
+    ASSERT_EQ(aabb.xmin, -2);
+    ASSERT_EQ(aabb.xmax, 3);
+    ASSERT_EQ(aabb.ymin, -5);
     ASSERT_EQ(aabb.ymax, 1);
 }
 


### PR DESCRIPTION
With the current implementation `CanConstructFromNegativePoints` failed, now the construction yields the expected results.